### PR TITLE
Fix issues with spaces on their own in groups

### DIFF
--- a/RTFDE/deencapsulate.py
+++ b/RTFDE/deencapsulate.py
@@ -78,7 +78,7 @@ class DeEncapsulator():
 start : OPENPAREN document CLOSEPAREN
 
 document: (CONTROLWORD | CONTROLSYMBOL | TEXT | group | " " | RTFESCAPE)+
-group: OPENPAREN (CONTROLWORD | CONTROLSYMBOL | TEXT | group | RTFESCAPE)* CLOSEPAREN
+group: OPENPAREN (CONTROLWORD | CONTROLSYMBOL | TEXT | group | RTFESCAPE | " ")* CLOSEPAREN
 
 // Text is given priority over control terms with TERM.PRIORITY = 2
 // This is used to ensure that escaped \ AND { AND } are not matched in others


### PR DESCRIPTION
Found an issue where a space or double space on it's own in a group (say, between groups) can cause the parser to throw an UnexpectedToken("SPACE") error. This seems to correct the issue without interfering with the output as far as I can tell. I know for a fact that it allows me to parse a file that was previously failing, however.

In this pull I've only updated the grammar, nothing else. 