### PR TITLE
Updated to only work with bytes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,19 @@ log = logging.getLogger("RTFDE.HTMLRTF_Stripping_logger")
 log.setLevel(logging.DEBUG)
 ```
 
+### HTMLRTF Stripping Logging
+
+If you are having difficulty tracking down some sort of text-transformation/decoding issue then you can use the text_extraction logging to show you FAR more information about what is occuring during text extraction. WARNING: This log is a flood of information!
+
+Here is how you enable this log.
+```
+log = logging.getLogger("RTFDE.text_extraction")
+log.setLevel(logging.DEBUG)
+```
+
+
+
+
 ### Grammar Debugging
 
 RTFDE

--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -492,7 +492,15 @@ Raises:
                                               column=surrogate_high.column,
                                               end_column=surrogate_low.end_column)
                         children[surrogate_start] = surrogate_tok
-                        children[i] = b""
+                        blank_tok = Token('STRING',
+                                          b"",
+                                          start_pos=surrogate_high.start_pos+1,
+                                          end_pos=surrogate_low.end_pos+1,
+                                          line=surrogate_high.line,
+                                          end_line=surrogate_low.end_line,
+                                          column=surrogate_high.column,
+                                          end_column=surrogate_low.end_column)
+                        children[i] = blank_tok
                         surrogate_start = None
                         surrogate_high = None
                     except UnicodeDecodeError as _e:

--- a/RTFDE/transformers.py
+++ b/RTFDE/transformers.py
@@ -22,12 +22,12 @@ from lark.visitors import Transformer
 from lark.visitors import v_args, Discard
 from lark.tree import Tree
 from lark.lexer import Token
+import re
 
 from RTFDE.utils import log_htmlrtf_stripping
 
 import logging
 log = logging.getLogger("RTFDE")
-
 
 class StripNonVisibleRTFGroups(Transformer):
     """Visits each Token in provided RTF Trees and strips out any RTF groups which are non-visible when de-encapsulated into HTML.
@@ -44,7 +44,7 @@ Args:
 """
         children = tree.children
         if len(children) == 0:
-            return ""
+            return b""
         first_child = children[0]
 
         known_control_groups = ["htmltag_group"]
@@ -54,13 +54,15 @@ Args:
         known_non_visible_control_groups = ["mhtmltag_group"]
         if isinstance(first_child, Tree):
             if first_child.data in known_non_visible_control_groups:
-                return ""
+                # print(f"DELETING: {first_child} : because mhtmltag")
+                return b""
 
         # process known non-visible groups
-        non_visible_control_words = ["\\context", "\\colortbl", "\\fonttbl"]
+        non_visible_control_words = [b"\\context", b"\\colortbl", b"\\fonttbl"]
         first_control = self.get_first_controlword(children)
+        # print(f"FIRST: {first_control}")
         if first_control in non_visible_control_words:
-            return ""
+            return b""
 
         # Process star escaped groups
         # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
@@ -75,13 +77,14 @@ Args:
                     is_star_escaped = True
         control_word = None
         if is_star_escaped is True:
+            # print(f"STAR: {children}")
             first_token = children[1]
             if isinstance(first_token, Token):
                 if first_token.type == "CONTROLWORD":
                     control_word = first_token
                     if control_word.value in understood_commands:
                         return tree
-                    return ""
+                    return b""
         return tree
 
     @staticmethod
@@ -106,23 +109,27 @@ class RTFCleaner(Transformer):
     """Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn't be visible. And, joins all strings that are left into one final string.
     """
 
-    def start(self, args: List) -> str:
+    def start(self, args: List) -> bytes:
         """Joins the .rtf object's string representations together at highest level object `start`.
 
 This is the final string combination. """
-        return "".join(args)
+        return b"".join(args)
 
-    def STRING(self, string: Token) -> str:
+    def STRING(self, string: Token) -> bytes:
         """Convert a string object into a raw string."""
         if string.value is not None:
             return string.value
-        return ""
+        return b""
 
-    def string(self, strings: List) -> str:
+    def SPACE_SAVE(self, string: Token) -> bytes:
+        return string.value
+
+    def string(self, strings: List) -> bytes:
         """Convert all string objects withing a string group into a single string."""
-        return "".join(strings)
+        # print(strings)
+        return b"".join(strings)
 
-    def group(self, grp: List) -> str:
+    def group(self, grp: List) -> bytes:
         """Join the strings in all group objects."""
         _new_children = []
         for i in grp:
@@ -130,19 +137,20 @@ This is the final string combination. """
                 pass
             else:
                 _new_children.append(i)
-        return "".join(_new_children)
+        return b"".join(_new_children)
 
-    def document(self, args: List) -> str:
+    def document(self, args: List) -> bytes:
         """Join the all the strings in an .rtf object into a single string representation of the document."""
-        return "".join(args)
+        args = [i for i in args if i is not None]
+        return b"".join(args)
 
-    def OPENPAREN(self, args: Token) -> str:
+    def OPENPAREN(self, args: Token) -> bytes:
         """Delete all open parens."""
-        return ""
+        return b""
 
-    def CLOSEPAREN(self, args: Token) -> str:
+    def CLOSEPAREN(self, args: Token) -> bytes:
         """Delete all closed parens."""
-        return ""
+        return b""
 
     def mhtmltag_group(self, args: List):
         """Process MHTMLTAG groups
@@ -153,86 +161,86 @@ Returns:
         Always returns a discard object."""
         return Discard
 
-    def htmltag_group(self, strings: List) -> str:
+    def htmltag_group(self, strings: List) -> bytes:
         """HTMLTAG processing.
 
 Takes any string values within an HTMLTAG and returns them.
         """
-        return "".join(strings)
+        return b"".join(strings)
 
-    def HTMLTAG(self, htmltag: Token) -> str:
+    def HTMLTAG(self, htmltag: Token) -> bytes:
         """Delete all HTMLTAG objects"""
-        return ""
+        return b""
 
-    def STAR_ESCAPE(self, char: Token) -> str:
+    def STAR_ESCAPE(self, char: Token) -> bytes:
         """Delete all star escape objects"""
         # '\\*': ''
-        return ""
+        return b""
 
-    def control_symbol(self, symbols: List) -> str:
+    def control_symbol(self, symbols: List) -> bytes:
         """Join all visible symbols from in control symbol groups."""
-        return "".join(symbols)
+        return b"".join(symbols)
 
-    def NONBREAKING_SPACE(self, args: Token) -> str:
+    def NONBREAKING_SPACE(self, args: Token) -> bytes:
         """Convert non-breaking spaces into visible representation."""
         # '\\~': '\u00A0',
-        return u'\u00A0'
+        return u'\u00A0'.encode()
 
-    def NONBREAKING_HYPHEN(self, args: Token) -> str:
+    def NONBREAKING_HYPHEN(self, args: Token) -> bytes:
         """Convert non-breaking hyphens into visible representation."""
         # '\\_': '\u00AD'
-        return u'\u00AD'
+        return u'\u00AD'.encode()
 
-    def OPTIONAL_HYPHEN(self, args: Token) -> str:
+    def OPTIONAL_HYPHEN(self, args: Token) -> bytes:
         """Convert hyphen control char into visible representation."""
         # '\\-': '\u2027'
-        return u'\u2027'
+        return u'\u2027'.encode()
 
-    def FORMULA_CHARACTER(self, args: Token) -> str:
+    def FORMULA_CHARACTER(self, args: Token) -> bytes:
         """Convert a formula character into an empty string.
 
 If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands."""
-        return ""
+        return b""
 
-    def INDEX_SUBENTRY(self, args: Token) -> str:
+    def INDEX_SUBENTRY(self, args: Token) -> bytes:
         """Process index subentry items
 
 Discard index sub-entries. Because, we don't care about indexes when de-encapsulating at this time."""
-        return ""
+        return b""
 
-    def CONTROLSYMBOL(self, args: Token) -> str:
+    def CONTROLSYMBOL(self, args: Token) -> bytes:
         """Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones."""
         symbols = {
-            '\\{': '\x7B',
-            '\\}': '\x7D',
-            '\\\\': '\x5C',
+            b'\\{': b'\x7B',
+            b'\\}': b'\x7D',
+            b'\\\\': b'\x5C',
         }
         replacement = symbols.get(args.value, None)
         # If this is simply a character to replace then return the value
         if replacement is not None:
             return replacement
-        return ""
+        return b""
 
-    def CONTROLWORD(self, args: Token) -> str:
+    def CONTROLWORD(self, args: Token) -> bytes:
         """Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
         """
         words = {
-            '\\par': '\n',
-            '\\tab': '\t',
-            '\\line': '\n',
-            '\\lquote': '\u2018',
-            '\\rquote': '\u2019',
-            '\\ldblquote': '\u201C',
-            '\\rdblquote': '\u201D',
-            '\\bullet': '\u2022',
-            '\\endash': '\u2013',
-            '\\emdash': '\u2014'
+            b'\\par': b'\n',
+            b'\\tab': b'\t',
+            b'\\line': b'\n',
+            b'\\lquote': b'\u2018',
+            b'\\rquote': b'\u2019',
+            b'\\ldblquote': b'\u201C',
+            b'\\rdblquote': b'\u201D',
+            b'\\bullet': b'\u2022',
+            b'\\endash': b'\u2013',
+            b'\\emdash': b'\u2014'
         }
         replacement = words.get(args.value, None)
         # If this is simply a character to replace then return the value as a string
         if replacement is not None:
             return replacement
-        return ""
+        return b""
 
 def get_stripped_HTMLRTF_values(tree: Tree, current_state: Union[bool,None] = None) -> Generator:
     """Get a list of Tokens which should be suppressed by HTMLRTF control words.
@@ -269,7 +277,7 @@ Returns:
 """
     if isinstance(child, Token):
         if child.type == "HTMLRTF":
-            htmlrtfstr = str(child).strip()
+            htmlrtfstr = child.value.decode().strip()
             if (len(htmlrtfstr) > 0 and htmlrtfstr[-1] == "0"):
                 return False
             return True
@@ -313,6 +321,7 @@ Returns:
                         i.end_pos == token.end_pos and
                         i.value == token.value):
                         log_htmlrtf_stripping(i)
+                        # print(f"DELETING: {i}")
                         return Discard
         return token
 
@@ -361,3 +370,53 @@ Args:
         """
         tok = token.update(value=token.value.strip())
         return tok
+
+
+def strip_binary_objects(raw_rtf: bytes) -> tuple:
+    """Extracts binary objects from a rtf file.
+
+Parameters:
+    raw_rtf: (bytes): It's the raw RTF file as bytes.
+
+Returns:
+    A tuple containing (new_raw, found_bytes)
+        new_raw: (bytes) A bytes object where any binary data has been removed.
+        found_bytes: (list) List of dictionaries containing binary data extracted from the rtf file. Each dictionary includes the data extracted, where it was extracted from in the original rtf file and where it can be inserted back into the stripped output.
+
+    Description of found_bytes dictionaries:
+
+        "bytes": (bytes) The binary data contained which was extracted.
+        "ctrl_char": (tuple) Tuple containing the binary control word and its numeric parameter
+        "start_pos": (int) The position (in the original raw rtf data) where the binary control word started.
+        "bin_start_pos": (int) The position (in the original raw rtf data) where the binary data starts.
+        "end_pos": (int) The position (in the original raw rtf data) where the binary data ends.
+
+    Here is an example of what this looks like (by displaying the printable representation so you can see the bytes and then splitting the dict keys on new lines to make it readable.)
+        >> print(repr(found_bytes))
+
+        "{'bytes': b'\\xf4UP\\x13\\xdb\\xe4\\xe6CO\\xa8\\x16\\x10\\x8b\\n\\xfbA\\x9d\\xc5\\xd1C',
+          'ctrl_char': (b'\\\\bin', b'20'),
+          'start_pos': 56,
+          'end_pos': 83,
+          'bin_start_pos': 63}"
+
+    """
+    found_bytes = []
+    byte_finder = rb'(\\bin)([0-9]+)[ ]?'
+    for matchitem in re.finditer(byte_finder, raw_rtf):
+        param = int(matchitem[2])
+        bin_start_pos = matchitem.span()[-1]
+        byte_obj = {"bytes": raw_rtf[bin_start_pos:bin_start_pos+param],
+                    "ctrl_char": matchitem.groups(),
+                    "start_pos": matchitem.span()[0],
+                    "end_pos": bin_start_pos+param,
+                    "bin_start_pos": bin_start_pos
+                    }
+        found_bytes.append(byte_obj)
+    new_raw = b''
+    start_buffer = 0
+    for new_bytes in found_bytes:
+        new_raw += raw_rtf[start_buffer:new_bytes["start_pos"]]
+        start_buffer = new_bytes["end_pos"]
+    new_raw += raw_rtf[start_buffer:]
+    return (new_raw, found_bytes)

--- a/RTFDE/transformers.py
+++ b/RTFDE/transformers.py
@@ -14,7 +14,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
 
 
-from typing import Union, List
+from typing import Union, List, Tuple
+from typing import TypedDict
 #  from Python 3.9 typing.Generator is deprecated in favour of collections.abc.Generator
 from collections.abc import Generator
 
@@ -399,7 +400,6 @@ Returns:
           'start_pos': 56,
           'end_pos': 83,
           'bin_start_pos': 63}"
-
     """
     found_bytes = []
     byte_finder = rb'(\\bin)([0-9]+)[ ]?'
@@ -412,6 +412,7 @@ Returns:
                     "end_pos": bin_start_pos+param,
                     "bin_start_pos": bin_start_pos
                     }
+        # byte_obj : dict[str, Union[bytes, int, Tuple[bytes, bytes]]]
         found_bytes.append(byte_obj)
     new_raw = b''
     start_buffer = 0

--- a/RTFDE/utils.py
+++ b/RTFDE/utils.py
@@ -63,7 +63,7 @@ Args:
         print(data)
         sys.stdout = original_stdout
 
-def encode_escaped_control_chars(raw_text: str) -> str:
+def encode_escaped_control_chars(raw_text: bytes) -> bytes:
     """Replaces escaped control chars within the text with their RTF encoded versions \\'HH.
 
 Args:
@@ -72,12 +72,12 @@ Args:
 Returns:
     A string with escaped control chars
     """
-    cleaned = raw_text.replace('\\\\', "\\'5c")
-    cleaned = cleaned.replace('\\{', "\\'7b")
-    cleaned = cleaned.replace('\\}', "\\'7d")
+    cleaned = raw_text.replace(b'\\\\', b"\\'5c")
+    cleaned = cleaned.replace(b'\\{', b"\\'7b")
+    cleaned = cleaned.replace(b'\\}', b"\\'7d")
     return cleaned
 
-def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword) -> bool:
+def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword: bytes) -> bool:
     """Checks if a Token is a codeword with a numeric argument.
 
 Returns:
@@ -85,6 +85,7 @@ Returns:
 """
     try:
         val = token.value.strip()
+        # print(val, codeword)
         if (val.startswith(codeword) and
             val[len(codeword):].isdigit()):
             return True
@@ -146,7 +147,7 @@ Raises:
                                   end_pos = data.end_pos)
         logger.debug(log_msg)
 
-def log_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+def log_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
     """Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
 
 Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
@@ -158,7 +159,7 @@ Args:
 """
     log.debug(get_string_diff(original, revised, sep))
 
-def get_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+def get_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
     """Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
 
 Args:
@@ -170,13 +171,13 @@ Returns:
     A string object representing the diff of the two strings provided.
 """
     if sep is None:
-        orig_split = original.splitlines(keepends=True)
-        revised_split = revised.splitlines(keepends=True)
+        orig_split = original.decode().splitlines(keepends=True)
+        revised_split = revised.decode().splitlines(keepends=True)
     else:
-        original = original.replace('\n','')
-        revised = revised.replace('\n','')
-        orig_split = [i for i in re.split(sep, original) if i != '']
-        revised_split = [i for i in re.split(sep, revised) if i != '']
+        original = original.replace(b'\n',b'')
+        revised = revised.replace(b'\n',b'')
+        orig_split = [i.decode() for i in re.split(sep, original) if i != b'']
+        revised_split = [i.decode() for i in re.split(sep, revised) if i != b'']
     return "\n".join(list(difflib.context_diff(orig_split,
                                                revised_split)))
 

--- a/tests/deencapsulate/test_de_encapsulate.py
+++ b/tests/deencapsulate/test_de_encapsulate.py
@@ -333,22 +333,35 @@ class TestTextDecoding(unittest.TestCase):
         # print(repr(output_text))
         # print(repr(rtf_obj.content))
 
-    def test_use_small_template(self):
-        raw_rtf = self.get_small_template()
+    def text_hexencode_as_replacement(self):
+        """test that unicode text with hex encoded replacement works."""
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "unicode_HH_replacement.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522;'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "unicode_HH_replacement_01.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522; \xf0\x9f\x93\x9e'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        print(rtf_obj.content)
 
-        # rtf_obj = deencapsulate_string(raw_rtf)
+#     def test_use_small_template(self):
+#         raw_rtf = self.get_small_template()
 
-        # REPLACE_ME
-        small_template = b"""{\\rtf1\\ansi\\ansicpg1252\\deff0\\fromhtml1\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}
-{\\*\\generator Riched20 10.0.16299}\\viewkind4\\uc1
-\\pard\\sa200\\sl276\\slmult1\\f0\\fs22\\lang9
+#         # rtf_obj = deencapsulate_string(raw_rtf)
 
-REPLACE_ME
+#         # REPLACE_ME
+#         small_template = b"""{\\rtf1\\ansi\\ansicpg1252\\deff0\\fromhtml1\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}
+# {\\*\\generator Riched20 10.0.16299}\\viewkind4\\uc1
+# \\pard\\sa200\\sl276\\slmult1\\f0\\fs22\\lang9
 
-{}}"""
+# REPLACE_ME
 
-        # To Test text_extraction
-        # is_font_number :
+# {}}"""
+
+#         # To Test text_extraction
+#         # is_font_number :
+
     def test_font_table_variation(self):
         from RTFDE.text_extraction import get_font_table,parse_font_tree
         raw_rtf = self.get_small_template()

--- a/tests/deencapsulate/test_de_encapsulate.py
+++ b/tests/deencapsulate/test_de_encapsulate.py
@@ -291,6 +291,27 @@ class TestTextDecoding(unittest.TestCase):
         for sur in surrogate_encodings:
             self.assertIsInstance(unicode_escape_to_chr(sur), str)
 
+
+    def test_surrogate_in_htmlrtf(self):
+        """Don't show surrogate text within htmlrtf block."""
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_02.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522;'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        print(rtf_obj.content)
+
+    def test_surrogate_without_16bitsigned(self):
+        """Test surrogate which doesn't use a 16 signed integer."""
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_03.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        print(rtf_obj.content)
+        correct_repr =  b'&#128522;'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_04.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522; \xf0\x9f\x93\x9e'
+        self.assertEqual(correct_repr, rtf_obj.content)
+
     def test_hexencoded(self):
         original_body = '【 This is a test 】'.encode()
         raw_rtf = self.get_small_template()

--- a/tests/deencapsulate/test_de_encapsulate.py
+++ b/tests/deencapsulate/test_de_encapsulate.py
@@ -2,6 +2,7 @@
 """
 
 import unittest
+import secrets
 import quopri # Decode MIME quoted-printable data
 from os.path import join, abspath, isfile
 from os import walk
@@ -82,11 +83,101 @@ class TestPrivateMsgTestCases(unittest.TestCase):
                         f.feed(html_output.decode())
                         html_output_text = f.text
                         f = ExtractHTMLText()
-                        f.feed(rtf_obj.content)
+                        f.feed(rtf_obj.content.decode())
                         rtf_output_text = f.text
                         self.assertEqual(rtf_output_text, html_output_text,
                                          msg=f"\nFailed comparing personal test file: {html_filename}")
 
+
+class TestBinaryData(unittest.TestCase):
+    """Test binary data in RTF files."""
+
+    def test_encoded_bytes_stay_encoded_character(self):
+        """Test that any hexbytes that are not encoded into the RTF stay in the bytes returned without being modified."""
+        raw_rtf = self.get_small_template()
+        bin_data = secrets.token_bytes(1)
+        binary_string = b'This test is one string ' + bin_data + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        self.assertEqual(binary_string,rtf_obj.content)
+
+    def test_bin_data_captured(self):
+        """Tests that binary data is captured.
+        """
+        # Test one bin string
+        raw_rtf = self.get_small_template()
+        bin_data = secrets.token_bytes(20)
+        binary_string = b'This test is one string \\bin20' + bin_data + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+
+        self.assertIsNotNone(rtf_obj.found_binary)
+        self.assertEqual(b'This test is one string that is it.',
+                         rtf_obj.content)
+        # Proove that the stripped data contains the bin_data at the right place.
+        # re_built_string = rtf_obj.content[:]
+        bin_dat = rtf_obj.found_binary[0]
+        self.assertEqual(bin_dat['start_pos'], 216)
+        self.assertEqual(bin_dat['end_pos'], 242)
+        self.assertEqual(bin_dat['bin_start_pos'], 222)
+        self.assertEqual(bin_dat['bytes'], bin_data)
+        self.assertEqual(bin_dat['ctrl_char'][0], b'\\bin')
+        self.assertEqual(bin_dat['ctrl_char'][1], b'20')
+
+        # Make sure spaces after the control char are handled correctly
+        binary_string = b'This test is one string \\bin20 ' + bin_data + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        bin_dat = rtf_obj.found_binary[0]
+        self.assertEqual(bin_dat['bytes'], bin_data)
+        self.assertEqual(bin_dat['ctrl_char'][1], b'20')
+        self.assertEqual(bin_dat['start_pos'], 216)
+        self.assertEqual(bin_dat['end_pos'], 243)
+        self.assertEqual(bin_dat['bin_start_pos'], 223)
+
+        # Test multiple bin string in an rtf file
+        bin_addition = b' and more \\bin20 ' + bin_data
+        bin_addition = bin_addition*5
+        binary_string = b'This test is one string ' + bin_addition + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        self.assertEqual(len(rtf_obj.found_binary), 5)
+
+        # Test bin with negative params are ignored as they are invalid (i.e. \\bin-1234)
+        binary_string = b'This test is one string \\bin-20 ' + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        with self.assertRaises(AttributeError):
+            _test = rtf_obj.found_binary
+
+        # Test bin with no params are ignored as they are invalid
+        binary_string = b'This test is one string \\bin ' + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        with self.assertRaises(AttributeError):
+            _test = rtf_obj.found_binary
+
+        # Test bin with 0 length params only include 0 length bytes (i.e. \\bin0 AND \\bin00000000 )
+        binary_string = b'This test is one string \\bin0 \\bin0000000' + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        self.assertEqual(len(rtf_obj.found_binary), 2)
+        for byte_obj in rtf_obj.found_binary:
+            self.assertEqual(byte_obj['bytes'], b'')
+
+
+    def deencapsulate_string(self, raw_rtf):
+        rtf_obj = DeEncapsulator(raw_rtf)
+        rtf_obj.deencapsulate()
+        return rtf_obj
+
+    def get_small_template(self):
+        template_path =  join(DATA_BASE_DIR,
+                              "rtf_parsing",
+                              "small_template.rtf")
+        with open(template_path, 'rb') as fp:
+            raw_rtf = fp.read()
+        return raw_rtf
 
 class TestTextCleanDeEncapsulate(unittest.TestCase):
     """ Test minimal deviation of original and de-encapsulated plain text content.
@@ -96,8 +187,8 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
     def test_japanese_encoded_text(self):
         """ """
         rtf_path = join(DATA_BASE_DIR, "plain_text", "japanese_iso_2022.rtf")
-        original_body = "すみません。\n"
-        with open(rtf_path, 'r') as fp:
+        original_body = "すみません。\n".encode()
+        with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
@@ -110,10 +201,10 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
         This test checks that it is STILL NOT IMPLEMENTED. So, if you fix it this test will expose that and we will need to change the test."""
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         quote_printable_txt_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.txt")
-        with open(quote_printable_txt_path, 'r') as fp:
+        with open(quote_printable_txt_path, 'rb') as fp:
             raw_text = fp.read()
             original_decoded_text = raw_text
-        with open(quote_printable_rtf_path, 'r') as fp:
+        with open(quote_printable_rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
@@ -125,16 +216,16 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         quote_printable_txt_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.txt")
         charset = "cp1251"
-        with open(quote_printable_txt_path, 'r') as fp:
+        with open(quote_printable_txt_path, 'rb') as fp:
             raw_text = fp.read()
             original_decoded_text = quopri.decodestring(raw_text)
             original_decoded_text = original_decoded_text.decode(charset)
-        with open(quote_printable_rtf_path, 'r') as fp:
+        with open(quote_printable_rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
             output_text = rtf_obj.text
-        self.assertEqual(original_decoded_text, output_text)
+        self.assertEqual(original_decoded_text, output_text.decode())
 
 
 
@@ -144,8 +235,8 @@ class TestTextDecoding(unittest.TestCase):
     def test_theta(self):
         """ """
         rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "theta.rtf")
-        original_body = 'ф\n'
-        with open(rtf_path, 'r') as fp:
+        original_body = '  ф\n'.encode()
+        with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
@@ -157,8 +248,8 @@ class TestTextDecoding(unittest.TestCase):
     def test_translated_by(self):
         """ """
         rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "translated_by.rtf")
-        original_body = 'ترجمة: سمير المجذوب\n'
-        with open(rtf_path, 'r') as fp:
+        original_body = 'ترجمة: سمير المجذوب\n'.encode()
+        with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
@@ -170,54 +261,56 @@ class TestTextDecoding(unittest.TestCase):
 
     def test_unicode_decoding(self):
         """ """
-        print("\n")
+        # print("\n")
         rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogates.rtf")
         rtf_obj = self.deencapsulate(rtf_path)
-        self.assertTrue("😊" in rtf_obj.content)
+        self.assertTrue("😊".encode() in rtf_obj.content)
         rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs.rtf")
         rtf_obj = self.deencapsulate(rtf_path)
-        correct_repr = "'Ǣ?\\nǢ\\n😊\\n😊??\\n😊\\n'"
-        self.assertEqual(correct_repr, repr(rtf_obj.content))
+        correct_repr = 'Ǣ?\nǢ\n😊\n😊??\n😊\n'.encode()
+        # print(correct_repr)
+        # print(rtf_obj.content)
+        self.assertEqual(correct_repr, rtf_obj.content)
 
         # Test that non unicode chars do not decode
         from RTFDE.text_extraction import unicode_escape_to_chr
-        surh = "\\u-10179"
-        surl = "\\u-8694"
+        surh = b"\\u-10179"
+        surl = b"\\u-8694"
         bad_encodings = [
-            "0x000000A9",
-            "0x00A9",
-            "0xC2 0xA9",
-            "&copy;",
-            "&#xA9;",
-            "&#169;"
+            b"0x000000A9",
+            b"0x00A9",
+            b"0xC2 0xA9",
+            b"&copy;",
+            b"&#xA9;",
+            b"&#169;"
         ]
         for bad in bad_encodings:
             with self.assertRaises(ValueError):
                 unicode_escape_to_chr(bad)
-        surrogate_encodings = ["\\u-10179", "\\u-8694"]
+        surrogate_encodings = [b"\\u-10179", b"\\u-8694"]
         for sur in surrogate_encodings:
             self.assertIsInstance(unicode_escape_to_chr(sur), str)
 
     def test_hexencoded(self):
-        original_body = '【 This is a test 】'
+        original_body = '【 This is a test 】'.encode()
         raw_rtf = self.get_small_template()
         # print(raw_rtf)
         # Add fontdef
-        font_def = """{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f1\\fswiss\\fcharset128 "PMingLiU";}{\\f2\\fnil\\fcharset1 Arial;}}"""
-        base = """{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}"""
+        font_def = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f1\\fswiss\\fcharset128 "PMingLiU";}{\\f2\\fnil\\fcharset1 Arial;}}"""
+        base = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}"""
         new_rtf = raw_rtf.replace(base, font_def)
         # print(new_rtf)
         # Add hec encoded item
-        hex_encoded_text = """{\\lang1028 \\f1 \\'81\\'79} This is a test {\\lang1028 \\f1 \\'81\\'7a}"""
-        rep_rtf = new_rtf.replace("REPLACE_ME", hex_encoded_text)
+        hex_encoded_text = b"""{\\lang1028 \\f1 \\'81\\'79} This is a test {\\lang1028 \\f1 \\'81\\'7a}"""
+        rep_rtf = new_rtf.replace(b"REPLACE_ME", hex_encoded_text)
         # print(rep_rtf)
         rtf_obj = self.deencapsulate_string(rep_rtf)
-        rtf_obj.deencapsulate()
+        # rtf_obj.deencapsulate()
         output_text = rtf_obj.content
         # 'not a valid ANSI representation'
         self.assertEqual(output_text, original_body)
-        print(repr(output_text))
-        print(repr(rtf_obj.content))
+        # print(repr(output_text))
+        # print(repr(rtf_obj.content))
 
     def test_use_small_template(self):
         raw_rtf = self.get_small_template()
@@ -225,7 +318,7 @@ class TestTextDecoding(unittest.TestCase):
         # rtf_obj = deencapsulate_string(raw_rtf)
 
         # REPLACE_ME
-        small_template = """{\\rtf1\\ansi\\ansicpg1252\\deff0\\fromhtml1\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}
+        small_template = b"""{\\rtf1\\ansi\\ansicpg1252\\deff0\\fromhtml1\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}
 {\\*\\generator Riched20 10.0.16299}\\viewkind4\\uc1
 \\pard\\sa200\\sl276\\slmult1\\f0\\fs22\\lang9
 
@@ -238,26 +331,26 @@ REPLACE_ME
     def test_font_table_variation(self):
         from RTFDE.text_extraction import get_font_table,parse_font_tree
         raw_rtf = self.get_small_template()
-        base = """{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}"""
+        base = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}"""
 
         # Test \\cpg is consistant with fcharset
-        base_w_cpg = """{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f2\\cpg1253\\fcharset161 Arial;}}"""
+        base_w_cpg = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f2\\cpg1253\\fcharset161 Arial;}}"""
         new_rtf = raw_rtf.replace(base, base_w_cpg)
         rtf_obj = self.full_tree_from_string(new_rtf)
         raw_font_table = get_font_table(rtf_obj.full_tree.children[1])
         font_table = parse_font_tree(raw_font_table)
         # print(repr(font_table))
         # print(type(font_table))
-        self.assertEqual(font_table['\\f2'].codepage, 1253)
+        self.assertEqual(font_table[b'\\f2'].codepage, 1253)
 
         # Test \\fcharset takes precedence over \\cpg
-        base_w_cpg = """{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f2\\cpg1253\\fcharset204 Arial;}}"""
+        base_w_cpg = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f2\\cpg1253\\fcharset204 Arial;}}"""
         new_rtf = raw_rtf.replace(base, base_w_cpg)
         rtf_obj = self.full_tree_from_string(new_rtf)
         raw_font_table = get_font_table(rtf_obj.full_tree.children[1])
         font_table = parse_font_tree(raw_font_table)
         # \\fcharset204 == codepage 1251
-        self.assertEqual(font_table['\\f2'].codepage, 1251)
+        self.assertEqual(font_table[b'\\f2'].codepage, 1251)
 
     def test_text_decoder(self):
         from RTFDE.text_extraction import TextDecoder
@@ -268,16 +361,16 @@ REPLACE_ME
         raw_rtf = self.get_small_template()
 
         # set_font_info with missing deff0
-        new_rtf = raw_rtf.replace('\\deff0', '')
+        new_rtf = raw_rtf.replace(b'\\deff0', b'')
         rtf_obj = self.deencapsulate_string(new_rtf)
         # deff0 is not required
         self.assertIsNone(get_default_font(rtf_obj.full_tree))
 
         # multiple deff0 is fine. Only use the first found
-        new_rtf = raw_rtf.replace('\\deff0', '\\deff0\\deff1\\deff2')
+        new_rtf = raw_rtf.replace(b'\\deff0', b'\\deff0\\deff1\\deff2')
         rtf_obj = self.deencapsulate_string(new_rtf)
         self.assertEqual(get_default_font(rtf_obj.full_tree),
-                         '\\f0')
+                         b'\\f0')
 
 
 
@@ -302,7 +395,7 @@ REPLACE_ME
         template_path =  join(DATA_BASE_DIR,
                               "rtf_parsing",
                               "small_template.rtf")
-        with open(template_path, 'r') as fp:
+        with open(template_path, 'rb') as fp:
             raw_rtf = fp.read()
         return raw_rtf
 
@@ -318,7 +411,7 @@ REPLACE_ME
         return rtf_obj
 
     def deencapsulate(self, rtf_path):
-        with open(rtf_path, 'r') as fp:
+        with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()

--- a/tests/parse_rtf/test_parse_rtf.py
+++ b/tests/parse_rtf/test_parse_rtf.py
@@ -36,28 +36,44 @@ Ensure that:
                                           "rtf_parsing",
                                           "from_header_template.rtf")
         # Has 20 control words
-        ctrl_words = ("\\deff0"*16) + "\\fromhtml1"
+        ctrl_words = (b"\\deff0"*16) + b"\\fromhtml1"
         rtf = self.replace_text_in_template(template_path, ctrl_words)
         output = self.run_parsing(rtf)
         ctrl_wds = output.get_header_control_words_before_first_group()
         ctrl_wds =[i.value.strip() for i in ctrl_wds]
-        correct_ctrl = ['\\rtf1', '\\ansi', '\\ansicpg1252', '\\deff0', '\\deff0', '\\deff0',
-                        '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0',
-                        '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0',
-                        '\\deff0', '\\fromhtml1']
+        correct_ctrl = [b'\\rtf1',
+                        b'\\ansi',
+                        b'\\ansicpg1252',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\fromhtml1']
         self.assertEqual(ctrl_wds, correct_ctrl)
 
         # group comes before 20 control words
-        ctrl_words = ("\\deff0"*5) + "\\fromhtml1 \\deff0" + '{\colortbl\red0\green0\blue0;\red5\green99\blue193;}'
+        ctrl_words = (b"\\deff0"*5) + b"\\fromhtml1 \\deff0" + b'{\colortbl\red0\green0\blue0;\red5\green99\blue193;}'
         rtf = self.replace_text_in_template(template_path, ctrl_words)
         output = self.run_parsing(rtf)
         ctrl_wds = output.get_header_control_words_before_first_group()
         ctrl_wds = [i.value.strip() for i in ctrl_wds]
-        correct_ctrl = ['\\rtf1', '\\ansi', '\\ansicpg1252', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\fromhtml1', '\\deff0']
+        correct_ctrl = [b'\\rtf1', b'\\ansi', b'\\ansicpg1252', b'\\deff0', b'\\deff0', b'\\deff0', b'\\deff0', b'\\deff0', b'\\fromhtml1', b'\\deff0']
         self.assertEqual(ctrl_wds, correct_ctrl)
 
         # fromhtml header parsing not affected by this function
-        ctrl_words = '{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}' + "\\fromhtml1 \\deff0"
+        ctrl_words = b'{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}' + b"\\fromhtml1 \\deff0"
         rtf = self.replace_text_in_template(template_path, ctrl_words)
         # The fromhtml header needs to be in the first 10 tokens. Tokens includes groups in this case. So this should succeed.
         self.check_deencapsulate_validity(rtf,
@@ -70,10 +86,10 @@ Ensure that:
                               "from_header_template.rtf")
 
         # bad
-        bad_charsets = ["\\ansicpg1234", "\\ansicpg"]
+        bad_charsets = [b"\\ansicpg1234", b"\\ansicpg"]
         for badchar in bad_charsets:
-            rtf = self.replace_text_in_template(template_path, "\\fromhtml1")
-            rtf = self.replace_text_in_template(None, badchar, rep_str="\\ansicpg1252", string=rtf)
+            rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+            rtf = self.replace_text_in_template(None, badchar, rep_str=b"\\ansicpg1252", string=rtf)
             self.check_deencapsulate_validity(rtf,
                                               expect_error=MalformedRtf,
                                               name="bad codepage keyword: {0}".format(badchar))
@@ -91,8 +107,8 @@ Ensure that:
             self.assertNotEqual(codec, 'utf8')
 
         # Codepage is optional. Therefore a missing codepage number is fine.
-        rtf = self.replace_text_in_template(template_path, "\\fromhtml1")
-        rtf = self.replace_text_in_template(None, "", rep_str="\\ansicpg1252", string=rtf)
+        rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+        rtf = self.replace_text_in_template(None, b"", rep_str=b"\\ansicpg1252", string=rtf)
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
                                           name="Ansi codepage num is optional")
@@ -103,54 +119,54 @@ Ensure that:
                               "from_header_template.rtf")
 
         # Bad charset
-        bad_charsets = ["\\ANSI", "ansi", "\\PC", "\\osx"]
+        bad_charsets = [b"\\ANSI", b"ansi", b"\\PC", b"\\osx"]
         for badchar in bad_charsets:
-            rtf = self.replace_text_in_template(template_path, "\\fromhtml1")
-            rtf = self.replace_text_in_template(None, badchar, rep_str="\\ansi", string=rtf)
+            rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+            rtf = self.replace_text_in_template(None, badchar, rep_str=b"\\ansi", string=rtf)
             self.check_deencapsulate_validity(rtf,
                                               expect_error=MalformedRtf,
                                               name="bad charset keyword: {0}".format(badchar))
 
         # Good charset
         # included \\ after the charset keyword to ensure we don't capture the \\ansicpg
-        good_charsets = ["\\ansi\\", "\\mac\\", "\\pc\\", "\\pca\\"]
+        good_charsets = [b"\\ansi\\", b"\\mac\\", b"\\pc\\", b"\\pca\\"]
         for goodchar in good_charsets:
-            rtf = self.replace_text_in_template(template_path, "\\fromhtml1")
-            rtf = self.replace_text_in_template(None, goodchar, rep_str="\\ansi\\", string=rtf)
+            rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+            rtf = self.replace_text_in_template(None, goodchar, rep_str=b"\\ansi\\", string=rtf)
             self.check_deencapsulate_validity(rtf,
                                               expect_error=None,
                                               name="Good charset keyword: {0}".format(goodchar))
 
         # group before charset
-        new_front = '{\\rtf1{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}'
-        rtf = self.replace_text_in_template(template_path, "\\fromhtml1")
+        new_front = b'{\\rtf1{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}'
+        rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
         rtf = new_front + rtf[6:] # Replaces `{\\rtf1`
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedRtf,
                                           name="no groups before charset")
 
         # Missing
-        rtf = self.replace_text_in_template(template_path, "\\fromhtml1")
-        rtf = self.replace_text_in_template(None, "\\", rep_str="\\ansi\\", string=rtf)
+        rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+        rtf = self.replace_text_in_template(None, b"\\", rep_str=b"\\ansi\\", string=rtf)
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedRtf,
                                           name="missing charset")
         # Test missing using default fallback to ansi
         output = self.run_parsing(rtf)
         charset = output.validate_charset(fallback_to_default=True)
-        self.assertEqual("\\ansi", charset)
+        self.assertEqual(b"\\ansi", charset)
 
     def test_get_python_codec(self):
         """Test getting correct python codec."""
         template_path =  join(DATA_BASE_DIR,
                               "rtf_parsing",
                               "from_header_template.rtf")
-        base = self.replace_text_in_template(template_path, "\\fromhtml1")
+        base = self.replace_text_in_template(template_path, b"\\fromhtml1")
         # Big-5
         big5string = b'\xb3o\xacO\xa4@\xad\xd3\xa4\xe5\xa5\xbb\xa6r\xb2\xc5\xa6\xea\xa1C'
         rtf = self.replace_text_in_template(None,
-                                       replacement="\\ansicpg10002",
-                                       rep_str="\\ansicpg1252",
+                                       replacement=b"\\ansicpg10002",
+                                       rep_str=b"\\ansicpg1252",
                                        string=base)
 
         output = self.run_parsing(rtf)
@@ -166,8 +182,8 @@ Ensure that:
         # Hebrew
         hebrew = b'\xe6\xe4\xe5 \xee\xe7\xf8\xe5\xe6\xfa \xe8\xf7\xf1\xe8.'
         rtf = self.replace_text_in_template(None,
-                                       replacement="\\ansicpg10005",
-                                       rep_str="\\ansicpg1252",
+                                       replacement=b"\\ansicpg10005",
+                                       rep_str=b"\\ansicpg1252",
                                        string=base)
         output = self.run_parsing(rtf)
         ansicpg_header = output.get_ansicpg_header()
@@ -182,7 +198,7 @@ Ensure that:
         from_html =  join(DATA_BASE_DIR,
                           "rtf_parsing",
                           "from_header_template.rtf")
-        rtf = self.replace_text_in_template(from_html, "\\fromhtml1")
+        rtf = self.replace_text_in_template(from_html, b"\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
                                           name="working fromheaderhtml")
@@ -192,7 +208,7 @@ Ensure that:
         from_text =  join(DATA_BASE_DIR,
                           "rtf_parsing",
                           "from_header_template.rtf")
-        rtf = self.replace_text_in_template(from_text, "\\fromtext")
+        rtf = self.replace_text_in_template(from_text, b"\\fromtext")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
                                           name="working fromheader text")
@@ -202,7 +218,7 @@ Ensure that:
         missing_from =  join(DATA_BASE_DIR,
                              "rtf_parsing",
                              "from_header_template.rtf")
-        rtf = self.replace_text_in_template(missing_from, "")
+        rtf = self.replace_text_in_template(missing_from, b"")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=NotEncapsulatedRtf,
                                           name="missing fromheader text")
@@ -210,9 +226,9 @@ Ensure that:
         missing_but_one_in_body =  join(DATA_BASE_DIR,
                                      "rtf_parsing",
                                      "from_header_template.rtf")
-        rtf = self.replace_text_in_template(missing_but_one_in_body, "")
-        rtf = self.replace_text_in_template(None, "\\fromtext",
-                                       rep_str="INSERT_BODY_TEXT_HERE",
+        rtf = self.replace_text_in_template(missing_but_one_in_body, b"")
+        rtf = self.replace_text_in_template(None, b"\\fromtext",
+                                       rep_str=b"INSERT_BODY_TEXT_HERE",
                                        string=rtf)
         self.check_deencapsulate_validity(rtf,
                                           expect_error=NotEncapsulatedRtf,
@@ -223,7 +239,7 @@ Ensure that:
         multiple_from_html =  join(DATA_BASE_DIR,
                                    "rtf_parsing",
                                    "from_header_template.rtf")
-        rtf = self.replace_text_in_template(multiple_from_html, "\\fromhtml1\\fromhtml1")
+        rtf = self.replace_text_in_template(multiple_from_html, b"\\fromhtml1\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -231,7 +247,7 @@ Ensure that:
         multiple_from_html_first =  join(DATA_BASE_DIR,
                                          "rtf_parsing",
                                          "from_header_template.rtf")
-        rtf = self.replace_text_in_template(multiple_from_html_first, "\\fromhtml1\\fromtext")
+        rtf = self.replace_text_in_template(multiple_from_html_first, b"\\fromhtml1\\fromtext")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -239,7 +255,7 @@ Ensure that:
         multiple_from_txt_first =  join(DATA_BASE_DIR,
                                         "rtf_parsing",
                                         "from_header_template.rtf")
-        rtf = self.replace_text_in_template(multiple_from_txt_first, "\\fromtext\\fromhtml1")
+        rtf = self.replace_text_in_template(multiple_from_txt_first, b"\\fromtext\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -249,9 +265,10 @@ Ensure that:
         missing_from =  join(DATA_BASE_DIR,
                              "rtf_parsing",
                              "from_header_template.rtf")
-        rtf = self.replace_text_in_template(missing_from, "")
+        rtf = self.replace_text_in_template(missing_from, b"")
         # Append a new curly and the control word to the start of the rtf file
-        rtf = "{\\fromhtml1" + rtf[1:]
+        # TODO: Fix this array use on a bytes object
+        rtf = b"{\\fromhtml1" + rtf[1:]
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedRtf,
                                           name="from header before magic")
@@ -261,22 +278,25 @@ Ensure that:
         missing_from =  join(DATA_BASE_DIR,
                              "rtf_parsing",
                              "from_header_template.rtf")
-        rtf = self.replace_text_in_template(missing_from, "\\fromhtml1")
+        rtf = self.replace_text_in_template(missing_from, b"\\fromhtml1")
         # Append a new curly and broken rtf to the start of the rtf file
-        rtf_no_one = "{\\rtf" + rtf[6:] # Removes `{\\rtf1`
+        # TODO: Fix this array use on a bytes object
+        rtf_no_one = b"{\\rtf" + rtf[6:] # Removes `{\\rtf1`
         self.check_deencapsulate_validity(rtf_no_one,
                                           expect_error=MalformedRtf,
                                           name="malformed file magic")
-
-        rtf_two = "{\\rtf2" + rtf[6:]
+        # TODO: Fix this array use on a bytes object
+        rtf_two = b"{\\rtf2" + rtf[6:]
         self.check_deencapsulate_validity(rtf_two,
                                           expect_error=MalformedRtf,
                                           name="malformed file magic")
-        RTF = "{\\RTF1" + rtf[6:]
+        # TODO: Fix this array use on a bytes object
+        RTF = b"{\\RTF1" + rtf[6:]
         self.check_deencapsulate_validity(RTF,
                                           expect_error=MalformedRtf,
                                           name="malformed file magic")
-        PiRTF = "{\\ARRRRRR-TEEE-FFF" + rtf[6:] # Because Pirates
+        # TODO: Fix this array use on a bytes object
+        PiRTF = b"{\\ARRRRRR-TEEE-FFF" + rtf[6:] # Because Pirates
         self.check_deencapsulate_validity(PiRTF,
                                           expect_error=MalformedRtf,
                                           name="Ahoy, matey! this here file magic be broken")
@@ -292,7 +312,7 @@ Ensure that:
                               "rtf_parsing",
                               "from_header_template.rtf")
 
-        early_font_table = '{\\fonttbl\n{\\f0\\fswiss Arial;}\n{\\f1\\fmodern Courier New;}\n{\\f2\\fnil\\fcharset2 Symbol;}\n{\\f3\\fmodern\\fcharset0 Courier New;}}' + "\\fromhtml1 \\deff0"
+        early_font_table = b'{\\fonttbl\n{\\f0\\fswiss Arial;}\n{\\f1\\fmodern Courier New;}\n{\\f2\\fnil\\fcharset2 Symbol;}\n{\\f3\\fmodern\\fcharset0 Courier New;}}' + b"\\fromhtml1 \\deff0"
         rtf = self.replace_text_in_template(template_path, early_font_table)
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
@@ -304,12 +324,12 @@ Ensure that:
                               "rtf_parsing",
                               "font_table_template.rtf")
 
-        no_font_table = ""
+        no_font_table = b""
         rtf = self.replace_text_in_template(template_path,
                                             no_font_table,
-                                            rep_str="REPLACE_FONT_TABLE_HERE")
-        NA = "REPLACE_FONT_TABLE_HERE"
-        default = """{\\fonttbl
+                                            rep_str=b"REPLACE_FONT_TABLE_HERE")
+        NA = b"REPLACE_FONT_TABLE_HERE"
+        default = b"""{\\fonttbl
 {\\f0\\fswiss Arial;}
 {\\f1\\fmodern Courier New;}
 {\\f2\\fnil\\fcharset2 Symbol;}
@@ -327,23 +347,23 @@ Ensure that:
         template_data =  join(DATA_BASE_DIR,
                           "rtf_parsing",
                           "from_header_template.rtf")
-        rtf = self.replace_text_in_template(template_data, "\\fromhtml1")
+        rtf = self.replace_text_in_template(template_data, b"\\fromhtml1")
         output = DeEncapsulator(rtf)
         output.deencapsulate()
         self.assertEqual('html', output.get_content_type())
 
-        rtf = self.replace_text_in_template(template_data, "\\fromtext")
+        rtf = self.replace_text_in_template(template_data, b"\\fromtext")
         output = DeEncapsulator(rtf)
         output.deencapsulate()
         self.assertEqual('text', output.get_content_type())
 
          # Try with them back to back. First should win.
-        rtf = self.replace_text_in_template(template_data, "\\fromtext\\fromhtml1")
+        rtf = self.replace_text_in_template(template_data, b"\\fromtext\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
 
-        rtf = self.replace_text_in_template(template_data, "\\fromhtml1\\fromtext")
+        rtf = self.replace_text_in_template(template_data, b"\\fromhtml1\\fromtext")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -355,7 +375,7 @@ Ensure that:
                      "rtf_parsing",
                      "control_chars.rtf")
         if path is not None:
-            with open(path, 'r') as fp:
+            with open(path, 'rb') as fp:
                 rtf = fp.read()
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
@@ -368,7 +388,7 @@ Ensure that:
                      "rtf_parsing",
                      "five_spaces.rtf")
         if path is not None:
-            with open(path, 'r') as fp:
+            with open(path, 'rb') as fp:
                 rtf = fp.read()
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
@@ -376,7 +396,7 @@ Ensure that:
         output = DeEncapsulator(rtf)
         output.deencapsulate()
         # self.maxDiff = None
-        self.assertEqual('INSERT_BODY_TEXT_HERE     ', output.text)
+        self.assertEqual(b'INSERT_BODY_TEXT_HERE     ', output.text)
 
     def test_parse_multiple_features(self):
         """Correctly parse spaces when in their own groups
@@ -389,10 +409,10 @@ Ensure that:
                         "encapsulated_example.html")
 
         if path is not None:
-            with open(path, 'r') as fp:
+            with open(path, 'rb') as fp:
                 rtf = fp.read()
         if htmlpath is not None:
-            with open(htmlpath, 'r') as fp:
+            with open(htmlpath, 'rb') as fp:
                 html = fp.read()
 
         self.check_deencapsulate_validity(rtf,
@@ -404,6 +424,10 @@ Ensure that:
         output.deencapsulate()
         # print("RUNNING DIFF")
         # print(repr(html))
+        # The CR+LF newlines should not match.
+        self.assertNotEqual(html, output.html)
+        # The LF newlines should be replaced.
+        html = html.replace(b'\r\n', b'\n')
         self.assertEqual(html, output.html)
 
 
@@ -431,10 +455,10 @@ Ensure that:
         return True
 
     def replace_text_in_template(self, path, replacement,
-                            rep_str="REPLACE_FROM_HEADER_HERE",
+                            rep_str=b"REPLACE_FROM_HEADER_HERE",
                             string=None):
         if path is not None:
-            with open(path, 'r') as fp:
+            with open(path, 'rb') as fp:
                 raw_rtf = fp.read()
         else:
             raw_rtf = string

--- a/tests/parse_rtf/test_validate_file.py
+++ b/tests/parse_rtf/test_validate_file.py
@@ -16,12 +16,12 @@ class TestInputValidity(unittest.TestCase):
     """ Tests basic valid and invalid inputs."""
 
     def test_valid_rtf_string(self):
-        """ Check that a valid encapsulated rtf string returns 0 exit status."""
+        """ Check that opening an rtf file as a string returns a TypeError."""
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         with open(quote_printable_rtf_path, 'r') as fp:
             raw_rtf = fp.read()
             self.check_deencapsulate_validity(raw_rtf,
-                                              expect_error=None,
+                                              expect_error=TypeError,
                                               name="quoted_printable_01.rtf")
 
     def test_valid_rtf_bytes(self):
@@ -35,7 +35,7 @@ class TestInputValidity(unittest.TestCase):
 
     def test_invalid_none(self):
         """ Check that passing nothing returns a non-zero exit status."""
-        self.check_deencapsulate_validity("",
+        self.check_deencapsulate_validity(b"",
                                           expect_error=MalformedRtf,
                                           name="empty string")
         self.check_deencapsulate_validity(b"",

--- a/tests/test_data/rtf_parsing/surrogate_pairs_02.rtf
+++ b/tests/test_data/rtf_parsing/surrogate_pairs_02.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;}\htmlrtf \u-10179 ?\u-8694 ?\htmlrtf0
+}

--- a/tests/test_data/rtf_parsing/surrogate_pairs_03.rtf
+++ b/tests/test_data/rtf_parsing/surrogate_pairs_03.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;}\htmlrtf \u55357 ?\u56542 ?\htmlrtf0
+}

--- a/tests/test_data/rtf_parsing/surrogate_pairs_04.rtf
+++ b/tests/test_data/rtf_parsing/surrogate_pairs_04.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;} \u55357 ?\u56542 ?
+}

--- a/tests/test_data/rtf_parsing/unicode_HH_replacement.rtf
+++ b/tests/test_data/rtf_parsing/unicode_HH_replacement.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;}\htmlrtf \u55357\'20\u56542 ?\htmlrtf0
+}

--- a/tests/test_data/rtf_parsing/unicode_HH_replacement_01.rtf
+++ b/tests/test_data/rtf_parsing/unicode_HH_replacement_01.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;} \u55357\'20\u56542 ?
+}

--- a/tests/test_utils/test_main_utils.py
+++ b/tests/test_utils/test_main_utils.py
@@ -92,15 +92,15 @@ class TestLogging(unittest.TestCase):
         logger = logging.getLogger("RTFDE")
         logger.setLevel(logging.DEBUG)
         rtf_path = join(DATA_BASE_DIR, "plain_text", "test_data.rtf")
-        with open(rtf_path, 'r') as fp:
+        with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
         mod_rtf = raw_rtf
-        mod_rtf = mod_rtf.replace('\\fswiss ', '\\things ')
-        mod_rtf = mod_rtf.replace('\\blue255', '\\notblueothernumber')
+        mod_rtf = mod_rtf.replace(b'\\fswiss ', b'\\things ')
+        mod_rtf = mod_rtf.replace(b'\\blue255', b'\\notblueothernumber')
         # log_string_diff(raw_rtf, mod_rtf)
         print("===========================sep========================")
         with capture_log(logger) as log:
-            log_string_diff(raw_rtf, mod_rtf, sep='\\{|\\}')
+            log_string_diff(raw_rtf, mod_rtf, sep=b'\\{|\\}')
         log = log.getvalue()
         self.assertIn(r"! \f0\fswiss Arial;", log)
         self.assertIn(r"! \f0\things Arial;", log)
@@ -110,11 +110,11 @@ class TestLogging(unittest.TestCase):
 
     def test_tree_diff(self):
         rtf_path = join(DATA_BASE_DIR, "plain_text", "test_data.rtf")
-        with open(rtf_path, 'r') as fp:
+        with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
         mod_rtf = raw_rtf
-        mod_rtf = mod_rtf.replace('\\fswiss ', '\\things ')
-        mod_rtf = mod_rtf.replace('\\blue255', '\\notblueothernumber')
+        mod_rtf = mod_rtf.replace(b'\\fswiss ', b'\\things ')
+        mod_rtf = mod_rtf.replace(b'\\blue255', b'\\notblueothernumber')
         # Create Trees
         rtf_obj = DeEncapsulator(raw_rtf)
         rtf_obj.deencapsulate()
@@ -122,18 +122,18 @@ class TestLogging(unittest.TestCase):
         mod_rtf_obj.deencapsulate()
         log = get_tree_diff(rtf_obj.full_tree,
                           mod_rtf_obj.full_tree)
-        self.assertIn(r"! Token('CONTROLWORD', '\\fswiss ')", log)
-        self.assertIn(r"! Token('CONTROLWORD', '\\things ')", log)
-        self.assertIn(r"! Token('CONTROLWORD', '\\blue255')", log)
-        self.assertIn(r"! Token('CONTROLWORD', '\\notblueothernumber')", log)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\fswiss ')", log)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\things ')", log)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\blue255')", log)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\notblueothernumber')", log)
 
 class TestUtilities(unittest.TestCase):
     """Test that important utilities are working
     """
 
     def test_encode_escape_chars(self):
-        raw_text = r"test\\thing\{stuff\}test"
+        raw_text = r"test\\thing\{stuff\}test".encode()
         converted = encode_escaped_control_chars(raw_text)
-        self.assertIn("\\'5c", converted)
-        self.assertIn("\\'7b", converted)
-        self.assertIn("\\'7d", converted)
+        self.assertIn(b"\\'5c", converted)
+        self.assertIn(b"\\'7b", converted)
+        self.assertIn(b"\\'7d", converted)

--- a/tests/test_utils/test_main_utils.py
+++ b/tests/test_utils/test_main_utils.py
@@ -137,3 +137,36 @@ class TestUtilities(unittest.TestCase):
         self.assertIn(b"\\'5c", converted)
         self.assertIn(b"\\'7b", converted)
         self.assertIn(b"\\'7d", converted)
+
+
+def embed():
+    import os
+    import readline
+    import rlcompleter
+    import code
+    import inspect
+    import traceback
+
+    history = os.path.join(os.path.expanduser('~'), '.python_history')
+    if os.path.isfile(history):
+        readline.read_history_file(history)
+
+    frame = inspect.currentframe().f_back
+    namespace = frame.f_locals.copy()
+    namespace.update(frame.f_globals)
+
+    readline.set_completer(rlcompleter.Completer(namespace).complete)
+    readline.parse_and_bind("tab: complete")
+
+    file = frame.f_code.co_filename
+    line = frame.f_lineno
+    function = frame.f_code.co_name
+
+    stack = ''.join(traceback.format_stack()[:-1])
+    print(stack)
+    banner = f" [ {os.path.basename(file)}:{line} in {function}() ]"
+    banner += "\n Entering interactive mode (Ctrl-D to exit) ..."
+    try:
+        code.interact(banner=banner, local=namespace)
+    finally:
+        readline.write_history_file(history)


### PR DESCRIPTION
Conversion of RTFDE to only work on encapsulated RTF as bytes and leave final decoding up to the user.  