### PR TITLE
Release 0.1.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+tests/test_data/html/multiple-encodings.rtf text eol=crlf
+tests/test_data/rtf_parsing/surrogate_pairs.rtf text eol=crlf
+tests/test_data/rtf_parsing/encapsulated_example.html text eol=crlf
+tests/test_data/rtf_parsing/surrogates.rtf text eol=crlf
+tests/test_data/rtf_parsing/small_template.rtf text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+# Testing
+tests/test_data/personal_rtf_test_files/*.rtf
+tests/test_data/personal_rtf_test_output_files/*.html

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,570 @@
+[MASTER]
+
+disable=line-too-long
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the 'python-enchant' package.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# class is considered mixin if its name matches the mixin-class-rgx option.
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins ignore-mixin-
+# members is set to 'yes'
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,87 @@ pip3 install -e .[dev]
 ```
 python3 -m unittest discover -v
 ```
+
+# Documentation
+
+This project uses [Google style docstrings](catch_common_validation_issues) which allows us to auto-generate the pdoc documentation.
+
+
+# Advanced Logging
+
+Any logging (including how verbose the logging is) can be handled by configuring logging.
+
+You can enable RTFDE's primary logging by getting and setting the "RTFDE" logger. Any logging that is needed for basic triage will be turned on by this logger.
+
+```
+log = logging.getLogger("RTFDE")
+log.setLevel(logging.DEBUG)
+```
+
+**Here is an example run on one of the test cases.**
+
+```
+import logging
+import RTFDE
+
+log = logging.getLogger("RTFDE")
+log.setLevel(logging.DEBUG)
+
+
+path = 'tests/test_data/plain_text/quoted_printable_01.rtf'
+with open(path, 'r') as fp:
+    raw = fp.read()
+output = RTFDE.DeEncapsulator(rtf)
+output = RTFDE.DeEncapsulator(raw)
+output.deencapsulate()
+```
+
+## Developer Debugging
+
+You should read this section if the normal logging set to DEBUG didn't give you enough information to understand an error or weird behavior of RTFDE. I've added a variety of levels of debug logging to help you dig in and understand these problems.
+
+### RTF Validation Errors
+
+You have, what you believe to be, a valid RTF file which RTFDE is rejecting and telling you is invalid. You can see what each of the validators is parsing by setting the `RTFDE.validation_logger`. If set to DEBUG it will output the data being validated so you can evaluate it yourself to track down the issue.
+
+```
+log = logging.getLogger("RTFDE.validation_logger")
+log.setLevel(logging.DEBUG)
+```
+
+### HTMLRTF Stripping Logging
+
+If you want to log all text and RTF control words that are suppressed by HTMLRTF control words you can use the `RTFDE.HTMLRTF_Stripping_logger` logger. If set to DEBUG it will output the Tokens which have been removed and the line the token starts on, the line it ends on, the starting position of that token in the line, and the end position of that token. The log uses the following format `HTMLRTF Removed: {value}, {line}, {end_line}, {start_pos}, {end_pos}`
+
+Here is how you enable this log.
+```
+log = logging.getLogger("RTFDE.HTMLRTF_Stripping_logger")
+log.setLevel(logging.DEBUG)
+```
+
+### HTMLRTF Stripping Logging
+
+If you are having difficulty tracking down some sort of text-transformation/decoding issue then you can use the text_extraction logging to show you FAR more information about what is occuring during text extraction. WARNING: This log is a flood of information!
+
+Here is how you enable this log.
+```
+log = logging.getLogger("RTFDE.text_extraction")
+log.setLevel(logging.DEBUG)
+```
+
+
+
+
+### Grammar Debugging
+
+RTFDE
+
+
+
+### Lark Debug Logs
+If you want to see underlying Lark language parsing toolkit's logging you can activate its logger like this.
+
+```
+log = logging.getLogger("lark")
+log.setLevel(logging.DEBUG)
+```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip3 install RTFDE
 ```python
 from RTFDE.deencapsulate import DeEncapsulator
 
-with open('rtf_file', 'r') as fp:
+with open('rtf_file', 'rb') as fp:
     raw_rtf  = fp.read()
     rtf_obj = DeEncapsulator(raw_rtf)
     rtf_obj.deencapsulate()
@@ -43,6 +43,33 @@ with open('rtf_file', 'r') as fp:
     else:
         print(rtf_obj.text)
 ```
+
+
+
+# Enabling Logging
+
+Any logging (including how verbose the logging is) can be handled by configuring logging. You can enable RTFDE's logging at the highest level by getting and setting the "RTFDE" logger.
+
+```
+log = logging.getLogger("RTFDE")
+log.setLevel(logging.INFO)
+```
+
+
+
+
+
+
+To see how to enable more in-depth logging for debugging check out the CONTRIBUTING.md file.
+
+```
+# Now, get the log that you want
+# The main logger is simply called RTFDE. That will get you all the *normal* logs.
+requests_log = logging.getLogger("RTFDE")
+requests_log.setLevel(logging.DEBUG)
+requests_log.propagate = True
+```
+
 
 # Contribute
 

--- a/RTFDE/__init__.py
+++ b/RTFDE/__init__.py
@@ -17,22 +17,19 @@
 """
 RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML.
 
-https://github.com/seamustuohy/RTF_De-Encapsulator
+https://github.com/seamustuohy/RTFDE
 """
 
 __author__ = 'seamus tuohy'
-__date__ = '2020-12-05'
-__version__ = '0.00.1'
+__date__ = '2023-06-18'
+__version__ = '0.1.0'
 
 import logging
+from logging import NullHandler
 
-FORMAT = "%(levelname)s [%(filename)s:%(lineno)s - %(funcName)s() ] %(message)s"
-formatter = logging.Formatter(FORMAT)
-default_handler = logging.StreamHandler()
-default_handler.setFormatter(formatter)
+logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__ + ".tree_logger").addHandler(NullHandler())
 
-logger = logging.getLogger(__name__)
-logger.addHandler(default_handler)
-logger.setLevel(logging.WARNING)
+
 
 from RTFDE.deencapsulate import DeEncapsulator

--- a/RTFDE/deencapsulate.py
+++ b/RTFDE/deencapsulate.py
@@ -25,7 +25,7 @@ from RTFDE.transformers import RTFCleaner, StripControlWords
 from RTFDE.transformers import StripNonVisibleRTFGroups
 from RTFDE.transformers import StripUnusedSpecialCharacters
 from RTFDE.utils import encode_escaped_control_chars
-from RTFDE.utils import log_validators, log_transformations
+from RTFDE.utils import log_validators, log_transformations, is_logger_on
 from RTFDE.transformers import get_stripped_HTMLRTF_values, DeleteTokensFromTree, strip_binary_objects
 from RTFDE.grammar import make_concise_grammar
 from RTFDE.text_extraction import TextDecoder

--- a/RTFDE/deencapsulate.py
+++ b/RTFDE/deencapsulate.py
@@ -19,6 +19,7 @@ from io import BufferedReader
 from lark import Lark
 from lark.tree import Tree
 from lark.lexer import Token
+from lark.exceptions import UnexpectedInput
 
 from RTFDE.transformers import RTFCleaner, StripControlWords
 from RTFDE.transformers import StripNonVisibleRTFGroups
@@ -109,7 +110,10 @@ Once you have loaded in the raw rtf this function will set the properties contai
             log.info("Binary data found and extracted from rtf file.")
         escaped_rtf = encode_escaped_control_chars(non_binary_rtf)
         log_transformations(escaped_rtf)
-        self.parse_rtf(escaped_rtf)
+        try:
+            self.parse_rtf(escaped_rtf)
+        except UnexpectedInput as _e:
+            raise MalformedEncapsulatedRtf(f"Malformed encapsulated RTF discovered:") from _e
         Decoder = TextDecoder()
         Decoder.update_children(self.full_tree)
         self.get_doc_tree()

--- a/RTFDE/deencapsulate.py
+++ b/RTFDE/deencapsulate.py
@@ -109,7 +109,8 @@ Once you have loaded in the raw rtf this function will set the properties contai
             self.found_binary = found_binary
             log.info("Binary data found and extracted from rtf file.")
         escaped_rtf = encode_escaped_control_chars(non_binary_rtf)
-        log_transformations(escaped_rtf)
+        if is_logger_on("RTFDE.transform_logger") is True:
+            log_transformations(escaped_rtf)
         try:
             self.parse_rtf(escaped_rtf)
         except UnexpectedInput as _e:
@@ -236,7 +237,8 @@ Args:
                            # debug=True,
                            propagate_positions=True)
         self.full_tree = self.parser.parse(rtf)
-        log_transformations(self.full_tree)
+        if is_logger_on("RTFDE.transform_logger") is True:
+            log_transformations(self.full_tree)
 
 
     def strip_htmlrtf_tokens(self) -> Tree:
@@ -293,7 +295,8 @@ Raises:
                 operating_tokens.append(token)
             else:
                 operating_tokens += list(token.scan_values(lambda t: t.type == 'CONTROLWORD'))
-        log_validators(f"Header tokens being evaluated: {operating_tokens}")
+        if is_logger_on("RTFDE.validation_logger") is True:
+            log_validators(f"Header tokens being evaluated: {operating_tokens}")
 
         for token in operating_tokens:
             cw_found,found_token = self.check_from_token(token=token, cw_found=cw_found)
@@ -362,7 +365,8 @@ Raises:
         first_token = doc_tree.children[0].value
         if first_token != b"\\rtf1":
             log.debug("RTF stream does not contain valid valid RTF document heading. The file must start with \"{\\rtf1\"")
-            log_validators(f"First child object in document tree is: {first_token!r}")
+            if is_logger_on("RTFDE.validation_logger") is True:
+                log_validators(f"First child object in document tree is: {first_token!r}")
             raise MalformedRtf("RTF stream does not start with {\\rtf1")
 
     @staticmethod

--- a/RTFDE/grammar.py
+++ b/RTFDE/grammar.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2020 seamus tuohy, <code@seamustuohy.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+GRAMMAR = {
+    "imports": r"""
+%import common.ESCAPED_STRING
+%import common.SIGNED_NUMBER
+%import common.DIGIT
+%import common.NEWLINE
+%import common.LETTER""",
+    "ignore": r"""%ignore NEWLINE""",
+    "_LBRACE": r'"{"',
+    "_RBRACE": r'"}"',
+    "BACKSLASH": r'"\\"',
+    "start": r"_LBRACE document _RBRACE",
+    "document": r"""(CONTROLWORD
+                    | control_symbol
+                    | string
+                    | group
+                    | _SPACE_DELETE
+                    | RTFESCAPE)+""",
+    "group": r"""_LBRACE (CONTROLWORD
+                        | control_symbol
+                        | string
+                        | htmltag_group
+                        | mhtmltag_group
+                        | group
+                        | RTFESCAPE
+                        | NEWLINE )* _RBRACE""",
+    "htmltag_group": r"STAR_ESCAPE HTMLTAG ( string | group )*",
+    "HTMLTAG": r'"\\htmltag" DIGIT~0..3 _SPACE_DELETE?',
+    "MHTMLTAG": r'"\\mhtmltag" DIGIT~0..3 _SPACE_DELETE?',
+    "mhtmltag_group": r"STAR_ESCAPE MHTMLTAG ( string | group )*",
+    "NUMERICALDEL": r"SIGNED_NUMBER*",
+    "_SPACE_DELETE": r'" "',
+    "SPACE_SAVE": r'" "',
+    "DELIMITER": r"NUMERICALDEL _SPACE_DELETE?",
+    "ASCIILETTERSEQUENCE" : r"LETTER+",
+    "CONTROLWORD": "BACKSLASH ASCIILETTERSEQUENCE~1..32 DELIMITER",
+    "STAR_ESCAPE": r'BACKSLASH "*"',
+    "NONBREAKING_HYPHEN": r'BACKSLASH "_"',
+    "OPTIONAL_HYPHEN": r'BACKSLASH "-"',
+    "NONBREAKING_SPACE": r'BACKSLASH "~"',
+    "FORMULA_CHARACTER": r'BACKSLASH "|"',
+    "INDEX_SUBENTRY": r'BACKSLASH ":"',
+    "control_symbol": r"(STAR_ESCAPE | INDEX_SUBENTRY | FORMULA_CHARACTER | NONBREAKING_SPACE | OPTIONAL_HYPHEN | NONBREAKING_HYPHEN )",
+    "STRING": r'/.+?/',
+    "?string": r"STRING+ SPACE_SAVE?",
+    "_QUESTION_MARK": r'"?"',
+    "RTFESCAPE" : r"""("\\'" /[0-9A-Fa-f]/~2)+ | ("\\u" /[-]*[0-9]+/)+ _SPACE_DELETE? _QUESTION_MARK?"""
+   }
+
+
+# // == Priority Levels ==
+# This dictionary sets the priority level for each type of object in the lexer.
+# Higher numbers give a greater priority.
+# All must start with a period
+# EXPLICIT IS BETTER THEN RELYING ON DEFAULTS
+# // 0 = Raw String Matching // text should defer to everything else if conflicting
+# // 1 = Generic undefined object (i.e. group, CONTROL_WORD, CONTROL_SYMBOL, etc.)
+# // 2 = Specific instances of objects (i.e. HTMLTAG, MHTMLTAG, etc.)
+
+PRIORITY_LEVELS = {
+    "_LBRACE": ".1",
+    "_RBRACE": ".1",
+    "BACKSLASH" : ".1",
+    "start" : ".1",
+    "document": ".1",
+    "group": ".1",
+    "htmltag_group" : ".2",
+    "HTMLTAG" : ".2",
+    "MHTMLTAG" : ".2",
+    "mhtmltag_group" : ".2",
+    "NUMERICALDEL" : ".1",
+    "_SPACE_DELETE" : ".1",
+    "SPACE_SAVE" : ".1",
+    "DELIMITER" : ".1",
+    "ASCIILETTERSEQUENCE" : ".1",
+    "CONTROLWORD": ".1",
+    "STAR_ESCAPE": ".1",
+    "NONBREAKING_HYPHEN": ".1",
+    "OPTIONAL_HYPHEN": ".1",
+    "NONBREAKING_SPACE": ".1",
+    "FORMULA_CHARACTER": ".1",
+    "INDEX_SUBENTRY": ".1",
+    "control_symbol": ".1",
+    "STRING" : ".0",
+    "_QUESTION_MARK": ".1",
+    "?string" : ".0",
+    "RTFESCAPE" : ".2",
+}
+
+def make_concise_grammar():
+    """Make a grammar string to use with the lexer.
+    """
+    grammar = r""""""
+    for key, priority in PRIORITY_LEVELS.items():
+        grammar += "{0}{1} : {2}\n".format(key,priority,GRAMMAR[key])
+    grammar += GRAMMAR['imports'] + "\n"
+    grammar += GRAMMAR['ignore'] + "\n"
+    return (grammar)
+
+
+
+def make_literate_grammar():
+    """Create a VERBOSE grammar string which can be used to understand the grammar.
+
+    This SHOULD be updated to include and changes to the grammar.
+    This is valuable when debugging and/or otherwise trying to understand the grammar.
+    """
+    grammar = r"""
+
+// ===== Precedence =========
+// Literals are matched according to the following precedence:
+// 1. Highest priority first (priority is specified as: TERM.number: …)
+// 2. Length of match (for regexps, the longest theoretical match is used)
+// 3. Length of literal / pattern definition
+// 4. Name
+//
+// == Priority Levels ==
+// WARNING: Priority Levels are not shown in this literate grammar.
+// NOTE: Look at PRIORITY_LEVELS for the prioritized levels used in production.
+// 0 = Raw String Matching // text should defer to everything else if conflicting
+// 1 = Generic undefined object (i.e. group, CONTROL_WORD, CONTROL_SYMBOL, etc.)
+// 2 = Specific instances of objects (i.e. HTMLTAG, MHTMLTAG, etc.)
+
+// ====== GRAMMAR OBJECT IMPORTS FROM LARK COMMONS ======
+// https://github.com/lark-parser/lark/blob/master/lark/grammars/common.lark
+{imports}
+
+
+// ====== Ignore Newlines ======
+// The real carriage returns are stored in \par or \line tags.
+{ignore}
+
+// ====== SIMPLE GRAMMAR OBJECTS USED THROUGHOUT ======
+// RTF is braces all the way down
+// We don't have to worry about escaped braces since we are pre-processing out escaped braces already
+_LBRACE: {_LBRACE}
+_RBRACE: {_RBRACE}
+
+// We don't have to worry about escaped backslashes since we are pre-processing out escaped braces already
+BACKSLASH: {BACKSLASH}
+
+// RTF control words are made up of ASCII alphabetical characters (a through z and A through Z)
+ASCIILETTERSEQUENCE: {ASCIILETTERSEQUENCE}
+
+// A space that should be deleted (See Delimiters below)
+_SPACE_DELETE: {_SPACE_DELETE}
+
+// But, we want to save spaces within strings. So, we have a special space for that.
+SPACE_SAVE : {SPACE_SAVE}
+
+// ====== UNMATCHED RAW TEXT ======
+// In order to split out everything that is simply plain text and not a special RTF object I've had to match all raw text characters individually. This allows us to store them all in their own rule branch (string) for tranformation later on.
+
+STRING : {STRING}
+
+// We use the ? char to inline this rule to remove the branch and replace it with its children if it has one match. This will make it easier to parse later and remove uneccesary matches of it.
+?string: {?string}
+
+
+
+
+// ====== HIGH LEVEL DOCUMENT PARSING ======
+
+// The start object is the top level object in the tree
+// An RTF file has the following syntax: '{{' <header & document> '}}'
+start: {start}
+
+// Parse <header & document>
+document: {document}
+
+// A group consists of text and control words or control symbols enclosed in braces ({{}}).
+// The opening brace ({{ ) indicates the start of the group and the closing brace ( }}) indicates the end of the group.
+group: {group}
+
+
+// ====== CONTROL WORD(s) ======
+
+// A control word is defined by: \<ASCII Letter Sequence><Delimiter>
+// A control word’s name cannot be longer than 32 letters.
+CONTROLWORD: {CONTROLWORD}
+
+// === Delimiter ==
+
+DELIMITER: {DELIMITER}
+
+// The <Delimiter> can be one of the following:
+// 1. A numeric digit or an ASCII minus sign (-), which indicates that a numeric parameter is associated with the control word.
+NUMERICALDEL: {NUMERICALDEL}
+// 2. A space: When a space is used as a the delimiter, it is discarded. This means that it’s not included in subsequent processing. So, we are using a discarded terminal (by putting a underscore in front of the name) to ensure it is tossed.
+// See: "_SPACE_DELETE" under SIMPLE GRAMMAR OBJECTS
+
+// 3. Any character other than a letter or a digit. In this case, the delimiting character terminates the control word and is not part of the control word. So, it's not included in the grammar here.
+
+
+// ====== CONTROL SYMBOLS(s) ======
+
+// A control symbol consists of a backslash followed by a single, nonalphabetic character.
+// For example, \~ represents a nonbreaking space.
+
+// The STAR_ESCAPE special construct means that if the program understands the \command, it takes this to mean {\command ...}, but if it doesn’t understand \command, the program ignores not just \command (as it would anyway) but everything in this group.
+STAR_ESCAPE: {STAR_ESCAPE}
+NONBREAKING_HYPHEN: {NONBREAKING_HYPHEN}
+OPTIONAL_HYPHEN: {OPTIONAL_HYPHEN}
+NONBREAKING_SPACE: {NONBREAKING_SPACE}
+FORMULA_CHARACTER: {FORMULA_CHARACTER}
+INDEX_SUBENTRY: {INDEX_SUBENTRY}
+
+// Control symbols take no delimiters.
+control_symbol: {control_symbol}
+
+
+
+
+
+// ====== SPECIAL CONTROL WORD(s) ======
+
+// ====== HEADER OBJECTS ======
+
+// The FROMHTML control word specifies that the RTF document contains encapsulated HTML text.
+// This control word MUST be \fromhtml1. Any other form, such as \fromhtml or \fromhtml0, will not be considered encapsulated
+// FROMTEXT: {FROMTEXT}
+
+//The FROMHTML control word specifies that the RTF document contains encapsulated HTML text.
+// This control word MUST be \fromhtml1. Any other form, such as \fromhtml or \fromhtml0, will not be considered encapsulated.
+//FROMHTML : {FROMHTML}
+
+
+// ====== SPECIFIC CONTROL WORD OBJECTS ======
+
+// HTMLRTF Toggle Control Word
+// The HTMLRTF control word identifies fragments of RTF that were not in the original HTML content
+// If the flag is "\htmlrtf" or "\htmlrtf1" then do not process anything else until you encounter "\htmlrtf0" which will toggle this off again.
+// A de-encapsulating RTF reader MUST support the HTMLRTF control word within nested groups. The state of the HTMLRTF control word MUST transfer when entering groups and be restored when exiting groups.
+// This means that you can only turn this off on it's own level (turning it off in an object nested within it does nothing). And, if the object it's in ends then it doesn't transfer up the tree to objects that contain it. So, if you don't find a closing "\htmlrtf0" you can delete from the opening "\htmlrtf" all the way until the end of the current object, but not above.
+// HTMLRTF : {HTMLRTF}
+
+// The HTMLTAG destination group encapsulates HTML fragments that cannot be directly represented in RTF
+htmltag_group: {htmltag_group}
+
+// The "DIGIT~0..3" in the following definition is the HTMLTagParameter from the spec.
+    // A space MUST be used to separate the CONTENT HTML fragment from the HTMLTagParameter HTML fragment if the text starts with a DIGIT, or if the HTMLTagParameter HTML fragment is omitted. As such, we throw away this space by using _SPACE_DELETE if we encounter one.
+HTMLTAG: {HTMLTAG}
+
+
+
+content : {content}
+
+// \*\mhtmltag[HTMLTagParameter] [CONTENT]
+// The values and format of the numeric parameter are identical to the numeric parameter in the HTMLTAG destination group.
+// This RTF control word SHOULD be skipped on de-encapsulation and SHOULD NOT be written when encapsulating.
+# TODO: https://datatracker.ietf.org/doc/html/draft-ietf-mhtml-cid-00#section-1
+// NOTE: mhtmltag's contain original URL which has been replaced in the corresponding  htmltag with the CID of an object. As such, it contains possibly useful URI data that, while not useful for the direct output, should be saved.
+MHTMLTAG : {MHTMLTAG}
+mhtmltag_group: {mhtmltag_group}
+
+
+// TODO: Check if really neeeded
+// Increased priority of escape chars to make unescaping easier
+// Multiple char acceptance is important here because if you just catch one escape at a time you mess up multi-byte values.
+_QUESTION_MARK: {_QUESTION_MARK}
+RTFESCAPE : {RTFESCAPE}
+
+
+    """.format(**GRAMMAR)
+    return grammar
+
+
+if __name__ == '__main__':
+    # print(make_literate_grammar())
+
+    print(make_concise_grammar())

--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -199,14 +199,6 @@ Args:
 Returns:
     The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
 """
-    if codepage_num == 950:
-        # See if an implementation has been added for windows-950. If it has, use that.
-        try:
-            codecs.lookup('windows-950') # Raises LookupError if not found.
-            log.debug('Found python codec corresponding to code page {0}: windows-950'.format(codepage_num))
-            return 'windows-950'
-        except LookupError:
-            pass
     text_codec = codepages.codepage2codec(codepage_num)
     log.debug('Found python codec corresponding to code page {0}: {1}'.format(codepage_num, text_codec))
     return text_codec

--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -25,7 +25,7 @@ from lark.tree import Tree
 from RTFDE.exceptions import MalformedRtf
 from RTFDE.utils import is_codeword_with_numeric_arg
 from RTFDE.utils import flatten_tree_to_string_array
-from RTFDE.utils import log_text_extraction
+from RTFDE.utils import log_text_extraction, is_logger_on
 
 import logging
 log = logging.getLogger("RTFDE")
@@ -108,7 +108,8 @@ Returns:
         238:{"name":"EE_CHARSET","hex":"0xEE","decimal":238,"id":1250},
         255:{"name":"OEM_CHARSET","hex":"0xFF","decimal":255,"id":None},
 }
-    log_text_extraction(f"Getting charset for {fcharsetN}")
+    if is_logger_on("RTFDE.text_extraction") is True:
+        log_text_extraction(f"Getting charset for {fcharsetN}")
     charset = charsets.get(fcharsetN, None)
     if charset is not None:
         charset_id = charset.get('id', None)
@@ -352,7 +353,8 @@ Returns:
     ascii_map: Dict[Token,List[Token]]  = {}
     new_children = []
     removal_map: List[Token] = []
-    log_text_extraction(f"Removing unicode replacements on {repr(children)}")
+    if is_logger_on("RTFDE.text_extraction") is True:
+        log_text_extraction(f"Removing unicode replacements on {repr(children)}")
     for child in children:
         if len(removal_map) > 0:
             if isinstance(child, Token):
@@ -612,13 +614,15 @@ def decode_hex_char(item, codec):
     item (bytes): A bytes object.
     codec (str): The name of the codec to use to decode the bytes
     """
-    log_text_extraction("decoding char {0} with font {1}".format(item, codec))
+    if is_logger_on("RTFDE.text_extraction") is True:
+        log_text_extraction("decoding char {0} with font {1}".format(item, codec))
     if codec is None:
         # Default to U.S. Windows default codepage
         codec = 'CP1252'
     decoded = item.decode(codec)
     decoded = decoded.encode()
-    log_text_extraction("char {0} decoded into {1} using codec {2}".format(item, decoded, codec))
+    if is_logger_on("RTFDE.text_extraction") is True:
+        log_text_extraction("char {0} decoded into {1} using codec {2}".format(item, decoded, codec))
     return decoded
 
 
@@ -651,7 +655,8 @@ class TextDecoder:
         self.font_stack = [self.default_font]
         raw_fonttbl = get_font_table(obj.children[1])
         self.font_table = parse_font_tree(raw_fonttbl)
-        log_text_extraction(f"FONT TABLE FOUND: {raw_fonttbl}")
+        if is_logger_on("RTFDE.text_extraction") is True:
+            log_text_extraction(f"FONT TABLE FOUND: {raw_fonttbl}")
 
 
     def update_children(self, obj: Tree):
@@ -682,10 +687,12 @@ class TextDecoder:
 
     def iterate_on_children(self, children): # Children should be 'List[Union[Token,Tree]]' but lark's Tree typing is defined badly.
         set_fonts = []
-        log_text_extraction("Starting to iterate on text extraction children...")
-        log_text_extraction("PREP-BEFORE: "+repr(children))
+        if is_logger_on("RTFDE.text_extraction") is True:
+            log_text_extraction("Starting to iterate on text extraction children...")
+            log_text_extraction("PREP-BEFORE: "+repr(children))
         children = self.prep_unicode(children)
-        log_text_extraction("PREP-AFTER: "+repr(children))
+        if is_logger_on("RTFDE.text_extraction") is True:
+            log_text_extraction("PREP-AFTER: "+repr(children))
 
         for item in children:
             if is_font_number(item): # Font Definitions
@@ -706,7 +713,8 @@ class TextDecoder:
                                     end_line=item.end_line,
                                     column=item.column,
                                     end_column=item.end_column)
-                log_text_extraction(f"UNICODE TOKEN {item}: {decoded_tok}")
+                if is_logger_on("RTFDE.text_extraction") is True:
+                    log_text_extraction(f"UNICODE TOKEN {item}: {decoded_tok}")
                 yield decoded_tok
             # Decode a hex array
             elif is_hexarray(item):

--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2022 seamus tuohy, <code@seamustuohy.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+import re
+from collections import namedtuple
+from typing import Union, Any, List, Tuple, Dict
+
+from oletools.common import codepages
+
+from lark.lexer import Token
+from lark.tree import Tree
+
+from RTFDE.exceptions import MalformedRtf
+from RTFDE.utils import is_codeword_with_numeric_arg
+from RTFDE.utils import flatten_tree_to_string_array
+from RTFDE.utils import log_text_extraction
+
+import logging
+log = logging.getLogger("RTFDE")
+
+fontdef = namedtuple("fontdef", ["fnum", "codepage", "codec", "fontdef_tree"])
+
+
+def get_font_table(tree: Tree) -> Tree:
+    """Extract the font table group from the first 20 tokens of a .rtf document.
+
+Args:
+    tree (Tree): A .rtf document object parsed into a Tree object
+
+Raises:
+    ValueError: If no group with a `\\fonttbl` token as its first controlword is found.
+
+Returns:
+    {'\\f0': fontdef(fnum='\\f0', codepage=932, codec='cp932', fontdef_tree='{\\f0\\fswiss\\fcharset128 MS PGothic;}'),
+    '\\f1': fontdef(fnum='\\f1', codepage=None, codec=None, fontdef_tree='{\\f1\\fmodern MS Gothic;}'),
+    '\\f2': fontdef(fnum='\\f2', codepage=None, codec=None, fontdef_tree='{\\f2\\fnil\\fcharset2 Symbol;}'),
+    '\\f3': fontdef(fnum='\\f3', codepage=1252, codec='cp1252', fontdef_tree='{\\f3\\fmodern\\fcharset0 Courier New;}'),
+    '\\f4': fontdef(fnum='\\f4', codepage=932, codec='cp932', fontdef_tree='{\\f4\\fswiss\\fcharset128 "PMingLiU";}'),
+    '\\f5': fontdef(fnum='\\f5', codepage=None, codec=None, fontdef_tree='{\\f5\\fswiss "Amnesty Trade Gothic";}'),
+    '\\f6': fontdef(fnum='\\f6', codepage=None, codec=None, fontdef_tree='{\\f6\\fswiss "Arial";}')}
+    """
+    for item in tree.children[:20]:
+        if isinstance(item, Tree):
+            try:
+                ctrl_value = item.children[1]
+            except IndexError as _e:
+                continue
+            if isinstance(ctrl_value, Token):
+                table_type = ctrl_value.value.strip()
+                if table_type == b"\\fonttbl":
+                    return item
+    raise ValueError("No font table found in tree")
+
+
+def is_font_number(token: Token) -> bool:
+    """Checks if an object is a "font number".
+
+Returns:
+    True if an object is a "font number" controlword `\\fN`. False if not.
+
+"""
+    try:
+        if is_codeword_with_numeric_arg(token, b'\\f'):
+            return True
+    except AttributeError: # pragma: no cover
+        return False
+    return False
+
+def get_codepage_num_from_fcharset(fcharsetN: int) -> Union[int,None]:
+    """Return the codepage to use with a specific fcharsetN.
+
+Args:
+    fcharsetN (int): The numeric argument N for a \fcharsetN control word.
+
+Returns:
+    (int OR None) Returns the int for a codepage if known. Returns None for unknown charsets or charsets with no corresponding codepage (such as OEM or DEFAULT.)
+
+    """
+    # Charset table retrieved on 2022-08-19
+    # https://web.archive.org/web/20220819215334/https://docs.microsoft.com/en-us/previous-versions/cc194829%28v=msdn.10%29?redirectedfrom=MSDN
+    charsets: dict[int,dict[str,Any]] = {
+        0:{"name":"ANSI_CHARSET","hex":"0x00","decimal":0,"id":1252},
+        1:{"name":"DEFAULT_CHARSET","hex":"0x01","decimal":1,"id":None},
+        2:{"name":"SYMBOL_CHARSET","hex":"0x02","decimal":2,"id":None},
+        128:{"name":"SHIFTJIS_CHARSET","hex":"0x80","decimal":128,"id":932},
+        129:{"name":"HANGUL_CHARSET","hex":"0x81","decimal":129,"id":949},
+        134:{"name":"GB2312_CHARSET","hex":"0x86","decimal":134,"id":936},
+        136:{"name":"CHINESEBIG5_CHARSET","hex":"0x88","decimal":136,"id":950},
+        161:{"name":"GREEK_CHARSET","hex":"0xA1","decimal":161,"id":1253},
+        162:{"name":"TURKISH_CHARSET","hex":"0xA2","decimal":162,"id":1254},
+        177:{"name":"HEBREW_CHARSET","hex":"0xB1","decimal":177,"id":1255},
+        178:{"name":"ARABIC_CHARSET","hex":"0xB2","decimal":178,"id":1256},
+        186:{"name":"BALTIC_CHARSET","hex":"0xBA","decimal":186,"id":1257},
+        204:{"name":"RUSSIAN_CHARSET","hex":"0xCC","decimal":204,"id":1251},
+        222:{"name":"THAI_CHARSET","hex":"0xDE","decimal":222,"id":874},
+        238:{"name":"EE_CHARSET","hex":"0xEE","decimal":238,"id":1250},
+        255:{"name":"OEM_CHARSET","hex":"0xFF","decimal":255,"id":None},
+}
+    log_text_extraction(f"Getting charset for {fcharsetN}")
+    charset = charsets.get(fcharsetN, None)
+    if charset is not None:
+        charset_id = charset.get('id', None)
+        return charset_id
+    return None
+
+
+def get_default_font(tree: Tree) -> Union[str,None]:
+    """Extract the font number controlword default font if it exists.
+
+If an RTF file uses a default font, the default font number is specified with the \\deffN control word, which must precede the font-table group.
+
+Args:
+    tree (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree object.
+
+Returns:
+    The default font control number if it exists from the first `\\deffN`. None if not found.
+"""
+    deff_gen = tree.scan_values(
+        lambda v: is_codeword_with_numeric_arg(v, b'\\deff')
+    )
+    deff_options = list(deff_gen)
+    try:
+        # We just want the first \\deffN. It shouldn't be set multiple times.
+        deff = deff_options[0]
+        deff_num = deff.value[5:]
+        return b'\\f' + deff_num
+    except IndexError:
+        return None
+
+def parse_font_tree(font_tree: Tree) -> dict:
+    """Create a font tree dictionary with appropriate codeces to decode text.
+
+Args:
+    font_tree (Tree): The .rtf font table object decoded as a tree.
+
+Returns:
+    A dictionary which maps font numbers to appropriate python codeces needed to decode text.
+"""
+    parsed_font_tree = {}
+    for tree in font_tree.children:
+        if isinstance(tree, Tree):
+            fnum = None
+            fcharset = None
+            cpg_num = None
+            for tok in tree.children:
+                if is_codeword_with_numeric_arg(tok, b'\\f'):
+                    fnum = tok.value
+                elif is_codeword_with_numeric_arg(tok, b'\\fcharset'):
+                    fchar_num = int(tok.value[9:])
+                    fcharset = get_codepage_num_from_fcharset(fchar_num)
+                elif is_codeword_with_numeric_arg(tok, b'\\cpg'):
+                    cpg_num = int(tok.value[4:])
+            if fnum is not None:
+                # get the codepage
+                codepage_num = None
+
+                if fcharset is not None:
+                    try:
+                        codepage_num = check_codepage_num(fcharset)
+                    except ValueError: # pragma: no cover
+                        codepage_num = None
+                # if both \\fcharset and \\cpg appear in the font table, \\cpg is ignored.
+                if ((codepage_num is None) and (cpg_num is not None)):
+                    try:
+                        codepage_num = check_codepage_num(cpg_num)
+                    except ValueError: # pragma: no cover
+                        codepage_num = None
+                # Get the appropriate codec
+                if codepage_num is not None:
+                    codec = get_python_codec(codepage_num)
+                else:
+                    codec = None
+                # Only add if there is a font definition
+                tree_str =  b"".join(list(flatten_tree_to_string_array(tree)))
+                parsed_font_tree[fnum] = fontdef(fnum, codepage_num, codec, tree_str)
+    return parsed_font_tree
+
+
+def get_python_codec(codepage_num: int) -> str:
+    """Returns the python codec needed to decode bytes to unicode.
+
+Args:
+    codepage_num (int): A codepage number.
+
+Returns:
+    The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
+"""
+    text_codec = codepages.codepage2codec(codepage_num)
+    log.debug('Found python codec corresponding to code page {0}: {1}'.format(codepage_num, text_codec))
+    return text_codec
+
+def check_codepage_num(codepage_num: int) -> int:
+    """Provide the codepage number back to you if it is valid.
+
+Args:
+    codepage_num (int): A possible codepage number.
+
+Returns:
+    The codepage number IF it is a valid codepage number
+
+Raises:
+    ValueError: The codepage_num provided isn't a valid codepage number.
+
+"""
+    # This keyword should be emitted in the RTF header section right after the \ansi, \mac, \pc or \pca keyword. But, various document tags like \fbids often are thrown all over the header so we have to check the first group of headers for it.
+    # Code page names from https://docs.microsoft.com/en-gb/windows/desktop/Intl/code-page-identifiers
+    # Retrieved on 2020-12-18
+    allowed_codepage_nums = set([37, 437, 500, 708, 709, 710, 720, 737, 775, 850, 852, 855, 857, 858, 860, 861, 862, 863, 864, 865, 866, 869, 870, 874, 875, 932, 936, 949, 950, 1026, 1047, 1140, 1141, 1142, 1143, 1144, 1145, 1146, 1147, 1148, 1149, 1200, 1201, 1250, 1251, 1252, 1253, 1254, 1255, 1256, 1257, 1258, 1361, 10000, 10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10010, 10017, 10021, 10029, 10079, 10081, 10082, 12000, 12001, 20000, 20001, 20002, 20003, 20004, 20005, 20105, 20106, 20107, 20108, 20127, 20261, 20269, 20273, 20277, 20278, 20280, 20284, 20285, 20290, 20297, 20420, 20423, 20424, 20833, 20838, 20866, 20871, 20880, 20905, 20924, 20932, 20936, 20949, 21025, 21027, 21866, 28591, 28592, 28593, 28594, 28595, 28596, 28597, 28598, 28599, 28603, 28605, 29001, 38598, 50220, 50221, 50222, 50225, 50227, 50229, 50930, 50931, 50933, 50935, 50936, 50937, 50939, 51932, 51936, 51949, 51950, 52936, 54936, 57002, 57003, 57004, 57005, 57006, 57007, 57008, 57009, 57010, 57011, 65000, 65001])
+    if codepage_num in allowed_codepage_nums:
+        return codepage_num
+    # Note: If support for a specific codepage ever becomes an issue we can look at add support using the actual code-pages.
+    # Conversion tables for codepages can be retrieved from here: https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/
+    raise ValueError(f"Unsupported unicode codepage number `{codepage_num}` found in the header")
+
+
+def validate_ansi_cpg(header: str) -> None:
+    """Check an '\\ansicpgNNNN' string to see if the number NNNN is an actual codepage.
+
+Args:
+    header (str): The value from the lark `\\ansicpg` CONTROLWORD Token.
+
+Raises:
+    MalformedRtf: If the value passed is not a valid ansi codepage.
+"""
+    try:
+        possible_cpg_num = int(header.strip()[8:])
+        check_codepage_num(possible_cpg_num)
+    except ValueError as _e:
+        raise MalformedRtf(f"Unsupported unicode codepage number `{header}` found in the header") from _e
+
+
+# UNICODE CHARS
+def unicode_escape_to_chr(item: bytes) -> str:
+    """Convert unicode char from it's decimal to its unicode character representation. From "\\u[-]NNNNN" to the string representing the character whose Unicode code point that decimal represents.
+
+Args:
+    item (str): A RTF Escape in the format \\u[-]NNNNN.
+
+Returns:
+    The unicode character representation of the identified character
+
+Raises:
+    ValueError: The escaped unicode character is not valid.
+"""
+    try:
+        nnnn = int(item.removeprefix(b'\\u')) # raises ValueError if not int.
+    except ValueError as _e:
+        raise ValueError(f"`{item}` is not a valid escaped unicode character.") from _e
+    if nnnn < 0: # § -NNNNN is a negative integer expressed in decimal digits
+        ncr = 65536 + nnnn
+    else: # § NNNNN is a positive integer expressed in decimal digits
+        ncr = nnnn
+    # § HHHH is the hexadecimal equivalent of NNNNN or -NNNNN
+    return chr(ncr)
+
+def is_hex_encoded(item: Token) -> bool:
+    """Identify if a token contains a HEXENCODED token.
+Args:
+    item (token): A token to check if it is HEXENCODED.
+
+Return:
+    True if HEXENCODED. False if not.
+    """
+    if isinstance(item, Token):
+        if item.type == "HEXENCODED":
+            return True
+    return False
+
+def is_valid_ANSI_representation_char(item: Token) -> bool:
+    """Is token contain a valid ANSI representation string for a Unicode char.
+
+Args:
+    item (token): A token to check if it is a valid ANSI representation.
+
+Return:
+    True if token is an ansi representation of a unicode char. False if not.
+"""
+    if isinstance(item, Token):
+        # print(f"found TOKEN posssible ansi {repr(item)}")
+        if is_hex_encoded(item):
+            # print(f"found hex posssible ansi {repr(item)}")
+            return True
+        if item.type == 'STRING':
+            # print(f"found STRING posssible ansi {repr(item)}")
+            if not item.value.isspace(): # whitespace doesn't count.
+                # print(f"found posssible ansi {repr(item)}")
+                return True
+            # else:
+            #     print(f"found SPACE posssible ansi {repr(item)}")
+    # print(f"found NON TOKEN posssible ansi {repr(item)}")
+    return False
+
+def is_unicode_encoded(item: Token) -> bool:
+    """Is token contain a unicode char.
+
+Args:
+    item (token): A token to check if contains a unicode char.
+
+Return:
+    True if token contains a unicode char. False if not.
+"""
+    if isinstance(item, Token):
+        if item.type == "UNICODE":
+            return True
+    return False
+
+def includes_unicode_chars(children: List[Token]) -> bool:
+    """Does a list include Tokens which contain unicode characters. Not recursive.
+
+Args:
+    children (list): A Tree.children list to check to see if it includes unicode characters.
+
+Returns:
+    True if list includes tokens which contain unicode chars. False if not.
+"""
+    for child in children:
+        if is_unicode_encoded(child):
+            return True
+    return False
+
+
+def remove_unicode_replacements(children: List[Token],
+                                return_ascii_map: bool = True,
+                                byte_count: int = 1) -> Union[
+                                    Tuple[List[Token], Dict[Token,List[Token]]],
+                                    List[Token]]:
+    """Remove all unicode replacement characters from a list of Tokens.
+
+Args:
+    children (list): A Tree.children list to remove unicode replacement characters from.
+    return_ascii_map (bool): On True, have this function return a map of the ASCII token that were removed.
+    byte_count (int): The number of bytes corresponding to a given \\uN Unicode character.  A default of 1 should be assumed if no \\uc keyword has been seen in the current or outer scopes.
+
+Returns:
+    new_children (list): The list of Tokens with all unicode replacement characters removed.
+    ascii_map (dict): All the Tokens which were removed from the provided children list keyed by
+
+"""
+    byte_count = 1
+    ascii_map: Dict[Token,List[Token]]  = {}
+    new_children = []
+    removal_map: List[Token] = []
+    log_text_extraction(f"Removing unicode replacements on {repr(children)}")
+    for child in children:
+        if len(removal_map) > 0:
+            if isinstance(child, Token):
+                # Delete all spaces between a unicode char and the last ANSI representation
+                # print(f"FOUND SPACE STRING with RM: {removal_map}")
+                if child.value.isspace():
+                    ascii_map.setdefault(removal_map[0], []).append(child)
+                    continue
+            if is_valid_ANSI_representation_char(child):
+                # Found an ansi representation removing unicode char from removal map.
+                # print(f"FOUND ASCII STRING {child} to RM with RM: {removal_map}")
+                ascii_map.setdefault(removal_map.pop(), []).append(child)
+                continue
+            elif isinstance(child, Tree) and (
+                    (child.data == "string") or (child.data == "hexarray")):
+                # print(f"FOUND ASCII STRING {child} with RM: {removal_map}")
+                ansi_children = child.children
+                new_ansi_children = []
+                for aci,ac in enumerate(ansi_children):
+                    # print(f"AC CHILD {repr(ac)}")
+                    if is_valid_ANSI_representation_char(ac):
+                        # print(f"AC CHILD VALID {repr(ac)}")
+                        if len(removal_map) > 0:
+                            # print(f"AC CHILD MAP >0 {repr(ac)}")
+                            # print(f"Popping removal for {repr(ac)}")
+                            ascii_map.setdefault(removal_map.pop(), []).append(ac)
+                        else:
+                            # print(f"AC CHILD MAP < 0 {repr(ac)}")
+                            new_ansi_children.append(ac)
+                    else:
+                        # print(f"AC CHILD NOT VALID {repr(ac)}")
+                        new_ansi_children.append(ac)
+                # print(f"NEW Children = {new_ansi_children}")
+                if new_ansi_children == []:
+                    from RTFDE.utils import make_token_replacement
+                    # from RTFDE.utils import embed
+                    # embed()
+                    child = make_token_replacement("STRING", b"", child)
+                else:
+                    child.children = new_ansi_children
+                # print(f"NEW Tree = {child}")
+            # else:
+                # print(f"FOUND ASCII STRING {child} with RM: {removal_map}")
+                # print(f"{repr(child)} not a valid ANSI representation? with RM: {removal_map}")
+        # Modify char byte count if we encounter it.
+        if is_unicode_char_byte_count(child):
+            byte_count = get_unicode_char_byte_count(child)
+            # print(f"Changing byte count because {child} to {byte_count}")
+        if is_unicode_encoded(child):
+            # print(f"Found unicode {child}")
+            for j in range(byte_count):
+                # Add the unicode key to the removal map once per byte
+                # This ensures we remove the right number of ANSI representation chars
+                removal_map.append(child)
+        new_children.append(child)
+    if return_ascii_map is True:
+        return new_children, ascii_map
+    return new_children
+
+
+# UNICODE SURROGATE CHARACTERS
+def is_surrogate_high_char(item: bytes) -> bool:
+    """Check's if chr is a is in the high-surrogate code point rage. "High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF." High-surrogate also sometimes known as the leading surrogate.
+
+        item (bytes): A bytes representation of a string representing a unicode character. "\\u-10179"
+    """
+    if item.startswith(b"\\u"):
+        item = item[2:]
+    if 0xD800 <= ord(chr(65536+int(item))) <= 0xDBFF:
+        return True
+    # In case unicode is NOT using the 16 bit signed integer
+    elif 0xD800 <= int(item) <= 0xDBFF:
+        return True
+    return False
+
+def is_surrogate_low_char(item: bytes) -> bool:
+    """Check's if chr is a is in the low-surrogate code point rage. "Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF."  Low-surrogate also sometimes known as following surrogates.
+
+        item (bytes): A bytes representation of a string representing a unicode character.
+    """
+    if item.startswith(b"\\u"):
+        item = item[2:]
+    if 0xDC00 <= ord(chr(65536+int(item))) <= 0xDFFF:
+        return True
+    # In case unicode is NOT using the 16 bit signed integer
+    elif 0xDC00 <= int(item) <= 0xDFFF:
+        return True
+    return False
+
+def is_surrogate_16bit(item: bytes, cp_range) -> bool:
+    """Checks if a unicode char is 16 bit signed integer or the raw unicode char. This should first check if it is a surrogate code using the is_surrogate_XXXX_char functions.
+
+Args:
+    item (bytes): A bytes representation of a string representing a unicode character.
+    cp_range (str): ['low' OR 'high'] The code point range (low-surrogate or high-surrogate).
+    """
+    if cp_range == 'low':
+        if 0xDC00 <= ord(chr(65536+int(item))) <= 0xDFFF:
+            return True
+    elif cp_range == 'high':
+        if 0xD800 <= ord(chr(65536+int(item))) <= 0xDBFF:
+            return True
+    else:
+        raise ValueError("cp_range must be either 'low' or 'high'")
+    return False
+
+
+def is_surrogate_pair(first: bytes, second: bytes) -> bool:
+    """Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.
+
+Args:
+    first (bytes): A bytes representation of a string representing the high-order byte in a surrogate char.
+    second (bytes): A bytes representation of a string representing the low-order byte in a surrogate char.
+    """
+    if is_surrogate_high_char(first):
+        if is_surrogate_low_char(second):
+            return True
+        else:
+            log.info("RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}".format(first, second))
+    return False
+
+def decode_surrogate_pair(high: bytes, low: bytes, encoding: str ='utf-16-le') -> bytes:
+    """ Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.
+
+Args:
+        high (bytes): the high-surrogate code point
+        low (bytes): the low-surrogate code point
+        encoding (str): The encoding to apply to the final value. Defaults to 'utf-16-le' because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
+    """
+    # Equation for turning surrogate pairs into a unicode scalar value which be used with utl-16 can ONLY found in Unicode 3.0.0 standard.
+    # Unicode scalar value means the same thing as "code position" or "code point"
+     # https://www.unicode.org/versions/Unicode3.0.0/
+     # section 3.7 https://www.unicode.org/versions/Unicode3.0.0/ch03.pdf#page=9
+    if high.startswith(b"\\u"):
+        high = high[2:]
+    if low.startswith(b"\\u"):
+        low = low[2:]
+    if is_surrogate_16bit(high, "high"):
+        char_high = chr(65536+int(high))
+    else:
+        char_high = chr(int(high))
+    if is_surrogate_16bit(low, "low"):
+        char_low = chr(65536+int(low))
+    else:
+        char_low = chr(int(low))
+    unicode_scalar_value = ((ord(char_high) - 0xD800) * 0x400) + (ord(char_low) - 0xDC00) + 0x10000
+    unicode_bytes = chr(unicode_scalar_value).encode(encoding)
+    return unicode_bytes.decode(encoding).encode()
+
+def merge_surrogate_chars(children,
+                          ascii_map,
+                          use_ASCII_alternatives_on_unicode_decode_failure = False):
+    """
+
+
+Raises:
+    ValueError:  A Standalone high-surrogate was found. High surrogate followed by a illegal low-surrogate character.
+    """
+    surrogate_start = None
+    surrogate_high = None
+    for i,c in enumerate(children):
+        if isinstance(c, Tree):
+            continue
+        if is_unicode_encoded(c):
+            if is_surrogate_high_char(c.value):
+                surrogate_start = i
+                surrogate_high = c
+            elif surrogate_start is not None:
+                if is_surrogate_low_char(c.value):
+                    surrogate_low = c
+                    try:
+                        surrogate_value = decode_surrogate_pair(surrogate_high.value,
+                                                                surrogate_low.value)
+                        # Convert into STRING token
+                        surrogate_tok = Token('STRING',
+                                              surrogate_value,
+                                              start_pos=surrogate_high.start_pos,
+                                              end_pos=surrogate_low.end_pos,
+                                              line=surrogate_high.line,
+                                              end_line=surrogate_low.end_line,
+                                              column=surrogate_high.column,
+                                              end_column=surrogate_low.end_column)
+                        children[surrogate_start] = surrogate_tok
+                        blank_tok = Token('STRING',
+                                          b"",
+                                          start_pos=surrogate_high.start_pos+1,
+                                          end_pos=surrogate_low.end_pos+1,
+                                          line=surrogate_high.line,
+                                          end_line=surrogate_low.end_line,
+                                          column=surrogate_high.column,
+                                          end_column=surrogate_low.end_column)
+                        children[i] = blank_tok
+                        surrogate_start = None
+                        surrogate_high = None
+                    except UnicodeDecodeError as _e:
+                        if use_ASCII_alternatives_on_unicode_decode_failure is True:
+                            children[surrogate_start] = b"".join([i.value for i in ascii_map[surrogate_high]])
+                            children[i] = b"".join([i.value for i in ascii_map[surrogate_low]])
+                        else:
+                            raise _e
+                else:
+                    log.info("RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}".format(surrogate_high, surrogate_low))
+                    if use_ASCII_alternatives_on_unicode_decode_failure is True:
+                        children[surrogate_start] = b"".join([i.value for i in ascii_map[surrogate_high]])
+                    else:
+                        raise ValueError("Standalone high-surrogate found. High surrogate followed by a illegal low-surrogate character.")
+    return children
+
+
+
+def is_unicode_char_byte_count(item: Token) -> bool:
+    if isinstance(item, Token):
+        if item.type == "CONTROLWORD":
+            if item.value.startswith(b'\\uc'):
+                return True
+    return False
+
+def get_unicode_char_byte_count(item: Token) -> int:
+    item = item.value.decode()
+    cur_uc = int(item[3:])
+    return cur_uc
+
+
+# Hex Encoded Chars
+def has_hexarray(children: List[Union[Token, Tree]]) -> bool:
+    """Checks if an tree's children includes a hexarray tree.
+
+    children (array): the children object from a tree.
+    """
+    for item in children:
+        if is_hexarray(item):
+            return True
+    return False
+
+def is_hexarray(item):
+    """Checks if an item is a hexarray tree.
+
+    item (Tree or Token): an item to check to see if its a hex array
+    """
+    if isinstance(item, Tree):
+        if item.data.value == 'hexarray':
+            return True
+    return False
+
+def get_bytes_from_hex_encoded(item):
+    """Convert hex encoded string to bytes.
+
+    item (str): a hex encoded string in format \\'XX
+    """
+    hexstring = item.replace(b"\\'", b"")
+    hex_bytes = bytes.fromhex(hexstring.decode())
+    return hex_bytes
+
+def decode_hex_char(item, codec):
+    """Decode a bytes object using a specified codec.
+
+    item (bytes): A bytes object.
+    codec (str): The name of the codec to use to decode the bytes
+    """
+    log_text_extraction("decoding char {0} with font {1}".format(item, codec))
+    if codec is None:
+        # Default to U.S. Windows default codepage
+        codec = 'CP1252'
+    decoded = item.decode(codec)
+    decoded = decoded.encode()
+    log_text_extraction("char {0} decoded into {1} using codec {2}".format(item, decoded, codec))
+    return decoded
+
+
+class TextDecoder:
+
+    def __init__(self, keep_fontdef=False,
+               initial_byte_count=None, use_ASCII_alternatives_on_unicode_decode_failure=False):
+        """
+        keep_fontdef: (bool) If False (default), will remove fontdef's from object tree once they are processed.
+        initial_byte_count: (int) The initial Unicode Character Byte Count. Does not need to be set unless you are only providing a RTF snippet which does not contain the RTF header which sets the  information.
+        use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors when decoding unicode chars we will use the ASCII alternative since that's what they are included for.
+
+        """
+        self.keep_fontdef = keep_fontdef
+        self.ucbc = initial_byte_count
+        self.use_ASCII_alternatives_on_unicode_decode_failure = use_ASCII_alternatives_on_unicode_decode_failure
+
+        # Font table values set set_font_info
+        self.default_font = None
+        self.font_stack = []
+        self.font_table = {}
+
+
+    def set_font_info(self, obj: Tree):
+        """
+
+        obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+        """
+        self.default_font = get_default_font(obj)
+        self.font_stack = [self.default_font]
+        raw_fonttbl = get_font_table(obj.children[1])
+        self.font_table = parse_font_tree(raw_fonttbl)
+        log_text_extraction(f"FONT TABLE FOUND: {raw_fonttbl}")
+
+
+    def update_children(self, obj: Tree):
+        """
+
+        obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+        """
+        # Reset font info
+        self.set_font_info(obj)
+        children = obj.children
+        obj.children = [i for i in self.iterate_on_children(children)]
+
+    def prep_unicode(self, children: List[Token]):
+        if includes_unicode_chars(children):
+            # Clean out all replacement chars
+            # log_text_extraction("Prepping Unicode Chars:" + repr(children))
+            children, ascii_map = remove_unicode_replacements(children,
+                                                              byte_count=self.ucbc)
+            # print("===\nCHILD:" + repr(children))
+            # print("===\nASCII:" + repr(ascii_map))
+            # Merge all surrogate pairs
+            children = merge_surrogate_chars(children,
+                                             ascii_map,
+                                             self.use_ASCII_alternatives_on_unicode_decode_failure)
+            # print("FINAL CHILDREN")
+            # log_text_extraction("Replaced Unicode Chars With: " + repr(children))
+        return children
+
+    def iterate_on_children(self, children): # Children should be 'List[Union[Token,Tree]]' but lark's Tree typing is defined badly.
+        set_fonts = []
+        log_text_extraction("Starting to iterate on text extraction children...")
+        log_text_extraction("PREP-BEFORE: "+repr(children))
+        children = self.prep_unicode(children)
+        log_text_extraction("PREP-AFTER: "+repr(children))
+
+        for item in children:
+            if is_font_number(item): # Font Definitions
+                self.font_stack.append(item.value.strip())
+                set_fonts.append(item.value)
+                if self.keep_fontdef is True:
+                    yield item
+            elif is_unicode_char_byte_count(item):
+                bc = get_unicode_char_byte_count(item)
+            elif is_unicode_encoded(item): # Unicode Chars
+                decoded = unicode_escape_to_chr(item.value).encode()
+                # Convert into STRING token
+                decoded_tok = Token('STRING',
+                                    decoded,
+                                    start_pos=item.start_pos,
+                                    end_pos=item.end_pos,
+                                    line=item.line,
+                                    end_line=item.end_line,
+                                    column=item.column,
+                                    end_column=item.end_column)
+                print(f"UNICODE TOKEN {item}: {decoded_tok}")
+                yield decoded_tok
+            # Decode a hex array
+            elif is_hexarray(item):
+                # print("IS Hex?? {0}".format(item))
+                base_bytes = None
+                for hexchild in item.children:
+                    if base_bytes is None:
+                        base_bytes = get_bytes_from_hex_encoded(hexchild.value)
+                    else:
+                        base_bytes += get_bytes_from_hex_encoded(hexchild.value)
+                current_fontdef = self.font_table[self.font_stack[-1]]
+                current_codec = current_fontdef.codec
+                decoded_hex = decode_hex_char(base_bytes, current_codec)
+                # We are replacing a Tree. So, need item.data to access it's info token
+                decoded_hex_tok = Token('STRING',
+                                        decoded_hex,
+                                        start_pos=item.data.start_pos,
+                                        end_pos=item.data.end_pos,
+                                        line=item.data.line,
+                                        end_line=item.data.end_line,
+                                        column=item.data.column,
+                                        end_column=item.data.end_column)
+                yield decoded_hex_tok
+            elif isinstance(item, Tree):
+                # Run this same function recursively on nested trees
+                item.children = [i for i in self.iterate_on_children(item.children)]
+                yield item
+            else:
+                yield item
+        for i in set_fonts:
+            # Remove all fonts defined while in this group
+            self.font_stack.pop()

--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -706,7 +706,7 @@ class TextDecoder:
                                     end_line=item.end_line,
                                     column=item.column,
                                     end_column=item.end_column)
-                print(f"UNICODE TOKEN {item}: {decoded_tok}")
+                log_text_extraction(f"UNICODE TOKEN {item}: {decoded_tok}")
                 yield decoded_tok
             # Decode a hex array
             elif is_hexarray(item):

--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -13,6 +13,7 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
 
+import codecs
 import re
 from collections import namedtuple
 from typing import Union, Any, List, Tuple, Dict
@@ -198,6 +199,14 @@ Args:
 Returns:
     The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
 """
+    if codepage_num == 950:
+        # See if an implementation has been added for windows-950. If it has, use that.
+        try:
+            codecs.lookup('windows-950') # Raises LookupError if not found.
+            log.debug('Found python codec corresponding to code page {0}: windows-950'.format(codepage_num))
+            return 'windows-950'
+        except LookupError:
+            pass
     text_codec = codepages.codepage2codec(codepage_num)
     log.debug('Found python codec corresponding to code page {0}: {1}'.format(codepage_num, text_codec))
     return text_codec

--- a/RTFDE/transformers.py
+++ b/RTFDE/transformers.py
@@ -13,86 +13,39 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
 
-import re
-from lark.visitors import Transformer, Visitor_Recursive, v_args
-from lark.visitors import Visitor_Recursive, Discard
+
+from typing import Union, List, Tuple
+from typing import TypedDict
+#  from Python 3.9 typing.Generator is deprecated in favour of collections.abc.Generator
+from collections.abc import Generator
+
+from lark.visitors import Transformer
+from lark.visitors import v_args, Discard
 from lark.tree import Tree
 from lark.lexer import Token
+import re
 
-from lark.exceptions import VisitError
+from RTFDE.utils import log_htmlrtf_stripping
 
-class StripControlWords(Transformer):
-    """Visits each control word and strips the whitespace from around it.
-    """
-
-    def CONTROLWORD(self, token):
-        """Strips the whitespace from around it the control word.
-        """
-        tok = token.update(value=token.value.strip())
-        return tok
-
-class RTFUnicodeDecoder(Visitor_Recursive):
-    """Visits each Token in provided RTF Trees and decodes any/all unicode characters which it finds.
-    """
-
-    def __init__(self):
-        """Create the initial \\ucN keyword stack with the default scope included."""
-        # A default of 1 should be assumed if no \uc keyword has been seen in the current or outer scopes. - RTF Spec
-        self.cur_uc = [1]
-
-    def visit_topdown(self, tree:Tree) -> Tree:
-        """Visit each Token in the RTF Tree to decode any/all unicode characters.
-
-        This decoder starts at the root of the tree, and ends at the leaves (top-down) so it can track the state of the '\\ucN' keyword. The \\ucN keyword identifies when the count of bytes for how Unicode characters translate into ANSI character streams differ from the current Unicode Character Byte Count. When unicode encodings (\\uNNNN) are  encountered, the code has to ignore the first N bytes, where N corresponds to the last \\ucN value encountered. If that sounds overly complex to you then then we are in agreement.
-
-        Parameters:
-            tree: (Tree): An RTF Tree object which needs its values decoded.
-        """
-        self._call_userfunc(tree)
-        cur_uc = None
-        for child in tree.children:
-            # The bytelen values (\ucN) are scoped like character properties. That is, a \ucN keyword applies only to text following the keyword, and within the same (or deeper) nested braces.
-            # This is covered in more detail in the RTF spec. No matter how much detail it goes into doesn't make up for how much I hate this kludge they implemented.
-            if isinstance(child, Token) and child.value.startswith('\\uc'):
-                strip_int = re.compile('^[^0-9]+([0-9]+)$')
-                cur_uc = int(strip_int.search(child.value).groups()[0])
-                self.cur_uc.append(cur_uc)
-            elif isinstance(child, Tree):
-                self.visit_topdown(child)
-            else:
-                strip_u = re.compile(r'\\u[-]?[0-9]+[\s]?\??')
-                rtfencoded = strip_u.findall(child.value)
-                for enc_str in rtfencoded:
-                    char_num = int(enc_str[2:].strip("?").strip())
-                    if char_num < 0:
-                        # RTF control words generally accept signed 16-bit numbers as arguments. For this reason, Unicode decimal values greater than 32767 must be expressed as negative numbers. For example, if Hexdecimal value is 1D703 then the decimal value (120579) is greater than 32767 so the negative Hex-decimal value (03B8) is used and its decimal code is 952
-                        # The value of \ucN which appears before a \u-NNNN (a negative decimal unicode char) will tell us how many bytes the -NNNN value occupies when converted to a Unicode character.
-                        # For instance, \uc1 would be one byte, thus while \u-3913 would convert to 0xF0B7 (U+F0B7 PRIVATE USE CHARACTER) if it were simply converted into unicode once only one byte (\uc1) is extracted it becomes 0xB7 (U+00B7 MIDDLE DOT) which is the correct character.
-                        char = chr(bytearray(chr(65536+char_num).encode())[-self.cur_uc[-1]])
-                    else:
-                        char = chr(char_num)
-                    child.value = child.value.replace(enc_str, char)
-        # On exiting the group, the previous \uc value is restored. When leaving an RTF group which specified a \uc value, the reader must revert to the previous value.
-        # If we captured a unicode bytelen in this scope we get rid of it when we exit the scope.
-        if cur_uc is not None:
-            self.cur_uc.pop()
-        return tree
-
+import logging
+log = logging.getLogger("RTFDE")
 
 class StripNonVisibleRTFGroups(Transformer):
     """Visits each Token in provided RTF Trees and strips out any RTF groups which are non-visible when de-encapsulated into HTML.
     """
 
     @v_args(tree=True)
-    def group(self, tree):
+    def group(self, tree: Tree):
         """Transformer which aggressively seeks out possible non-visible RTF groups and replaces them with empty strings.
 
-        NOTE: Currently deleting all groups that don't have an htmltag. Please file an issue if you find one that should be included in de-encapsulated HTML. I will refine what gets deleted and what is converted based on identified needs for greater functionality or specific issues which need to be addressed.
+NOTE: Currently deleting all groups that don't have an htmltag. Please file an issue if you find one that should be included in de-encapsulated HTML. I will refine what gets deleted and what is converted based on identified needs for greater functionality or specific issues which need to be addressed.
 
-        Parameters:
-            tree: (Tree): An RTF Tree object which needs its values decoded.
-        """
+Args:
+        tree: A .rtf group (Tree object) which needs its contents decoded.
+"""
         children = tree.children
+        if len(children) == 0:
+            return b""
         first_child = children[0]
 
         known_control_groups = ["htmltag_group"]
@@ -102,38 +55,48 @@ class StripNonVisibleRTFGroups(Transformer):
         known_non_visible_control_groups = ["mhtmltag_group"]
         if isinstance(first_child, Tree):
             if first_child.data in known_non_visible_control_groups:
-                return ""
+                # print(f"DELETING: {first_child} : because mhtmltag")
+                return b""
 
         # process known non-visible groups
-        non_visible_control_words = ["\\context", "\\colortbl", "\\fonttbl"]
-        first_control = self._first_controlword(children)
+        non_visible_control_words = [b"\\context", b"\\colortbl", b"\\fonttbl"]
+        first_control = self.get_first_controlword(children)
+        # print(f"FIRST: {first_control}")
         if first_control in non_visible_control_words:
-            return ""
+            return b""
 
         # Process star escaped groups
         # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
-        understood_commands = []
+        # For example, if we added support for `destination text` we would need to add '\\bkmkstart' and '\\ud' so our processor doesn't delete those groups
+        understood_commands: List[str] = []
         is_star_escaped = None
-        if isinstance(first_child, Tree):
+        if (isinstance(first_child, Tree) and
+             len(first_child.children) != 0 ):
             first_item = first_child.children[0]
             if isinstance(first_item, Token):
                 if first_item.type == "STAR_ESCAPE":
                     is_star_escaped = True
         control_word = None
         if is_star_escaped is True:
+            # print(f"STAR: {children}")
             first_token = children[1]
             if isinstance(first_token, Token):
                 if first_token.type == "CONTROLWORD":
                     control_word = first_token
-                    if control_word in understood_commands:
+                    if control_word.value in understood_commands:
                         return tree
-                    else:
-                        return ""
+                    return b""
         return tree
 
     @staticmethod
-    def _first_controlword(children) -> str:
-        """Extracts the first control word from a group to make identifying groups easier.
+    def get_first_controlword(children: List) -> Union[str,None]:
+        """Extracts the first control word from a .rtf group.
+
+Args:
+        children: A list of child objects within a .rtf group
+
+Returns:
+        The first controlword found in a group. Returns None if no controls words are found.
         """
         for i in children:
             try:
@@ -141,159 +104,320 @@ class StripNonVisibleRTFGroups(Transformer):
                     return i.value
             except AttributeError:
                 continue
+        return None
 
 class RTFCleaner(Transformer):
     """Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn't be visible. And, joins all strings that are left into one final string.
     """
 
-    def __init__(self, rtf_codec=None):
-        """Setup the RTF codec.
+    def start(self, args: List) -> bytes:
+        """Joins the .rtf object's string representations together at highest level object `start`.
 
-        Parameters:
-            rtf_codec: (str): The python codec to use when decoding strings.
-        """
-        if rtf_codec is None:
-            self.rtf_codec = 'CP1252'
-        else:
-            self.rtf_codec = rtf_codec
+This is the final string combination. """
+        return b"".join(args)
 
-    def start(self, args):
-        return "".join(args)
-
-    def string(self, strings):
-        """
-        Join the strings in all groups.
-        """
-        return "".join(strings)
-
-    def STRING(self, string):
-        """Convert all objects with strings into strings
-        """
+    def STRING(self, string: Token) -> bytes:
+        """Convert a string object into a raw string."""
         if string.value is not None:
             return string.value
-        else:
-            return ""
+        return b""
 
-    def group(self, grp):
-        """
-        Join the strings in all groups.
-        """
+    def SPACE_SAVE(self, string: Token) -> bytes:
+        return string.value
+
+    def string(self, strings: List) -> bytes:
+        """Convert all string objects withing a string group into a single string."""
+        # print(strings)
+        return b"".join(strings)
+
+    def group(self, grp: List) -> bytes:
+        """Join the strings in all group objects."""
         _new_children = []
         for i in grp:
             if isinstance(i, type(Discard)):
                 pass
             else:
                 _new_children.append(i)
-        return "".join(_new_children)
+        return b"".join(_new_children)
 
-    def document(self, args):
-        """Join the final set of strings to make the final html string."""
-        return "".join(args)
+    def document(self, args: List) -> bytes:
+        """Join the all the strings in an .rtf object into a single string representation of the document."""
+        args = [i for i in args if i is not None]
+        return b"".join(args)
 
-    def OPENPAREN(self, args):
+    def OPENPAREN(self, args: Token) -> bytes:
         """Delete all open parens."""
-        return ""
+        return b""
 
-    def CLOSEPAREN(self, args):
+    def CLOSEPAREN(self, args: Token) -> bytes:
         """Delete all closed parens."""
-        return ""
+        return b""
 
-    def mhtmltag_group(self, tree):
+    def mhtmltag_group(self, args: List):
         """Process MHTMLTAG groups
 
         Currently discarding because they don't need to be processed.
-        """
+
+Returns:
+        Always returns a discard object."""
         return Discard
 
-    def htmltag_group(self, strings):
+    def htmltag_group(self, strings: List) -> bytes:
         """HTMLTAG processing.
 
-        Takes any string values within an HTMLTAG and returns them.
+Takes any string values within an HTMLTAG and returns them.
         """
-        return "".join(strings)
+        return b"".join(strings)
 
-    def HTMLTAG(self, tag):
-        return ""
+    def HTMLTAG(self, htmltag: Token) -> bytes:
+        """Delete all HTMLTAG objects"""
+        return b""
 
-    def STAR_ESCAPE(self, char):
+    def STAR_ESCAPE(self, char: Token) -> bytes:
+        """Delete all star escape objects"""
         # '\\*': ''
-        return ""
+        return b""
 
-    def control_symbol(self, symbols):
-        return "".join(symbols)
+    def control_symbol(self, symbols: List) -> bytes:
+        """Join all visible symbols from in control symbol groups."""
+        return b"".join(symbols)
 
-    def NONBREAKING_SPACE(self, args):
+    def NONBREAKING_SPACE(self, args: Token) -> bytes:
+        """Convert non-breaking spaces into visible representation."""
         # '\\~': '\u00A0',
-        return u'\u00A0'
+        return u'\u00A0'.encode()
 
-    def NONBREAKING_HYPHEN(self, args):
+    def NONBREAKING_HYPHEN(self, args: Token) -> bytes:
+        """Convert non-breaking hyphens into visible representation."""
         # '\\_': '\u00AD'
-        return u'\u00AD'
+        return u'\u00AD'.encode()
 
-    def OPTIONAL_HYPHEN(self, args):
+    def OPTIONAL_HYPHEN(self, args: Token) -> bytes:
+        """Convert hyphen control char into visible representation."""
         # '\\-': '\u2027'
-        return u'\u2027'
+        return u'\u2027'.encode()
 
-    def FORMULA_CHARACTER(self, args):
+    def FORMULA_CHARACTER(self, args: Token) -> bytes:
         """Convert a formula character into an empty string.
 
-        If we are encountering formula characters the scope has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.
-        """
-        return ""
+If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands."""
+        return b""
 
-    def INDEX_SUBENTRY(self, args):
+    def INDEX_SUBENTRY(self, args: Token) -> bytes:
         """Process index subentry items
 
-        Discard index sub-entries. Because, we don't care about indexes when de-encapsulating at this time.
-        """
-        return ""
+Discard index sub-entries. Because, we don't care about indexes when de-encapsulating at this time."""
+        return b""
 
-    def CONTROLSYMBOL(self, args):
-        """Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.
-        """
+    def CONTROLSYMBOL(self, args: Token) -> bytes:
+        """Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones."""
         symbols = {
-            '\\{': '\x7B',
-            '\\}': '\x7D',
-            '\\\\': '\x5C',
+            b'\\{': b'\x7B',
+            b'\\}': b'\x7D',
+            b'\\\\': b'\x5C',
         }
         replacement = symbols.get(args.value, None)
         # If this is simply a character to replace then return the value
         if replacement is not None:
             return replacement
-        else:
-            return ""
+        return b""
 
-    def CONTROLWORD(self, args):
+    def CONTROLWORD(self, args: Token) -> bytes:
         """Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
         """
         words = {
-            '\\par': '\n',
-            '\\tab': '\t',
-            '\\line': '\n',
-            '\\lquote': '\u2018',
-            '\\rquote': '\u2019',
-            '\\ldblquote': '\u201C',
-            '\\rdblquote': '\u201D',
-            '\\bullet': '\u2022',
-            '\\endash': '\u2013',
-            '\\emdash': '\u2014'
+            b'\\par': b'\n',
+            b'\\tab': b'\t',
+            b'\\line': b'\n',
+            b'\\lquote': b'\u2018',
+            b'\\rquote': b'\u2019',
+            b'\\ldblquote': b'\u201C',
+            b'\\rdblquote': b'\u201D',
+            b'\\bullet': b'\u2022',
+            b'\\endash': b'\u2013',
+            b'\\emdash': b'\u2014'
         }
         replacement = words.get(args.value, None)
         # If this is simply a character to replace then return the value as a string
         if replacement is not None:
             return replacement
-        return ""
+        return b""
 
-    def RTFESCAPE(self, args):
-        """Decode hex encoded chars using the codec provided. Insert unicode chars directly since we already decoded those earlier.
-        """
-        if args.value.startswith("\\'"):
-            hexstring = args.value.replace("\\'", "")
-            hex_bytes = bytes.fromhex(hexstring)
-            decoded = hex_bytes.decode(self.rtf_codec)
-            return decoded
-        # \\u RTFEscapes need to have the \ucN value identified in order to do byte manipulation before being converted. So, we converted those previously in RTFUnicodeDecoder.
+def get_stripped_HTMLRTF_values(tree: Tree, current_state: Union[bool,None] = None) -> Generator:
+    """Get a list of Tokens which should be suppressed by HTMLRTF control words.
+
+
+    NOTE: This de-encapsulation supports the HTMLRTF control word within nested groups. The state of the HTMLRTF control word transfers when entering groups and is restored when exiting groups, as specified in [MSFT-RTF].
+
+Returns:
+    A list of Tokens which should be suppressed by HTMLRTF control words.
+    """
+    if current_state is None:
+        htmlrtf_stack = [False]
+    else:
+        htmlrtf_stack = [current_state]
+    for child in tree.children:
+        is_htmlrtf = None
+        if isinstance(child, Tree):
+            # A de-encapsulating RTF reader MUST support the HTMLRTF control word within nested groups. The state of the HTMLRTF control word MUST transfer when entering groups and be restored when exiting groups, as specified in [MSFT-RTF].
+            for toggle in get_stripped_HTMLRTF_values(child, htmlrtf_stack[-1]):
+                yield toggle
         else:
-            # We should have handled all escaped chars by here
-            # We can simply insert the values from \u RTF Escapes now
-            return args.value
+            is_htmlrtf = toggle_htmlrtf(child)
+            if is_htmlrtf is not None:
+                htmlrtf_stack.append(is_htmlrtf)
+                yield child
+            elif htmlrtf_stack[-1] is True:
+                yield child
+
+def toggle_htmlrtf(child: Union[Token,str]) -> Union[bool,None]:
+    """Identify if htmlrtf is being turned on or off.
+
+Returns:
+    Bool representing if htmlrtf is being enabled or disabled. None if object is not an HTMLRTF token.
+"""
+    if isinstance(child, Token):
+        if child.type == "HTMLRTF":
+            htmlrtfstr = child.value.decode().strip()
+            if (len(htmlrtfstr) > 0 and htmlrtfstr[-1] == "0"):
+                return False
+            return True
+    return None
+
+class DeleteTokensFromTree(Transformer):
+    """Removes a series of tokens from a Tree.
+
+Parameters:
+    tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+
+Attributes:
+    to_delete: A list of tokens to delete from the Tree object.
+    delete_start_pos: The starting position for all the identified tokens. Used to identify which tokens to delete.
+"""
+
+    def __init__(self, tokens_to_delete: List[Token]):
+        """Setup attributes including token start_pos tracking.
+
+Args:
+    tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+"""
+        super().__init__()
+        self.to_delete = tokens_to_delete
+        self.delete_start_pos = {i.start_pos for i in self.to_delete}
+
+    def __default_token__(self, token: Token):
+        """Discard any identified tokens.
+
+Args:
+        token: All tokens within the transformed tree.
+
+Returns:
+        Returns all non-identified tokens. Returns Discard objects for any identified tokens.
+"""
+        # print"(Evaluating token {0} at {1} to consider deleting".format(child.value, child.end_pos))
+        if isinstance(token, Token):
+            if token.start_pos in self.delete_start_pos:
+                for i in self.to_delete:
+                    if (i.start_pos == token.start_pos and
+                        i.end_pos == token.end_pos and
+                        i.value == token.value):
+                        log_htmlrtf_stripping(i)
+                        # print(f"DELETING: {i}")
+                        return Discard
+        return token
+
+class StripUnusedSpecialCharacters(Transformer):
+    """Strip all unused tokens which lark has extracted from the RTF.
+
+These tokens are largely artifacts of the RTF format.
+
+We have to do this because we use the "keep_all_tokens" option in our lark parser. It's better to be explicit then to allow for ambiguity because of the grammar.
+    """
+
+    def _LBRACE(self, token: Token):
+        """Remove RTF braces.
+
+Returns:
+        Always returns a discard object."""
+        return Discard
+
+    def _RBRACE(self, token: Token):
+        """Remove RTF braces.
+
+Returns:
+        Always returns a discard object."""
+        return Discard
+
+    def _SPACE_DELETE(self, token: Token):
+        """Remove spaces which are not a part of the content
+
+These are mostly spaces used to separate control words from the content they precede.
+
+Returns:
+        Always returns a discard object.
+        """
+        return Discard
+
+
+class StripControlWords(Transformer):
+    """Visits each control word and strips the whitespace from around it.
+    """
+
+    def CONTROLWORD(self, token: Token):
+        """Strips the whitespace from around a provided control word.
+
+Args:
+        token: A CONTROLWORD token to strip whitespace from.
+        """
+        tok = token.update(value=token.value.strip())
+        return tok
+
+
+def strip_binary_objects(raw_rtf: bytes) -> tuple:
+    """Extracts binary objects from a rtf file.
+
+Parameters:
+    raw_rtf: (bytes): It's the raw RTF file as bytes.
+
+Returns:
+    A tuple containing (new_raw, found_bytes)
+        new_raw: (bytes) A bytes object where any binary data has been removed.
+        found_bytes: (list) List of dictionaries containing binary data extracted from the rtf file. Each dictionary includes the data extracted, where it was extracted from in the original rtf file and where it can be inserted back into the stripped output.
+
+    Description of found_bytes dictionaries:
+
+        "bytes": (bytes) The binary data contained which was extracted.
+        "ctrl_char": (tuple) Tuple containing the binary control word and its numeric parameter
+        "start_pos": (int) The position (in the original raw rtf data) where the binary control word started.
+        "bin_start_pos": (int) The position (in the original raw rtf data) where the binary data starts.
+        "end_pos": (int) The position (in the original raw rtf data) where the binary data ends.
+
+    Here is an example of what this looks like (by displaying the printable representation so you can see the bytes and then splitting the dict keys on new lines to make it readable.)
+        >> print(repr(found_bytes))
+
+        "{'bytes': b'\\xf4UP\\x13\\xdb\\xe4\\xe6CO\\xa8\\x16\\x10\\x8b\\n\\xfbA\\x9d\\xc5\\xd1C',
+          'ctrl_char': (b'\\\\bin', b'20'),
+          'start_pos': 56,
+          'end_pos': 83,
+          'bin_start_pos': 63}"
+    """
+    found_bytes = []
+    byte_finder = rb'(\\bin)([0-9]+)[ ]?'
+    for matchitem in re.finditer(byte_finder, raw_rtf):
+        param = int(matchitem[2])
+        bin_start_pos = matchitem.span()[-1]
+        byte_obj = {"bytes": raw_rtf[bin_start_pos:bin_start_pos+param],
+                    "ctrl_char": matchitem.groups(),
+                    "start_pos": matchitem.span()[0],
+                    "end_pos": bin_start_pos+param,
+                    "bin_start_pos": bin_start_pos
+                    }
+        # byte_obj : dict[str, Union[bytes, int, Tuple[bytes, bytes]]]
+        found_bytes.append(byte_obj)
+    new_raw = b''
+    start_buffer = 0
+    for new_bytes in found_bytes:
+        new_raw += raw_rtf[start_buffer:new_bytes["start_pos"]]
+        start_buffer = new_bytes["end_pos"]
+    new_raw += raw_rtf[start_buffer:]
+    return (new_raw, found_bytes)

--- a/RTFDE/transformers.py
+++ b/RTFDE/transformers.py
@@ -25,7 +25,7 @@ from lark.tree import Tree
 from lark.lexer import Token
 import re
 
-from RTFDE.utils import log_htmlrtf_stripping
+from RTFDE.utils import log_htmlrtf_stripping, is_logger_on
 
 import logging
 log = logging.getLogger("RTFDE")
@@ -321,7 +321,8 @@ Returns:
                     if (i.start_pos == token.start_pos and
                         i.end_pos == token.end_pos and
                         i.value == token.value):
-                        log_htmlrtf_stripping(i)
+                        if is_logger_on("RTFDE.HTMLRTF_Stripping_logger") is True:
+                            log_htmlrtf_stripping(i)
                         # print(f"DELETING: {i}")
                         return Discard
         return token

--- a/RTFDE/utils.py
+++ b/RTFDE/utils.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of package name, a package description short.
+# Copyright © 2022 seamus tuohy, <code@seamustuohy.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+import argparse
+
+import logging
+logging.basicConfig(level=logging.ERROR)
+log = logging.getLogger(__name__)
+
+
+def main():
+    args = parse_arguments()
+    set_logging(args.verbose, args.debug)
+
+
+def get_control_parameter_as_hex_string(control_parameter):
+    """Returns the hex encoded value of a control parameter.
+
+    control_parameter: (int/str) Integer either as an integer or a string which represents an int.
+    """
+    try:
+        return "{0:#06x}".format(control_parameter)
+    except ValueError:
+        # If passed as string convert first
+        return "{0:#06x}".format(int(control_parameter))
+
+def print_to_tmp_file(data, path):
+    """Debugging function
+    """
+    # Be able to print binary objects easily
+    if isinstance(data, (bytes, bytearray)) is True:
+        open_as = 'wb+'
+    else:
+        open_as = 'w+'
+    with open(path, open_as) as fp:
+        import sys
+        original_stdout = sys.stdout
+        sys.stdout = fp
+        print(data)
+        sys.stdout = original_stdout
+
+def encode_escaped_control_chars(raw_text):
+    """Replaces escaped control chars within the text with their RTF encoded versions \\'HH.
+    """
+    cleaned = raw_text.replace('\\\\', "\\'5c")
+    cleaned = cleaned.replace('\\{', "\\'7b")
+    cleaned = cleaned.replace('\\}', "\\'7d")
+    return cleaned
+
+
+# Command Line Functions below this point
+
+def set_logging(verbose=False, debug=False):
+    if debug == True:
+        log.setLevel("DEBUG")
+    elif verbose == True:
+        log.setLevel("INFO")
+
+def parse_arguments():
+    parser = argparse.ArgumentParser("package name")
+    parser.add_argument("--verbose", "-v",
+                        help="Turn verbosity on",
+                        action='store_true')
+    parser.add_argument("--debug", "-d",
+                        help="Turn debugging on",
+                        action='store_true')
+    args = parser.parse_args()
+    return args
+
+if __name__ == '__main__':
+    main()

--- a/RTFDE/utils.py
+++ b/RTFDE/utils.py
@@ -13,31 +13,44 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
 
-import argparse
+import difflib
+import sys
+import re
+from typing import Union, AnyStr, Any
+#  from Python 3.9 typing.Generator is deprecated in favour of collections.abc.Generator
+from collections.abc import Generator
+from lark.lexer import Token
+from lark.tree import Tree
+from lark import Lark
+
 
 import logging
-logging.basicConfig(level=logging.ERROR)
-log = logging.getLogger(__name__)
+log = logging.getLogger("RTFDE")
 
+def get_control_parameter_as_hex_strings(control_parameter: Union[str,int]) -> str:
+    """Returns the hex encoded value of a .rtf control parameter.
 
-def main():
-    args = parse_arguments()
-    set_logging(args.verbose, args.debug)
+Args:
+    control_parameter: (int/str) Int or a string which represents an int.
 
-
-def get_control_parameter_as_hex_string(control_parameter):
-    """Returns the hex encoded value of a control parameter.
-
-    control_parameter: (int/str) Integer either as an integer or a string which represents an int.
-    """
+Returns:
+    Zero padded 6 char long hexedecimal string.
+"""
     try:
-        return "{0:#06x}".format(control_parameter)
+        return f"{control_parameter:#06x}"
     except ValueError:
         # If passed as string convert first
-        return "{0:#06x}".format(int(control_parameter))
+        control_parameter = int(control_parameter)
+        return f"{control_parameter:#06x}"
 
-def print_to_tmp_file(data, path):
-    """Debugging function
+def print_to_tmp_file(data: Union[AnyStr,bytes,bytearray], path: str):
+    """Prints binary object to a dump file for quick debugging.
+
+Warning: Not for normal use. Only use when debugging.
+
+Args:
+    data (bytes|str): Data to write to path
+    path (str): The file path to write data to
     """
     # Be able to print binary objects easily
     if isinstance(data, (bytes, bytearray)) is True:
@@ -45,39 +58,240 @@ def print_to_tmp_file(data, path):
     else:
         open_as = 'w+'
     with open(path, open_as) as fp:
-        import sys
         original_stdout = sys.stdout
         sys.stdout = fp
         print(data)
         sys.stdout = original_stdout
 
-def encode_escaped_control_chars(raw_text):
+def encode_escaped_control_chars(raw_text: bytes) -> bytes:
     """Replaces escaped control chars within the text with their RTF encoded versions \\'HH.
+
+Args:
+    raw_text (str): string which needs escape characters encoded
+
+Returns:
+    A string with escaped control chars
     """
-    cleaned = raw_text.replace('\\\\', "\\'5c")
-    cleaned = cleaned.replace('\\{', "\\'7b")
-    cleaned = cleaned.replace('\\}', "\\'7d")
+    cleaned = raw_text.replace(b'\\\\', b"\\'5c")
+    cleaned = cleaned.replace(b'\\{', b"\\'7b")
+    cleaned = cleaned.replace(b'\\}', b"\\'7d")
     return cleaned
 
+def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword: bytes) -> bool:
+    """Checks if a Token is a codeword with a numeric argument.
 
-# Command Line Functions below this point
+Returns:
+    True if a Token is a codeword with a numeric argument. False if not.
+"""
+    try:
+        val = token.value.strip()
+        # print(val, codeword)
+        if (val.startswith(codeword) and
+            val[len(codeword):].isdigit()):
+            return True
+    except AttributeError:
+        return False
+    return False
 
-def set_logging(verbose=False, debug=False):
-    if debug == True:
-        log.setLevel("DEBUG")
-    elif verbose == True:
-        log.setLevel("INFO")
+def print_lark_parser_evaluated_grammar(parser):
+    """Prints the final evaluated grammar.
 
-def parse_arguments():
-    parser = argparse.ArgumentParser("package name")
-    parser.add_argument("--verbose", "-v",
-                        help="Turn verbosity on",
-                        action='store_true')
-    parser.add_argument("--debug", "-d",
-                        help="Turn debugging on",
-                        action='store_true')
-    args = parser.parse_args()
-    return args
+Can be useful for debugging possible errors in grammar evaluation.
 
-if __name__ == '__main__':
-    main()
+Args:
+    parser (Lark obj): Lark object to extract grammar from.
+    """
+    if not isinstance(parser, Lark):
+        raise ValueError("Requires a Lark object.")
+    eq = "="*15
+    eq = " " + eq + " "
+    print(eq + "RULES" + eq + "\n")
+    for i in parser.rules:
+        print("    " + i)
+    print(eq + "TERMINALS" + eq + "\n")
+    for i in parser.terminals:
+        print("    " + i)
+    print(eq + "IGNORED TOKENS" + eq + "\n")
+    for i in parser.ignore_tokens:
+        print("    " + i)
+
+def log_validators(data):
+    """Log validator logging only if RTFDE.validation_logger set to debug.
+    """
+    logger = logging.getLogger("RTFDE.validation_logger")
+    if logger.level == logging.DEBUG:
+        logger.debug(data)
+
+def log_transformations(data):
+    """Log transform logging only if RTFDE.transform_logger set to debug.
+    """
+    logger = logging.getLogger("RTFDE.transform_logger")
+    if logger.level == logging.DEBUG:
+        logger.debug(data)
+
+def log_text_extraction(data):
+    """Log additional text decoding/encoding logging only if RTFDE.text_extraction set to debug.
+    """
+    logger = logging.getLogger("RTFDE.text_extraction")
+    if logger.level == logging.DEBUG:
+        logger.debug(data)
+
+def log_htmlrtf_stripping(data: Token):
+    """Log HTMLRTF Stripping logging only if RTFDE.HTMLRTF_Stripping_logger set to debug.
+
+Raises:
+    AttributeError: Will occur if you pass this something that is not a token.
+"""
+    logger = logging.getLogger("RTFDE.HTMLRTF_Stripping_logger")
+    if logger.level == logging.DEBUG:
+        if not isinstance(data, Token):
+            raise AttributeError("HTMLRTF Stripping logger only logs Tokens")
+        tok_desc = "HTMLRTF Removed: {value}, {line}, {end_line}, {start_pos}, {end_pos}"
+        log_msg = tok_desc.format(value=data.value,
+                                  line=data.line,
+                                  end_line=data.end_line,
+                                  start_pos=data.start_pos,
+                                  end_pos = data.end_pos)
+        logger.debug(log_msg)
+
+def log_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
+    """Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
+
+Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
+
+Args:
+    original: The original string
+    revised: The changed version of the string
+    sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+"""
+    log.debug(get_string_diff(original, revised, sep))
+
+def get_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
+    """Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
+
+Args:
+    original: The original string
+    revised: The changed version of the string
+    sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+
+Returns:
+    A string object representing the diff of the two strings provided.
+"""
+    if sep is None:
+        orig_split = original.decode().splitlines(keepends=True)
+        revised_split = revised.decode().splitlines(keepends=True)
+    else:
+        original = original.replace(b'\n',b'')
+        revised = revised.replace(b'\n',b'')
+        orig_split = [i.decode() for i in re.split(sep, original) if i != b'']
+        revised_split = [i.decode() for i in re.split(sep, revised) if i != b'']
+    return "\n".join(list(difflib.context_diff(orig_split,
+                                               revised_split)))
+
+def get_tree_diff(original: Tree, revised: Tree):
+    """Get the diff of two trees.
+
+Args:
+    original (lark Tree): A lark tree before transformation
+    revised (lark Tree): A lark tree after transformation
+
+Returns:
+    A string object representing the diff of the two Trees provided.
+
+Example:
+    rtf_obj = DeEncapsulator(raw_rtf)
+    rtf_obj.deencapsulate()
+    transformed_tree = SomeTransformer.transform(rtf_obj.full_tree)
+    get_tree_diff(rtf_obj.full_tree, transformed_tree)
+
+    """
+    log = logging.getLogger("RTFDE")
+    flat_original  = list(flatten_tree(original))
+    flat_revised  = list(flatten_tree(revised))
+    return "\n".join(list(difflib.context_diff(flat_original,
+                                               flat_revised)))
+def flatten_tree(tree: Tree) -> Generator:
+    """Flatten a lark Tree into a list of repr's of tree objects.
+
+Args:
+    tree (lark Tree): A lark tree
+"""
+    yield f"Tree('{tree.data}')"
+    for child in tree.children:
+        if isinstance(child, Token):
+            yield repr(child)
+        elif isinstance(child, Tree):
+            for i in flatten_tree(child):
+                yield i
+        else:
+            yield repr(child)
+
+def flatten_tree_to_string_array(tree: Tree) -> Generator:
+    """Flatten a lark Tree into a list of repr's of tree objects.
+
+Args:
+    tree (lark Tree): A lark tree
+"""
+    for child in tree.children:
+        if isinstance(child, Tree):
+            for i in flatten_tree_to_string_array(child):
+                yield i
+        elif isinstance(child, Token):
+            yield child.value
+        else:
+            yield child
+
+def make_token_replacement(ttype, value, example):
+    if isinstance(example, Token):
+        fake_tok = Token(ttype,
+                        value,
+                        start_pos=example.start_pos,
+                        end_pos=example.end_pos,
+                        line=example.line,
+                        end_line=example.end_line,
+                        column=example.column,
+                        end_column=example.end_column)
+    elif isinstance(example, Tree):
+        fake_tok = Token(ttype,
+                         value,
+                         start_pos=example.meta.start_pos,
+                         end_pos=example.meta.end_pos,
+                         line=example.meta.line,
+                         end_line=example.meta.end_line,
+                         column=example.meta.column,
+                         end_column=example.meta.end_column)
+
+    return fake_tok
+
+
+def embed():
+    import os
+    import readline
+    import rlcompleter
+    import code
+    import inspect
+    import traceback
+
+    history = os.path.join(os.path.expanduser('~'), '.python_history')
+    if os.path.isfile(history):
+        readline.read_history_file(history)
+
+    frame = inspect.currentframe().f_back
+    namespace = frame.f_locals.copy()
+    namespace.update(frame.f_globals)
+
+    readline.set_completer(rlcompleter.Completer(namespace).complete)
+    readline.parse_and_bind("tab: complete")
+
+    file = frame.f_code.co_filename
+    line = frame.f_lineno
+    function = frame.f_code.co_name
+
+    stack = ''.join(traceback.format_stack()[:-1])
+    print(stack)
+    banner = f" [ {os.path.basename(file)}:{line} in {function}() ]"
+    banner += "\n Entering interactive mode (Ctrl-D to exit) ..."
+    try:
+        code.interact(banner=banner, local=namespace)
+    finally:
+        readline.write_history_file(history)

--- a/RTFDE/utils.py
+++ b/RTFDE/utils.py
@@ -129,6 +129,14 @@ def log_transformations(data):
     if logger.level == logging.DEBUG:
         logger.debug(data)
 
+def is_logger_on(logger_name, level=logging.DEBUG):
+    """Check if a logger is enabled and on debug.
+    """
+    logger = logging.getLogger(logger_name)
+    if logger.level == level:
+        return True
+    return False
+
 def log_text_extraction(data):
     """Log additional text decoding/encoding logging only if RTFDE.text_extraction set to debug.
     """

--- a/docs/RTFDE/deencapsulate.html
+++ b/docs/RTFDE/deencapsulate.html
@@ -1,0 +1,1350 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>RTFDE.deencapsulate API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>RTFDE.deencapsulate</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2020 seamus tuohy, &lt;code@seamustuohy.com&gt;
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+from typing import Union, AnyStr, Tuple, Dict, Any
+from io import BufferedReader
+
+from lark import Lark
+from lark.tree import Tree
+from lark.lexer import Token
+
+from RTFDE.transformers import RTFCleaner, StripControlWords
+from RTFDE.transformers import StripNonVisibleRTFGroups
+from RTFDE.transformers import StripUnusedSpecialCharacters
+from RTFDE.utils import encode_escaped_control_chars
+from RTFDE.utils import log_validators, log_transformations
+from RTFDE.transformers import get_stripped_HTMLRTF_values, DeleteTokensFromTree
+from RTFDE.grammar import make_concise_grammar
+from RTFDE.text_extraction import TextDecoder
+from RTFDE.text_extraction import validate_ansi_cpg
+
+# For catching exceptions
+from RTFDE.exceptions import NotEncapsulatedRtf, MalformedEncapsulatedRtf, MalformedRtf
+
+import logging
+log = logging.getLogger(&#34;RTFDE&#34;)
+
+class DeEncapsulator():
+    &#34;&#34;&#34;De-Encapsulating RTF converter of HTML/TEXT found in .msg files.
+
+De-encapsulation enables previously encapsulated HTML and plain text content to be extracted and rendered as HTML and plain text instead of the encapsulating RTF content. After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.
+
+
+Parameters:
+    raw_rtf: (str): It&#39;s the raw RTF string.
+    grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
+
+Attributes:
+    content: The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
+    html: The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
+    text: The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+    content_type: The type of content encapsulated in .rtf data (html or text). Populated by the `get_content_type` function.
+    full_tree: The full .rtf object parsed into an object Tree using the grammar. Populated by the `parse_rtf` function.
+    doc_tree: The `document` portion of the .rtf full_tree object.
+    raw_rtf: The raw encapsulated .rtf data in string format.
+    grammar: The Lark parsing grammer used to parse the .rtf data.
+    content_type_token: The .rtf header token identifying the content type. (\\fromhtml1 OR \\fromtext)
+    parser: The lark parser. Should not need to be manipulated directly. But, useful for debugging and saving the parsed object.
+    &#34;&#34;&#34;
+
+    def __init__(self, raw_rtf:AnyStr, grammar: Union[str,None] = None):
+        &#34;&#34;&#34;Load in the Encapsulated test and setup the grammar used to parse the encapsulated RTF.
+
+NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.
+
+Parameters:
+        raw_rtf: (str): It&#39;s the raw RTF string.
+        grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
+
+Raises:
+        TypeError: The raw_rtf data passed is not the correct type of data (string/byte string).
+&#34;&#34;&#34;
+        self.content: str
+        self.content_type: str
+        self.content_type_token: str
+        self.parser: Any
+
+        self.html: str
+        self.text: str
+        self.simplified_rtf: AnyStr
+        self.full_tree: Tree
+        self.doc_tree: Tree
+        self.catch_common_validation_issues(raw_rtf)
+        if isinstance(raw_rtf, bytes):
+            # Remove any null bytes at end of file.
+            raw_rtf = raw_rtf.rstrip(b&#39;\x00&#39;)
+            # Remove any windows newlines
+            raw_rtf = raw_rtf.replace(b&#39;\r\n&#39;,b&#39;\n&#39;)
+            raw_rtf = raw_rtf.replace(b&#39;\r&#39;,b&#39;\n&#39;)
+            self.raw_rtf: str = raw_rtf.decode()
+        elif isinstance(raw_rtf, str):
+            # Remove any windows newlines
+            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r\\n&#39;,r&#39;\\n&#39;)
+            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r&#39;,r&#39;\\n&#39;)
+            self.raw_rtf = raw_rtf
+        else:
+            raise TypeError(&#34;DeEncapssulator only accepts RTF files in string or byte-string formats&#34;)
+        if grammar is not None:
+            self.grammar: str = grammar
+        else:
+            self.grammar = make_concise_grammar()
+
+    def deencapsulate(self):
+        &#34;&#34;&#34;De-encapsulate the RTF content loaded into the De-Encapsulator.
+
+Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The `content` property will store the content no matter what format it is in. The `html` and `text` properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)
+        &#34;&#34;&#34;
+        escaped_rtf = encode_escaped_control_chars(self.raw_rtf)
+        log_transformations(escaped_rtf)
+        self.parse_rtf(escaped_rtf)
+        Decoder = TextDecoder()
+        Decoder.update_children(self.full_tree)
+        self.get_doc_tree()
+        self.validate_encapsulation()
+        # remove htmlrtf escaped values
+        htmlrtf_stripped = self.strip_htmlrtf_tokens()
+        # Strips whitespace from control words
+        control_stripped = StripControlWords().transform(htmlrtf_stripped)
+        # Strip unused control chars
+        special_stripper = StripUnusedSpecialCharacters()
+        non_special_tree = special_stripper.transform(control_stripped)
+        # Strip out non-visible RTF groups
+        stripper = StripNonVisibleRTFGroups()
+        stripped_tree = stripper.transform(non_special_tree)
+        # Converts any remaining tokens
+        cleaner = RTFCleaner(visit_tokens=True)
+        cleaned_text = cleaner.transform(stripped_tree)
+
+        self.content = cleaned_text
+        self.set_content() # Populates self.html || self.text
+
+    def validate_charset(self, fallback_to_default:bool =False) -&gt; str:
+        &#34;&#34;&#34;Validate and return the RTF charset keyword from the RTF streams header.
+
+Args:
+        fallback_to_default (bool): Allows you to force the use of the default charset &#34;\\ansi&#34; if one is not found.
+
+Raises:
+        MalformedRtf: RTF stream does not include charset control word.
+
+Returns:
+        The RTF charset keyword from the RTF streams header.
+&#34;&#34;&#34;
+        main_headers = self.get_header_control_words_before_first_group()
+
+        for token in main_headers:
+            if token in [&#34;\\ansi&#34;, &#34;\\mac&#34;, &#34;\\pc&#34;, &#34;\\pca&#34;]:
+                return token
+
+        log.debug(&#34;Acceptable charset not found as the second token in the RTF stream. The control word for the character set must precede any plain text or any table control words. So, if this stream doesn&#39;t have one it is malformed or corrupted.&#34;)
+        if fallback_to_default is False:
+            raise MalformedRtf(&#34;RTF stream does not include charset control word.&#34;)
+
+        log.warning(&#34;The fallback_to_default option on _get_charset is considered DANGEROUS if used on possibly malicious samples. Make sure you know what you are doing before using it.&#34;)
+        log.info(&#34;Attempting to decode RTF using the default charset ansi. This is not recommended and could have unforeseen consequences for the resulting file and your systems security.&#34;)
+        log.debug(&#34;You have a malformed RTF stream. Are you sure you really want to be parsing it? It might not just be corrupted. It could be maliciously constructed.&#34;)
+        return &#34;\\ansi&#34;
+
+    def set_content(self):
+        &#34;&#34;&#34;Populate the html or text content based on the content type. Populates self.html and/or self.text variables.&#34;&#34;&#34;
+        self.content_type = self.get_content_type()
+        if self.content_type == &#39;html&#39;:
+            self.html = self.content
+        else:
+            self.text = self.content
+
+    def get_doc_tree(self):
+        &#34;&#34;&#34;Extract the document portion of the .rtf full_tree object. Populates the classes doc_tree attribute.
+
+Raises:
+        ValueError: The .rtf document object is missing or mis-located in the .rtf&#39;s full_tree object.
+&#34;&#34;&#34;
+        if self.full_tree.children[1].data == &#34;document&#34;:
+            self.doc_tree = self.full_tree.children[1]
+        else:
+            raise ValueError(&#34;Document object in the wrong place after parsing.&#34;)
+
+    def get_content_type(self):
+        &#34;&#34;&#34;Provide the type of content encapsulated in RTF.
+
+NOTE: This function will only work after the header validation has completed. Header validation also extracts the content type of the encapsulated data.
+
+Raises:
+        NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+&#34;&#34;&#34;
+        if self.content_type_token is None:
+            self.validate_FROM_in_doc_header()
+        elif self.content_type_token == &#39;\\fromhtml1&#39;:
+            return &#39;html&#39;
+        elif self.content_type_token == &#39;\\fromtext&#39;:
+            return &#34;text&#34;
+
+        raise NotEncapsulatedRtf(&#34;Data is missing encapsulated content type header (the FROM header).&#34;)
+
+    def validate_encapsulation(self):
+        &#34;&#34;&#34;Runs simple tests to validate that the file in question is an rtf document which contains encapsulation.&#34;&#34;&#34;
+        self.validate_rtf_doc_header(self.doc_tree)
+        self.validate_charset()
+        self.validate_FROM_in_doc_header()
+        ansicpg = self.get_ansicpg_header()
+        if ansicpg is not None: # ansicpg is not manditory
+            validate_ansi_cpg(ansicpg.value)
+
+    def get_ansicpg_header(self) -&gt; Union[Token,None]:
+        &#34;&#34;&#34;Extract the ansicpg control word from the .rtf header.
+
+Returns:
+        A lark CONTROLWORD Token with the `\\ansicpg` value. Returns None if the `\\ansicpg` control word is not included as this is only required if there is Unicode which needs to be converted to ANSI within a .rtf file.
+&#34;&#34;&#34;
+        headers = self.get_header_control_words_before_first_group()
+        for item in headers:
+            if item.value.startswith(&#39;\\ansicpg&#39;):
+                return item
+        return None
+
+    def parse_rtf(self, rtf: str):
+        &#34;&#34;&#34;Parse RTF file&#39;s header and document and extract the objects within the RTF into a Tree. Populates the self.full_tree attribute.
+
+Args:
+        rtf: The .rtf string to parse with the projects lark grammar.
+&#34;&#34;&#34;
+        # Uncomment Lark debug argument if you want to enable logging.
+        # Note, this not enable ALL lark debug logging.
+        # To do that we would not be able to use the Lark convinence class which we are using here.
+        self.parser = Lark(self.grammar,
+                           parser=&#39;lalr&#39;,
+                           keep_all_tokens=True,
+                           # debug=True,
+                           propagate_positions=True)
+        self.full_tree = self.parser.parse(rtf)
+        log_transformations(self.full_tree)
+
+
+    def strip_htmlrtf_tokens(self) -&gt; Tree:
+        &#34;&#34;&#34;Strip tokens from with htmlrtf regions of the doc_tree as they were not part of the original HTML content.
+
+Returns:
+        .rtf doc_tree stripped of all non-original tokens.
+&#34;&#34;&#34;
+        # remove htmlrtf escaped values
+        delete_generator = get_stripped_HTMLRTF_values(self.doc_tree)
+        tokens_to_delete = list(delete_generator)
+        deleter = DeleteTokensFromTree(tokens_to_delete)
+        htmlrtf_cleaned_tree = deleter.transform(self.doc_tree)
+        return htmlrtf_cleaned_tree
+
+
+    def get_header_control_words_before_first_group(self) -&gt; list:
+        &#34;&#34;&#34;Extracts all the control words in the first 20 tokens of the document or all the tokens which occur before the first group (whichever comes first.)
+
+This is used to extract initial header values for validation functions.
+
+Returns:
+        A list containing the header tokens in the .rtf data.
+        &#34;&#34;&#34;
+        initial_control_words = []
+        for token in self.doc_tree.children[:20]:
+            if isinstance(token, Token):
+                initial_control_words.append(token)
+            else:
+                return initial_control_words
+        return initial_control_words
+
+
+    def validate_FROM_in_doc_header(self):
+        &#34;&#34;&#34;Inspect the header to identify what type of content (html/plain text) is encapsulated within the document.
+
+NOTE: The de-encapsulating RTF reader inspects no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. If one of the control words is the FROMHTML control word, the de-encapsulating RTF reader will conclude that the RTF document contains an encapsulated HTML document and stop further inspection. If one of the control words is the FROMTEXT control word, the de-encapsulating RTF reader concludes that the RTF document was produced from a plain text document and stops further inspection. - MS-OXRTFEX
+
+Raises:
+        MalformedEncapsulatedRtf: The .rtf headers are malformed.
+        NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+        &#34;&#34;&#34;
+        cw_found = {&#34;rtf1&#34;:False,
+                    &#34;from&#34;:False,
+                    &#34;fonttbl&#34;:False,
+                    &#34;malformed&#34;:False}
+        # The de-encapsulating RTF reader SHOULD inspect no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. This means more than just control words.
+        decoded_tree = StripControlWords().transform(self.doc_tree)
+        first_ten_tokens = decoded_tree.children[:10]
+        operating_tokens = []
+        found_token = None
+        for token in first_ten_tokens:
+            if isinstance(token, Token):
+                operating_tokens.append(token)
+            else:
+                operating_tokens += list(token.scan_values(lambda t: t.type == &#39;CONTROLWORD&#39;))
+        log_validators(f&#34;Header tokens being evaluated: {operating_tokens}&#34;)
+
+        for token in operating_tokens:
+            cw_found,found_token = self.check_from_token(token=token, cw_found=cw_found)
+            if cw_found[&#39;from&#39;] is True and cw_found[&#34;malformed&#34;] is True:
+                raise MalformedEncapsulatedRtf(&#34;RTF file looks like is was supposed to be encapsulated HTML/TEXT but the headers are malformed. Turn on debugging to see specific information&#34;)
+            # Save content type token available for id-ing type of content later
+            if found_token is not None:
+                self.content_type_token = found_token
+
+        if cw_found[&#39;from&#39;] is False:
+            log.debug(&#34;FROMHTML/TEXT control word not found in first 10 RTF tokens. This is not an HTML/TEXT encapsulated RTF document.&#34;)
+            raise NotEncapsulatedRtf(&#34;FROMHTML/TEXT control word not found.&#34;)
+
+    @staticmethod
+    def check_from_token(token:Token, cw_found:dict) -&gt; Tuple[Dict,Union[None,str]] :
+        &#34;&#34;&#34;Checks if fromhtml1 or fromtext tokens are in the proper place in the header based on the state passed to it by the validate_FROM_in_doc_header function.
+
+Args:
+        token: The token to check for in the cw_found state dictionary.
+        cw_found: The state dictionary which is used to track the position of the from token within the header.
+
+        `cw_found = {&#34;rtf1&#34;:&lt;BOOL&gt;, &#34;from&#34;:&lt;BOOL&gt;, &#34;fonttbl&#34;:&lt;BOOL&gt;, &#34;malformed&#34;:&lt;BOOL&gt;}`
+
+
+Returns:
+        cw_found: Updated state dictionary
+        found_token: The content_type_token found in the header.
+
+        &#34;&#34;&#34;
+        from_cws = [&#39;\\fromhtml1&#39;, &#39;\\fromtext&#39;]
+        # This control word MUST appear before the \fonttbl control word and after the \rtf1 control word, as specified in [MSFT-RTF].
+        rtf1_cw = &#34;\\rtf1&#34;
+        found_token = None
+        fonttbl_cw = &#34;\\fonttbl&#34;
+        if token.type == &#34;CONTROLWORD&#34;:
+            if token.value.strip() in from_cws:
+                if cw_found[&#39;from&#39;] is True:
+                    cw_found[&#34;malformed&#34;] = True
+                    log.debug(&#34;Multiple FROM HTML/TXT tokens found in the header. This encapsulated RTF is malformed.&#34;)
+                if cw_found[&#39;rtf1&#39;] is True:
+                    cw_found[&#39;from&#39;] = True
+                    found_token = token.value
+                else:
+                    log.debug(&#34;FROMHTML/TEXT control word found before rtf1 control word. That&#39;s not allowed in the RTF spec.&#34;)
+                    cw_found[&#39;from&#39;] = True
+                    cw_found[&#34;malformed&#34;] = True
+            elif token.value.strip() == rtf1_cw:
+                cw_found[&#39;rtf1&#39;] = True
+            elif token.value.strip() == fonttbl_cw:
+                cw_found[&#39;fonttbl&#39;] = True
+                if cw_found[&#39;from&#39;] is not True:
+                    log.debug(&#34;\\fonttbl code word found before FROMTML/TEXT was defined. This is not allowed for encapsulated HTML/TEXT. So... this is not encapsulated HTML/TEXT or it was badly encapsulated.&#34;)
+                    cw_found[&#34;malformed&#34;] = True
+        return cw_found, found_token
+
+
+    @staticmethod
+    def validate_rtf_doc_header(doc_tree: Tree):
+        &#34;&#34;&#34;Check if doc starts with a valid RTF header `\\rtf1`.
+
+        &#34;Before the de-encapsulating RTF reader tries to recognize the encapsulation, the reader SHOULD ensure that the document has a valid RTF document heading according to [MSFT-RTF] (that is, it starts with the character sequence &#34;{\\rtf1&#34;).&#34; - MS-OXRTFEX
+
+Raises:
+        MalformedRtf: The .rtf headers do not include \\rtf1.
+&#34;&#34;&#34;
+        first_token = doc_tree.children[0].value
+        if first_token != &#34;\\rtf1&#34;:
+            log.debug(&#34;RTF stream does not contain valid valid RTF document heading. The file must start with \&#34;{\\rtf1\&#34;&#34;)
+            log_validators(f&#34;First child object in document tree is: {first_token!r}&#34;)
+            raise MalformedRtf(&#34;RTF stream does not start with {\\rtf1&#34;)
+
+    @staticmethod
+    def catch_common_validation_issues(raw_rtf: AnyStr):
+        &#34;&#34;&#34;Checks for likely common valid input mistakes that may occur when folks try to use this library and raises exceptions to try and help identify them.
+
+Args:
+        raw_rtf: A raw .rtf string or byte-string.
+
+Raises:
+        TypeError: The data passed is the wrong type of data.
+        MalformedRtf: The data passed is not a correctly formatted .rtf string.
+&#34;&#34;&#34;
+        if isinstance(raw_rtf, BufferedReader):
+            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts strings and byte-strings.&#34;)
+        if raw_rtf is None:
+            raise TypeError(&#34;Data passed as raw RTF file is a null object `None` keyword.&#34;)
+        if raw_rtf[:8] == b&#34;=\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
+            raise TypeError(&#34;Data passed is a full MSG object. You must extract the encapsulated RTF body first.&#34;)
+        if raw_rtf in (b&#39;&#39;, &#39;&#39;):
+            raise MalformedRtf(&#34;Data passed as raw RTF file is an empty string.&#34;)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="RTFDE.deencapsulate.DeEncapsulator"><code class="flex name class">
+<span>class <span class="ident">DeEncapsulator</span></span>
+<span>(</span><span>raw_rtf: ~AnyStr, grammar: Optional[str] = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>De-Encapsulating RTF converter of HTML/TEXT found in .msg files.</p>
+<p>De-encapsulation enables previously encapsulated HTML and plain text content to be extracted and rendered as HTML and plain text instead of the encapsulating RTF content. After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.</p>
+<h2 id="parameters">Parameters</h2>
+<p>raw_rtf: (str): It's the raw RTF string.
+grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. <a href="https://github.com/lark-parser/lark">https://github.com/lark-parser/lark</a> If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>content</code></strong></dt>
+<dd>The deencapsulated content no matter what format it is in. Populated by the <code>deencapsulate</code> function.</dd>
+<dt><strong><code>html</code></strong></dt>
+<dd>The deencapsulated content IF it is HTML content. Populated by the <code>set_content</code> function.</dd>
+<dt><strong><code>text</code></strong></dt>
+<dd>The deencapsulated content IF it is plain text content. Populated by the <code>set_content</code> function.</dd>
+<dt><strong><code>content_type</code></strong></dt>
+<dd>The type of content encapsulated in .rtf data (html or text). Populated by the <code>get_content_type</code> function.</dd>
+<dt><strong><code>full_tree</code></strong></dt>
+<dd>The full .rtf object parsed into an object Tree using the grammar. Populated by the <code>parse_rtf</code> function.</dd>
+<dt><strong><code>doc_tree</code></strong></dt>
+<dd>The <code>document</code> portion of the .rtf full_tree object.</dd>
+<dt><strong><code>raw_rtf</code></strong></dt>
+<dd>The raw encapsulated .rtf data in string format.</dd>
+<dt><strong><code>grammar</code></strong></dt>
+<dd>The Lark parsing grammer used to parse the .rtf data.</dd>
+<dt><strong><code>content_type_token</code></strong></dt>
+<dd>The .rtf header token identifying the content type. (\fromhtml1 OR \fromtext)</dd>
+<dt><strong><code>parser</code></strong></dt>
+<dd>The lark parser. Should not need to be manipulated directly. But, useful for debugging and saving the parsed object.</dd>
+</dl>
+<p>Load in the Encapsulated test and setup the grammar used to parse the encapsulated RTF.</p>
+<p>NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.</p>
+<h2 id="parameters_1">Parameters</h2>
+<p>raw_rtf: (str): It's the raw RTF string.
+grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. <a href="https://github.com/lark-parser/lark">https://github.com/lark-parser/lark</a> If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>TypeError</code></dt>
+<dd>The raw_rtf data passed is not the correct type of data (string/byte string).</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class DeEncapsulator():
+    &#34;&#34;&#34;De-Encapsulating RTF converter of HTML/TEXT found in .msg files.
+
+De-encapsulation enables previously encapsulated HTML and plain text content to be extracted and rendered as HTML and plain text instead of the encapsulating RTF content. After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.
+
+
+Parameters:
+    raw_rtf: (str): It&#39;s the raw RTF string.
+    grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
+
+Attributes:
+    content: The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
+    html: The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
+    text: The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+    content_type: The type of content encapsulated in .rtf data (html or text). Populated by the `get_content_type` function.
+    full_tree: The full .rtf object parsed into an object Tree using the grammar. Populated by the `parse_rtf` function.
+    doc_tree: The `document` portion of the .rtf full_tree object.
+    raw_rtf: The raw encapsulated .rtf data in string format.
+    grammar: The Lark parsing grammer used to parse the .rtf data.
+    content_type_token: The .rtf header token identifying the content type. (\\fromhtml1 OR \\fromtext)
+    parser: The lark parser. Should not need to be manipulated directly. But, useful for debugging and saving the parsed object.
+    &#34;&#34;&#34;
+
+    def __init__(self, raw_rtf:AnyStr, grammar: Union[str,None] = None):
+        &#34;&#34;&#34;Load in the Encapsulated test and setup the grammar used to parse the encapsulated RTF.
+
+NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.
+
+Parameters:
+        raw_rtf: (str): It&#39;s the raw RTF string.
+        grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
+
+Raises:
+        TypeError: The raw_rtf data passed is not the correct type of data (string/byte string).
+&#34;&#34;&#34;
+        self.content: str
+        self.content_type: str
+        self.content_type_token: str
+        self.parser: Any
+
+        self.html: str
+        self.text: str
+        self.simplified_rtf: AnyStr
+        self.full_tree: Tree
+        self.doc_tree: Tree
+        self.catch_common_validation_issues(raw_rtf)
+        if isinstance(raw_rtf, bytes):
+            # Remove any null bytes at end of file.
+            raw_rtf = raw_rtf.rstrip(b&#39;\x00&#39;)
+            # Remove any windows newlines
+            raw_rtf = raw_rtf.replace(b&#39;\r\n&#39;,b&#39;\n&#39;)
+            raw_rtf = raw_rtf.replace(b&#39;\r&#39;,b&#39;\n&#39;)
+            self.raw_rtf: str = raw_rtf.decode()
+        elif isinstance(raw_rtf, str):
+            # Remove any windows newlines
+            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r\\n&#39;,r&#39;\\n&#39;)
+            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r&#39;,r&#39;\\n&#39;)
+            self.raw_rtf = raw_rtf
+        else:
+            raise TypeError(&#34;DeEncapssulator only accepts RTF files in string or byte-string formats&#34;)
+        if grammar is not None:
+            self.grammar: str = grammar
+        else:
+            self.grammar = make_concise_grammar()
+
+    def deencapsulate(self):
+        &#34;&#34;&#34;De-encapsulate the RTF content loaded into the De-Encapsulator.
+
+Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The `content` property will store the content no matter what format it is in. The `html` and `text` properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)
+        &#34;&#34;&#34;
+        escaped_rtf = encode_escaped_control_chars(self.raw_rtf)
+        log_transformations(escaped_rtf)
+        self.parse_rtf(escaped_rtf)
+        Decoder = TextDecoder()
+        Decoder.update_children(self.full_tree)
+        self.get_doc_tree()
+        self.validate_encapsulation()
+        # remove htmlrtf escaped values
+        htmlrtf_stripped = self.strip_htmlrtf_tokens()
+        # Strips whitespace from control words
+        control_stripped = StripControlWords().transform(htmlrtf_stripped)
+        # Strip unused control chars
+        special_stripper = StripUnusedSpecialCharacters()
+        non_special_tree = special_stripper.transform(control_stripped)
+        # Strip out non-visible RTF groups
+        stripper = StripNonVisibleRTFGroups()
+        stripped_tree = stripper.transform(non_special_tree)
+        # Converts any remaining tokens
+        cleaner = RTFCleaner(visit_tokens=True)
+        cleaned_text = cleaner.transform(stripped_tree)
+
+        self.content = cleaned_text
+        self.set_content() # Populates self.html || self.text
+
+    def validate_charset(self, fallback_to_default:bool =False) -&gt; str:
+        &#34;&#34;&#34;Validate and return the RTF charset keyword from the RTF streams header.
+
+Args:
+        fallback_to_default (bool): Allows you to force the use of the default charset &#34;\\ansi&#34; if one is not found.
+
+Raises:
+        MalformedRtf: RTF stream does not include charset control word.
+
+Returns:
+        The RTF charset keyword from the RTF streams header.
+&#34;&#34;&#34;
+        main_headers = self.get_header_control_words_before_first_group()
+
+        for token in main_headers:
+            if token in [&#34;\\ansi&#34;, &#34;\\mac&#34;, &#34;\\pc&#34;, &#34;\\pca&#34;]:
+                return token
+
+        log.debug(&#34;Acceptable charset not found as the second token in the RTF stream. The control word for the character set must precede any plain text or any table control words. So, if this stream doesn&#39;t have one it is malformed or corrupted.&#34;)
+        if fallback_to_default is False:
+            raise MalformedRtf(&#34;RTF stream does not include charset control word.&#34;)
+
+        log.warning(&#34;The fallback_to_default option on _get_charset is considered DANGEROUS if used on possibly malicious samples. Make sure you know what you are doing before using it.&#34;)
+        log.info(&#34;Attempting to decode RTF using the default charset ansi. This is not recommended and could have unforeseen consequences for the resulting file and your systems security.&#34;)
+        log.debug(&#34;You have a malformed RTF stream. Are you sure you really want to be parsing it? It might not just be corrupted. It could be maliciously constructed.&#34;)
+        return &#34;\\ansi&#34;
+
+    def set_content(self):
+        &#34;&#34;&#34;Populate the html or text content based on the content type. Populates self.html and/or self.text variables.&#34;&#34;&#34;
+        self.content_type = self.get_content_type()
+        if self.content_type == &#39;html&#39;:
+            self.html = self.content
+        else:
+            self.text = self.content
+
+    def get_doc_tree(self):
+        &#34;&#34;&#34;Extract the document portion of the .rtf full_tree object. Populates the classes doc_tree attribute.
+
+Raises:
+        ValueError: The .rtf document object is missing or mis-located in the .rtf&#39;s full_tree object.
+&#34;&#34;&#34;
+        if self.full_tree.children[1].data == &#34;document&#34;:
+            self.doc_tree = self.full_tree.children[1]
+        else:
+            raise ValueError(&#34;Document object in the wrong place after parsing.&#34;)
+
+    def get_content_type(self):
+        &#34;&#34;&#34;Provide the type of content encapsulated in RTF.
+
+NOTE: This function will only work after the header validation has completed. Header validation also extracts the content type of the encapsulated data.
+
+Raises:
+        NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+&#34;&#34;&#34;
+        if self.content_type_token is None:
+            self.validate_FROM_in_doc_header()
+        elif self.content_type_token == &#39;\\fromhtml1&#39;:
+            return &#39;html&#39;
+        elif self.content_type_token == &#39;\\fromtext&#39;:
+            return &#34;text&#34;
+
+        raise NotEncapsulatedRtf(&#34;Data is missing encapsulated content type header (the FROM header).&#34;)
+
+    def validate_encapsulation(self):
+        &#34;&#34;&#34;Runs simple tests to validate that the file in question is an rtf document which contains encapsulation.&#34;&#34;&#34;
+        self.validate_rtf_doc_header(self.doc_tree)
+        self.validate_charset()
+        self.validate_FROM_in_doc_header()
+        ansicpg = self.get_ansicpg_header()
+        if ansicpg is not None: # ansicpg is not manditory
+            validate_ansi_cpg(ansicpg.value)
+
+    def get_ansicpg_header(self) -&gt; Union[Token,None]:
+        &#34;&#34;&#34;Extract the ansicpg control word from the .rtf header.
+
+Returns:
+        A lark CONTROLWORD Token with the `\\ansicpg` value. Returns None if the `\\ansicpg` control word is not included as this is only required if there is Unicode which needs to be converted to ANSI within a .rtf file.
+&#34;&#34;&#34;
+        headers = self.get_header_control_words_before_first_group()
+        for item in headers:
+            if item.value.startswith(&#39;\\ansicpg&#39;):
+                return item
+        return None
+
+    def parse_rtf(self, rtf: str):
+        &#34;&#34;&#34;Parse RTF file&#39;s header and document and extract the objects within the RTF into a Tree. Populates the self.full_tree attribute.
+
+Args:
+        rtf: The .rtf string to parse with the projects lark grammar.
+&#34;&#34;&#34;
+        # Uncomment Lark debug argument if you want to enable logging.
+        # Note, this not enable ALL lark debug logging.
+        # To do that we would not be able to use the Lark convinence class which we are using here.
+        self.parser = Lark(self.grammar,
+                           parser=&#39;lalr&#39;,
+                           keep_all_tokens=True,
+                           # debug=True,
+                           propagate_positions=True)
+        self.full_tree = self.parser.parse(rtf)
+        log_transformations(self.full_tree)
+
+
+    def strip_htmlrtf_tokens(self) -&gt; Tree:
+        &#34;&#34;&#34;Strip tokens from with htmlrtf regions of the doc_tree as they were not part of the original HTML content.
+
+Returns:
+        .rtf doc_tree stripped of all non-original tokens.
+&#34;&#34;&#34;
+        # remove htmlrtf escaped values
+        delete_generator = get_stripped_HTMLRTF_values(self.doc_tree)
+        tokens_to_delete = list(delete_generator)
+        deleter = DeleteTokensFromTree(tokens_to_delete)
+        htmlrtf_cleaned_tree = deleter.transform(self.doc_tree)
+        return htmlrtf_cleaned_tree
+
+
+    def get_header_control_words_before_first_group(self) -&gt; list:
+        &#34;&#34;&#34;Extracts all the control words in the first 20 tokens of the document or all the tokens which occur before the first group (whichever comes first.)
+
+This is used to extract initial header values for validation functions.
+
+Returns:
+        A list containing the header tokens in the .rtf data.
+        &#34;&#34;&#34;
+        initial_control_words = []
+        for token in self.doc_tree.children[:20]:
+            if isinstance(token, Token):
+                initial_control_words.append(token)
+            else:
+                return initial_control_words
+        return initial_control_words
+
+
+    def validate_FROM_in_doc_header(self):
+        &#34;&#34;&#34;Inspect the header to identify what type of content (html/plain text) is encapsulated within the document.
+
+NOTE: The de-encapsulating RTF reader inspects no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. If one of the control words is the FROMHTML control word, the de-encapsulating RTF reader will conclude that the RTF document contains an encapsulated HTML document and stop further inspection. If one of the control words is the FROMTEXT control word, the de-encapsulating RTF reader concludes that the RTF document was produced from a plain text document and stops further inspection. - MS-OXRTFEX
+
+Raises:
+        MalformedEncapsulatedRtf: The .rtf headers are malformed.
+        NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+        &#34;&#34;&#34;
+        cw_found = {&#34;rtf1&#34;:False,
+                    &#34;from&#34;:False,
+                    &#34;fonttbl&#34;:False,
+                    &#34;malformed&#34;:False}
+        # The de-encapsulating RTF reader SHOULD inspect no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. This means more than just control words.
+        decoded_tree = StripControlWords().transform(self.doc_tree)
+        first_ten_tokens = decoded_tree.children[:10]
+        operating_tokens = []
+        found_token = None
+        for token in first_ten_tokens:
+            if isinstance(token, Token):
+                operating_tokens.append(token)
+            else:
+                operating_tokens += list(token.scan_values(lambda t: t.type == &#39;CONTROLWORD&#39;))
+        log_validators(f&#34;Header tokens being evaluated: {operating_tokens}&#34;)
+
+        for token in operating_tokens:
+            cw_found,found_token = self.check_from_token(token=token, cw_found=cw_found)
+            if cw_found[&#39;from&#39;] is True and cw_found[&#34;malformed&#34;] is True:
+                raise MalformedEncapsulatedRtf(&#34;RTF file looks like is was supposed to be encapsulated HTML/TEXT but the headers are malformed. Turn on debugging to see specific information&#34;)
+            # Save content type token available for id-ing type of content later
+            if found_token is not None:
+                self.content_type_token = found_token
+
+        if cw_found[&#39;from&#39;] is False:
+            log.debug(&#34;FROMHTML/TEXT control word not found in first 10 RTF tokens. This is not an HTML/TEXT encapsulated RTF document.&#34;)
+            raise NotEncapsulatedRtf(&#34;FROMHTML/TEXT control word not found.&#34;)
+
+    @staticmethod
+    def check_from_token(token:Token, cw_found:dict) -&gt; Tuple[Dict,Union[None,str]] :
+        &#34;&#34;&#34;Checks if fromhtml1 or fromtext tokens are in the proper place in the header based on the state passed to it by the validate_FROM_in_doc_header function.
+
+Args:
+        token: The token to check for in the cw_found state dictionary.
+        cw_found: The state dictionary which is used to track the position of the from token within the header.
+
+        `cw_found = {&#34;rtf1&#34;:&lt;BOOL&gt;, &#34;from&#34;:&lt;BOOL&gt;, &#34;fonttbl&#34;:&lt;BOOL&gt;, &#34;malformed&#34;:&lt;BOOL&gt;}`
+
+
+Returns:
+        cw_found: Updated state dictionary
+        found_token: The content_type_token found in the header.
+
+        &#34;&#34;&#34;
+        from_cws = [&#39;\\fromhtml1&#39;, &#39;\\fromtext&#39;]
+        # This control word MUST appear before the \fonttbl control word and after the \rtf1 control word, as specified in [MSFT-RTF].
+        rtf1_cw = &#34;\\rtf1&#34;
+        found_token = None
+        fonttbl_cw = &#34;\\fonttbl&#34;
+        if token.type == &#34;CONTROLWORD&#34;:
+            if token.value.strip() in from_cws:
+                if cw_found[&#39;from&#39;] is True:
+                    cw_found[&#34;malformed&#34;] = True
+                    log.debug(&#34;Multiple FROM HTML/TXT tokens found in the header. This encapsulated RTF is malformed.&#34;)
+                if cw_found[&#39;rtf1&#39;] is True:
+                    cw_found[&#39;from&#39;] = True
+                    found_token = token.value
+                else:
+                    log.debug(&#34;FROMHTML/TEXT control word found before rtf1 control word. That&#39;s not allowed in the RTF spec.&#34;)
+                    cw_found[&#39;from&#39;] = True
+                    cw_found[&#34;malformed&#34;] = True
+            elif token.value.strip() == rtf1_cw:
+                cw_found[&#39;rtf1&#39;] = True
+            elif token.value.strip() == fonttbl_cw:
+                cw_found[&#39;fonttbl&#39;] = True
+                if cw_found[&#39;from&#39;] is not True:
+                    log.debug(&#34;\\fonttbl code word found before FROMTML/TEXT was defined. This is not allowed for encapsulated HTML/TEXT. So... this is not encapsulated HTML/TEXT or it was badly encapsulated.&#34;)
+                    cw_found[&#34;malformed&#34;] = True
+        return cw_found, found_token
+
+
+    @staticmethod
+    def validate_rtf_doc_header(doc_tree: Tree):
+        &#34;&#34;&#34;Check if doc starts with a valid RTF header `\\rtf1`.
+
+        &#34;Before the de-encapsulating RTF reader tries to recognize the encapsulation, the reader SHOULD ensure that the document has a valid RTF document heading according to [MSFT-RTF] (that is, it starts with the character sequence &#34;{\\rtf1&#34;).&#34; - MS-OXRTFEX
+
+Raises:
+        MalformedRtf: The .rtf headers do not include \\rtf1.
+&#34;&#34;&#34;
+        first_token = doc_tree.children[0].value
+        if first_token != &#34;\\rtf1&#34;:
+            log.debug(&#34;RTF stream does not contain valid valid RTF document heading. The file must start with \&#34;{\\rtf1\&#34;&#34;)
+            log_validators(f&#34;First child object in document tree is: {first_token!r}&#34;)
+            raise MalformedRtf(&#34;RTF stream does not start with {\\rtf1&#34;)
+
+    @staticmethod
+    def catch_common_validation_issues(raw_rtf: AnyStr):
+        &#34;&#34;&#34;Checks for likely common valid input mistakes that may occur when folks try to use this library and raises exceptions to try and help identify them.
+
+Args:
+        raw_rtf: A raw .rtf string or byte-string.
+
+Raises:
+        TypeError: The data passed is the wrong type of data.
+        MalformedRtf: The data passed is not a correctly formatted .rtf string.
+&#34;&#34;&#34;
+        if isinstance(raw_rtf, BufferedReader):
+            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts strings and byte-strings.&#34;)
+        if raw_rtf is None:
+            raise TypeError(&#34;Data passed as raw RTF file is a null object `None` keyword.&#34;)
+        if raw_rtf[:8] == b&#34;=\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
+            raise TypeError(&#34;Data passed is a full MSG object. You must extract the encapsulated RTF body first.&#34;)
+        if raw_rtf in (b&#39;&#39;, &#39;&#39;):
+            raise MalformedRtf(&#34;Data passed as raw RTF file is an empty string.&#34;)</code></pre>
+</details>
+<h3>Static methods</h3>
+<dl>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.catch_common_validation_issues"><code class="name flex">
+<span>def <span class="ident">catch_common_validation_issues</span></span>(<span>raw_rtf: ~AnyStr)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks for likely common valid input mistakes that may occur when folks try to use this library and raises exceptions to try and help identify them.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>raw_rtf</code></strong></dt>
+<dd>A raw .rtf string or byte-string.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>TypeError</code></dt>
+<dd>The data passed is the wrong type of data.</dd>
+<dt><code>MalformedRtf</code></dt>
+<dd>The data passed is not a correctly formatted .rtf string.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    @staticmethod
+    def catch_common_validation_issues(raw_rtf: AnyStr):
+        &#34;&#34;&#34;Checks for likely common valid input mistakes that may occur when folks try to use this library and raises exceptions to try and help identify them.
+
+Args:
+        raw_rtf: A raw .rtf string or byte-string.
+
+Raises:
+        TypeError: The data passed is the wrong type of data.
+        MalformedRtf: The data passed is not a correctly formatted .rtf string.
+&#34;&#34;&#34;
+        if isinstance(raw_rtf, BufferedReader):
+            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts strings and byte-strings.&#34;)
+        if raw_rtf is None:
+            raise TypeError(&#34;Data passed as raw RTF file is a null object `None` keyword.&#34;)
+        if raw_rtf[:8] == b&#34;=\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
+            raise TypeError(&#34;Data passed is a full MSG object. You must extract the encapsulated RTF body first.&#34;)
+        if raw_rtf in (b&#39;&#39;, &#39;&#39;):
+            raise MalformedRtf(&#34;Data passed as raw RTF file is an empty string.&#34;)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.check_from_token"><code class="name flex">
+<span>def <span class="ident">check_from_token</span></span>(<span>token: lark.lexer.Token, cw_found: dict) ‑> Tuple[Dict, Optional[None]]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks if fromhtml1 or fromtext tokens are in the proper place in the header based on the state passed to it by the validate_FROM_in_doc_header function.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>token</code></strong></dt>
+<dd>The token to check for in the cw_found state dictionary.</dd>
+<dt><strong><code>cw_found</code></strong></dt>
+<dd>The state dictionary which is used to track the position of the from token within the header.</dd>
+</dl>
+<p><code>cw_found = {"rtf1":&lt;BOOL&gt;, "from":&lt;BOOL&gt;, "fonttbl":&lt;BOOL&gt;, "malformed":&lt;BOOL&gt;}</code></p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>cw_found</code></dt>
+<dd>Updated state dictionary</dd>
+<dt><code>found_token</code></dt>
+<dd>The content_type_token found in the header.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    @staticmethod
+    def check_from_token(token:Token, cw_found:dict) -&gt; Tuple[Dict,Union[None,str]] :
+        &#34;&#34;&#34;Checks if fromhtml1 or fromtext tokens are in the proper place in the header based on the state passed to it by the validate_FROM_in_doc_header function.
+
+Args:
+        token: The token to check for in the cw_found state dictionary.
+        cw_found: The state dictionary which is used to track the position of the from token within the header.
+
+        `cw_found = {&#34;rtf1&#34;:&lt;BOOL&gt;, &#34;from&#34;:&lt;BOOL&gt;, &#34;fonttbl&#34;:&lt;BOOL&gt;, &#34;malformed&#34;:&lt;BOOL&gt;}`
+
+
+Returns:
+        cw_found: Updated state dictionary
+        found_token: The content_type_token found in the header.
+
+        &#34;&#34;&#34;
+        from_cws = [&#39;\\fromhtml1&#39;, &#39;\\fromtext&#39;]
+        # This control word MUST appear before the \fonttbl control word and after the \rtf1 control word, as specified in [MSFT-RTF].
+        rtf1_cw = &#34;\\rtf1&#34;
+        found_token = None
+        fonttbl_cw = &#34;\\fonttbl&#34;
+        if token.type == &#34;CONTROLWORD&#34;:
+            if token.value.strip() in from_cws:
+                if cw_found[&#39;from&#39;] is True:
+                    cw_found[&#34;malformed&#34;] = True
+                    log.debug(&#34;Multiple FROM HTML/TXT tokens found in the header. This encapsulated RTF is malformed.&#34;)
+                if cw_found[&#39;rtf1&#39;] is True:
+                    cw_found[&#39;from&#39;] = True
+                    found_token = token.value
+                else:
+                    log.debug(&#34;FROMHTML/TEXT control word found before rtf1 control word. That&#39;s not allowed in the RTF spec.&#34;)
+                    cw_found[&#39;from&#39;] = True
+                    cw_found[&#34;malformed&#34;] = True
+            elif token.value.strip() == rtf1_cw:
+                cw_found[&#39;rtf1&#39;] = True
+            elif token.value.strip() == fonttbl_cw:
+                cw_found[&#39;fonttbl&#39;] = True
+                if cw_found[&#39;from&#39;] is not True:
+                    log.debug(&#34;\\fonttbl code word found before FROMTML/TEXT was defined. This is not allowed for encapsulated HTML/TEXT. So... this is not encapsulated HTML/TEXT or it was badly encapsulated.&#34;)
+                    cw_found[&#34;malformed&#34;] = True
+        return cw_found, found_token</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.validate_rtf_doc_header"><code class="name flex">
+<span>def <span class="ident">validate_rtf_doc_header</span></span>(<span>doc_tree: lark.tree.Tree)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check if doc starts with a valid RTF header <code>\rtf1</code>.</p>
+<pre><code>    "Before the de-encapsulating RTF reader tries to recognize the encapsulation, the reader SHOULD ensure that the document has a valid RTF document heading according to [MSFT-RTF] (that is, it starts with the character sequence "{\rtf1")." - MS-OXRTFEX
+</code></pre>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>MalformedRtf</code></dt>
+<dd>The .rtf headers do not include \rtf1.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    @staticmethod
+    def validate_rtf_doc_header(doc_tree: Tree):
+        &#34;&#34;&#34;Check if doc starts with a valid RTF header `\\rtf1`.
+
+        &#34;Before the de-encapsulating RTF reader tries to recognize the encapsulation, the reader SHOULD ensure that the document has a valid RTF document heading according to [MSFT-RTF] (that is, it starts with the character sequence &#34;{\\rtf1&#34;).&#34; - MS-OXRTFEX
+
+Raises:
+        MalformedRtf: The .rtf headers do not include \\rtf1.
+&#34;&#34;&#34;
+        first_token = doc_tree.children[0].value
+        if first_token != &#34;\\rtf1&#34;:
+            log.debug(&#34;RTF stream does not contain valid valid RTF document heading. The file must start with \&#34;{\\rtf1\&#34;&#34;)
+            log_validators(f&#34;First child object in document tree is: {first_token!r}&#34;)
+            raise MalformedRtf(&#34;RTF stream does not start with {\\rtf1&#34;)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.deencapsulate"><code class="name flex">
+<span>def <span class="ident">deencapsulate</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>De-encapsulate the RTF content loaded into the De-Encapsulator.</p>
+<p>Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The <code>content</code> property will store the content no matter what format it is in. The <code>html</code> and <code>text</code> properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def deencapsulate(self):
+        &#34;&#34;&#34;De-encapsulate the RTF content loaded into the De-Encapsulator.
+
+Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The `content` property will store the content no matter what format it is in. The `html` and `text` properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)
+        &#34;&#34;&#34;
+        escaped_rtf = encode_escaped_control_chars(self.raw_rtf)
+        log_transformations(escaped_rtf)
+        self.parse_rtf(escaped_rtf)
+        Decoder = TextDecoder()
+        Decoder.update_children(self.full_tree)
+        self.get_doc_tree()
+        self.validate_encapsulation()
+        # remove htmlrtf escaped values
+        htmlrtf_stripped = self.strip_htmlrtf_tokens()
+        # Strips whitespace from control words
+        control_stripped = StripControlWords().transform(htmlrtf_stripped)
+        # Strip unused control chars
+        special_stripper = StripUnusedSpecialCharacters()
+        non_special_tree = special_stripper.transform(control_stripped)
+        # Strip out non-visible RTF groups
+        stripper = StripNonVisibleRTFGroups()
+        stripped_tree = stripper.transform(non_special_tree)
+        # Converts any remaining tokens
+        cleaner = RTFCleaner(visit_tokens=True)
+        cleaned_text = cleaner.transform(stripped_tree)
+
+        self.content = cleaned_text
+        self.set_content() # Populates self.html || self.text</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.get_ansicpg_header"><code class="name flex">
+<span>def <span class="ident">get_ansicpg_header</span></span>(<span>self) ‑> Optional[lark.lexer.Token]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extract the ansicpg control word from the .rtf header.</p>
+<h2 id="returns">Returns</h2>
+<p>A lark CONTROLWORD Token with the <code>\ansicpg</code> value. Returns None if the <code>\ansicpg</code> control word is not included as this is only required if there is Unicode which needs to be converted to ANSI within a .rtf file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def get_ansicpg_header(self) -&gt; Union[Token,None]:
+        &#34;&#34;&#34;Extract the ansicpg control word from the .rtf header.
+
+Returns:
+        A lark CONTROLWORD Token with the `\\ansicpg` value. Returns None if the `\\ansicpg` control word is not included as this is only required if there is Unicode which needs to be converted to ANSI within a .rtf file.
+&#34;&#34;&#34;
+        headers = self.get_header_control_words_before_first_group()
+        for item in headers:
+            if item.value.startswith(&#39;\\ansicpg&#39;):
+                return item
+        return None</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.get_content_type"><code class="name flex">
+<span>def <span class="ident">get_content_type</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Provide the type of content encapsulated in RTF.</p>
+<p>NOTE: This function will only work after the header validation has completed. Header validation also extracts the content type of the encapsulated data.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>NotEncapsulatedRtf</code></dt>
+<dd>The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def get_content_type(self):
+        &#34;&#34;&#34;Provide the type of content encapsulated in RTF.
+
+NOTE: This function will only work after the header validation has completed. Header validation also extracts the content type of the encapsulated data.
+
+Raises:
+        NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+&#34;&#34;&#34;
+        if self.content_type_token is None:
+            self.validate_FROM_in_doc_header()
+        elif self.content_type_token == &#39;\\fromhtml1&#39;:
+            return &#39;html&#39;
+        elif self.content_type_token == &#39;\\fromtext&#39;:
+            return &#34;text&#34;
+
+        raise NotEncapsulatedRtf(&#34;Data is missing encapsulated content type header (the FROM header).&#34;)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.get_doc_tree"><code class="name flex">
+<span>def <span class="ident">get_doc_tree</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extract the document portion of the .rtf full_tree object. Populates the classes doc_tree attribute.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>The .rtf document object is missing or mis-located in the .rtf's full_tree object.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def get_doc_tree(self):
+        &#34;&#34;&#34;Extract the document portion of the .rtf full_tree object. Populates the classes doc_tree attribute.
+
+Raises:
+        ValueError: The .rtf document object is missing or mis-located in the .rtf&#39;s full_tree object.
+&#34;&#34;&#34;
+        if self.full_tree.children[1].data == &#34;document&#34;:
+            self.doc_tree = self.full_tree.children[1]
+        else:
+            raise ValueError(&#34;Document object in the wrong place after parsing.&#34;)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.get_header_control_words_before_first_group"><code class="name flex">
+<span>def <span class="ident">get_header_control_words_before_first_group</span></span>(<span>self) ‑> list</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extracts all the control words in the first 20 tokens of the document or all the tokens which occur before the first group (whichever comes first.)</p>
+<p>This is used to extract initial header values for validation functions.</p>
+<h2 id="returns">Returns</h2>
+<p>A list containing the header tokens in the .rtf data.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def get_header_control_words_before_first_group(self) -&gt; list:
+        &#34;&#34;&#34;Extracts all the control words in the first 20 tokens of the document or all the tokens which occur before the first group (whichever comes first.)
+
+This is used to extract initial header values for validation functions.
+
+Returns:
+        A list containing the header tokens in the .rtf data.
+        &#34;&#34;&#34;
+        initial_control_words = []
+        for token in self.doc_tree.children[:20]:
+            if isinstance(token, Token):
+                initial_control_words.append(token)
+            else:
+                return initial_control_words
+        return initial_control_words</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.parse_rtf"><code class="name flex">
+<span>def <span class="ident">parse_rtf</span></span>(<span>self, rtf: str)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Parse RTF file's header and document and extract the objects within the RTF into a Tree. Populates the self.full_tree attribute.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>rtf</code></strong></dt>
+<dd>The .rtf string to parse with the projects lark grammar.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def parse_rtf(self, rtf: str):
+        &#34;&#34;&#34;Parse RTF file&#39;s header and document and extract the objects within the RTF into a Tree. Populates the self.full_tree attribute.
+
+Args:
+        rtf: The .rtf string to parse with the projects lark grammar.
+&#34;&#34;&#34;
+        # Uncomment Lark debug argument if you want to enable logging.
+        # Note, this not enable ALL lark debug logging.
+        # To do that we would not be able to use the Lark convinence class which we are using here.
+        self.parser = Lark(self.grammar,
+                           parser=&#39;lalr&#39;,
+                           keep_all_tokens=True,
+                           # debug=True,
+                           propagate_positions=True)
+        self.full_tree = self.parser.parse(rtf)
+        log_transformations(self.full_tree)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.set_content"><code class="name flex">
+<span>def <span class="ident">set_content</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Populate the html or text content based on the content type. Populates self.html and/or self.text variables.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_content(self):
+    &#34;&#34;&#34;Populate the html or text content based on the content type. Populates self.html and/or self.text variables.&#34;&#34;&#34;
+    self.content_type = self.get_content_type()
+    if self.content_type == &#39;html&#39;:
+        self.html = self.content
+    else:
+        self.text = self.content</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.strip_htmlrtf_tokens"><code class="name flex">
+<span>def <span class="ident">strip_htmlrtf_tokens</span></span>(<span>self) ‑> lark.tree.Tree</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Strip tokens from with htmlrtf regions of the doc_tree as they were not part of the original HTML content.</p>
+<h2 id="returns">Returns</h2>
+<p>.rtf doc_tree stripped of all non-original tokens.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def strip_htmlrtf_tokens(self) -&gt; Tree:
+        &#34;&#34;&#34;Strip tokens from with htmlrtf regions of the doc_tree as they were not part of the original HTML content.
+
+Returns:
+        .rtf doc_tree stripped of all non-original tokens.
+&#34;&#34;&#34;
+        # remove htmlrtf escaped values
+        delete_generator = get_stripped_HTMLRTF_values(self.doc_tree)
+        tokens_to_delete = list(delete_generator)
+        deleter = DeleteTokensFromTree(tokens_to_delete)
+        htmlrtf_cleaned_tree = deleter.transform(self.doc_tree)
+        return htmlrtf_cleaned_tree</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.validate_FROM_in_doc_header"><code class="name flex">
+<span>def <span class="ident">validate_FROM_in_doc_header</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Inspect the header to identify what type of content (html/plain text) is encapsulated within the document.</p>
+<p>NOTE: The de-encapsulating RTF reader inspects no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. If one of the control words is the FROMHTML control word, the de-encapsulating RTF reader will conclude that the RTF document contains an encapsulated HTML document and stop further inspection. If one of the control words is the FROMTEXT control word, the de-encapsulating RTF reader concludes that the RTF document was produced from a plain text document and stops further inspection. - MS-OXRTFEX</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>MalformedEncapsulatedRtf</code></dt>
+<dd>The .rtf headers are malformed.</dd>
+<dt><code>NotEncapsulatedRtf</code></dt>
+<dd>The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def validate_FROM_in_doc_header(self):
+        &#34;&#34;&#34;Inspect the header to identify what type of content (html/plain text) is encapsulated within the document.
+
+NOTE: The de-encapsulating RTF reader inspects no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. If one of the control words is the FROMHTML control word, the de-encapsulating RTF reader will conclude that the RTF document contains an encapsulated HTML document and stop further inspection. If one of the control words is the FROMTEXT control word, the de-encapsulating RTF reader concludes that the RTF document was produced from a plain text document and stops further inspection. - MS-OXRTFEX
+
+Raises:
+        MalformedEncapsulatedRtf: The .rtf headers are malformed.
+        NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+        &#34;&#34;&#34;
+        cw_found = {&#34;rtf1&#34;:False,
+                    &#34;from&#34;:False,
+                    &#34;fonttbl&#34;:False,
+                    &#34;malformed&#34;:False}
+        # The de-encapsulating RTF reader SHOULD inspect no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. This means more than just control words.
+        decoded_tree = StripControlWords().transform(self.doc_tree)
+        first_ten_tokens = decoded_tree.children[:10]
+        operating_tokens = []
+        found_token = None
+        for token in first_ten_tokens:
+            if isinstance(token, Token):
+                operating_tokens.append(token)
+            else:
+                operating_tokens += list(token.scan_values(lambda t: t.type == &#39;CONTROLWORD&#39;))
+        log_validators(f&#34;Header tokens being evaluated: {operating_tokens}&#34;)
+
+        for token in operating_tokens:
+            cw_found,found_token = self.check_from_token(token=token, cw_found=cw_found)
+            if cw_found[&#39;from&#39;] is True and cw_found[&#34;malformed&#34;] is True:
+                raise MalformedEncapsulatedRtf(&#34;RTF file looks like is was supposed to be encapsulated HTML/TEXT but the headers are malformed. Turn on debugging to see specific information&#34;)
+            # Save content type token available for id-ing type of content later
+            if found_token is not None:
+                self.content_type_token = found_token
+
+        if cw_found[&#39;from&#39;] is False:
+            log.debug(&#34;FROMHTML/TEXT control word not found in first 10 RTF tokens. This is not an HTML/TEXT encapsulated RTF document.&#34;)
+            raise NotEncapsulatedRtf(&#34;FROMHTML/TEXT control word not found.&#34;)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.validate_charset"><code class="name flex">
+<span>def <span class="ident">validate_charset</span></span>(<span>self, fallback_to_default: bool = False) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Validate and return the RTF charset keyword from the RTF streams header.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>fallback_to_default</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Allows you to force the use of the default charset "\ansi" if one is not found.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>MalformedRtf</code></dt>
+<dd>RTF stream does not include charset control word.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The RTF charset keyword from the RTF streams header.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def validate_charset(self, fallback_to_default:bool =False) -&gt; str:
+        &#34;&#34;&#34;Validate and return the RTF charset keyword from the RTF streams header.
+
+Args:
+        fallback_to_default (bool): Allows you to force the use of the default charset &#34;\\ansi&#34; if one is not found.
+
+Raises:
+        MalformedRtf: RTF stream does not include charset control word.
+
+Returns:
+        The RTF charset keyword from the RTF streams header.
+&#34;&#34;&#34;
+        main_headers = self.get_header_control_words_before_first_group()
+
+        for token in main_headers:
+            if token in [&#34;\\ansi&#34;, &#34;\\mac&#34;, &#34;\\pc&#34;, &#34;\\pca&#34;]:
+                return token
+
+        log.debug(&#34;Acceptable charset not found as the second token in the RTF stream. The control word for the character set must precede any plain text or any table control words. So, if this stream doesn&#39;t have one it is malformed or corrupted.&#34;)
+        if fallback_to_default is False:
+            raise MalformedRtf(&#34;RTF stream does not include charset control word.&#34;)
+
+        log.warning(&#34;The fallback_to_default option on _get_charset is considered DANGEROUS if used on possibly malicious samples. Make sure you know what you are doing before using it.&#34;)
+        log.info(&#34;Attempting to decode RTF using the default charset ansi. This is not recommended and could have unforeseen consequences for the resulting file and your systems security.&#34;)
+        log.debug(&#34;You have a malformed RTF stream. Are you sure you really want to be parsing it? It might not just be corrupted. It could be maliciously constructed.&#34;)
+        return &#34;\\ansi&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.deencapsulate.DeEncapsulator.validate_encapsulation"><code class="name flex">
+<span>def <span class="ident">validate_encapsulation</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Runs simple tests to validate that the file in question is an rtf document which contains encapsulation.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def validate_encapsulation(self):
+    &#34;&#34;&#34;Runs simple tests to validate that the file in question is an rtf document which contains encapsulation.&#34;&#34;&#34;
+    self.validate_rtf_doc_header(self.doc_tree)
+    self.validate_charset()
+    self.validate_FROM_in_doc_header()
+    ansicpg = self.get_ansicpg_header()
+    if ansicpg is not None: # ansicpg is not manditory
+        validate_ansi_cpg(ansicpg.value)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="RTFDE" href="index.html">RTFDE</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="RTFDE.deencapsulate.DeEncapsulator" href="#RTFDE.deencapsulate.DeEncapsulator">DeEncapsulator</a></code></h4>
+<ul class="">
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.catch_common_validation_issues" href="#RTFDE.deencapsulate.DeEncapsulator.catch_common_validation_issues">catch_common_validation_issues</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.check_from_token" href="#RTFDE.deencapsulate.DeEncapsulator.check_from_token">check_from_token</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.deencapsulate" href="#RTFDE.deencapsulate.DeEncapsulator.deencapsulate">deencapsulate</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.get_ansicpg_header" href="#RTFDE.deencapsulate.DeEncapsulator.get_ansicpg_header">get_ansicpg_header</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.get_content_type" href="#RTFDE.deencapsulate.DeEncapsulator.get_content_type">get_content_type</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.get_doc_tree" href="#RTFDE.deencapsulate.DeEncapsulator.get_doc_tree">get_doc_tree</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.get_header_control_words_before_first_group" href="#RTFDE.deencapsulate.DeEncapsulator.get_header_control_words_before_first_group">get_header_control_words_before_first_group</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.parse_rtf" href="#RTFDE.deencapsulate.DeEncapsulator.parse_rtf">parse_rtf</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.set_content" href="#RTFDE.deencapsulate.DeEncapsulator.set_content">set_content</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.strip_htmlrtf_tokens" href="#RTFDE.deencapsulate.DeEncapsulator.strip_htmlrtf_tokens">strip_htmlrtf_tokens</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.validate_FROM_in_doc_header" href="#RTFDE.deencapsulate.DeEncapsulator.validate_FROM_in_doc_header">validate_FROM_in_doc_header</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.validate_charset" href="#RTFDE.deencapsulate.DeEncapsulator.validate_charset">validate_charset</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.validate_encapsulation" href="#RTFDE.deencapsulate.DeEncapsulator.validate_encapsulation">validate_encapsulation</a></code></li>
+<li><code><a title="RTFDE.deencapsulate.DeEncapsulator.validate_rtf_doc_header" href="#RTFDE.deencapsulate.DeEncapsulator.validate_rtf_doc_header">validate_rtf_doc_header</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/RTFDE/deencapsulate.html
+++ b/docs/RTFDE/deencapsulate.html
@@ -53,7 +53,7 @@ from RTFDE.transformers import StripNonVisibleRTFGroups
 from RTFDE.transformers import StripUnusedSpecialCharacters
 from RTFDE.utils import encode_escaped_control_chars
 from RTFDE.utils import log_validators, log_transformations
-from RTFDE.transformers import get_stripped_HTMLRTF_values, DeleteTokensFromTree
+from RTFDE.transformers import get_stripped_HTMLRTF_values, DeleteTokensFromTree, strip_binary_objects
 from RTFDE.grammar import make_concise_grammar
 from RTFDE.text_extraction import TextDecoder
 from RTFDE.text_extraction import validate_ansi_cpg
@@ -71,29 +71,30 @@ De-encapsulation enables previously encapsulated HTML and plain text content to 
 
 
 Parameters:
-    raw_rtf: (str): It&#39;s the raw RTF string.
+    raw_rtf: (bytes): It&#39;s the raw RTF file as bytes.
     grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
 
 Attributes:
-    content: The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
-    html: The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
-    text: The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+    content: (bytes) The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
+    html: (bytes) The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
+    text: (bytes) The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+    found_binary: List of dictionaries containing binary data extracted from the rtf file.
     content_type: The type of content encapsulated in .rtf data (html or text). Populated by the `get_content_type` function.
     full_tree: The full .rtf object parsed into an object Tree using the grammar. Populated by the `parse_rtf` function.
     doc_tree: The `document` portion of the .rtf full_tree object.
-    raw_rtf: The raw encapsulated .rtf data in string format.
+    raw_rtf: The raw encapsulated .rtf data in byte format.
     grammar: The Lark parsing grammer used to parse the .rtf data.
     content_type_token: The .rtf header token identifying the content type. (\\fromhtml1 OR \\fromtext)
     parser: The lark parser. Should not need to be manipulated directly. But, useful for debugging and saving the parsed object.
     &#34;&#34;&#34;
 
-    def __init__(self, raw_rtf:AnyStr, grammar: Union[str,None] = None):
+    def __init__(self, raw_rtf:bytes, grammar: Union[str,None] = None):
         &#34;&#34;&#34;Load in the Encapsulated test and setup the grammar used to parse the encapsulated RTF.
 
 NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.
 
 Parameters:
-        raw_rtf: (str): It&#39;s the raw RTF string.
+        raw_rtf: (bytes): It&#39;s the raw RTF string.
         grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
 
 Raises:
@@ -106,24 +107,18 @@ Raises:
 
         self.html: str
         self.text: str
-        self.simplified_rtf: AnyStr
+        self.found_binary: list
         self.full_tree: Tree
         self.doc_tree: Tree
         self.catch_common_validation_issues(raw_rtf)
         if isinstance(raw_rtf, bytes):
-            # Remove any null bytes at end of file.
-            raw_rtf = raw_rtf.rstrip(b&#39;\x00&#39;)
-            # Remove any windows newlines
-            raw_rtf = raw_rtf.replace(b&#39;\r\n&#39;,b&#39;\n&#39;)
-            raw_rtf = raw_rtf.replace(b&#39;\r&#39;,b&#39;\n&#39;)
-            self.raw_rtf: str = raw_rtf.decode()
-        elif isinstance(raw_rtf, str):
-            # Remove any windows newlines
-            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r\\n&#39;,r&#39;\\n&#39;)
-            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r&#39;,r&#39;\\n&#39;)
-            self.raw_rtf = raw_rtf
+            raw_rtf_bytes = raw_rtf
         else:
             raise TypeError(&#34;DeEncapssulator only accepts RTF files in string or byte-string formats&#34;)
+        raw_rtf_bytes = raw_rtf_bytes.rstrip(b&#39;\x00&#39;)
+        raw_rtf_bytes = raw_rtf_bytes.replace(b&#39;\r\n&#39;,b&#39;\n&#39;)
+        raw_rtf_bytes = raw_rtf_bytes.replace(b&#39;\r&#39;,b&#39;\n&#39;)
+        self.raw_rtf: bytes = raw_rtf_bytes
         if grammar is not None:
             self.grammar: str = grammar
         else:
@@ -134,13 +129,20 @@ Raises:
 
 Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The `content` property will store the content no matter what format it is in. The `html` and `text` properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)
         &#34;&#34;&#34;
-        escaped_rtf = encode_escaped_control_chars(self.raw_rtf)
+        stripped_data = strip_binary_objects(self.raw_rtf)
+        non_binary_rtf = stripped_data[0]
+        found_binary = stripped_data[1]
+        if len(found_binary) &gt; 0:
+            self.found_binary = found_binary
+            log.info(&#34;Binary data found and extracted from rtf file.&#34;)
+        escaped_rtf = encode_escaped_control_chars(non_binary_rtf)
         log_transformations(escaped_rtf)
         self.parse_rtf(escaped_rtf)
         Decoder = TextDecoder()
         Decoder.update_children(self.full_tree)
         self.get_doc_tree()
         self.validate_encapsulation()
+
         # remove htmlrtf escaped values
         htmlrtf_stripped = self.strip_htmlrtf_tokens()
         # Strips whitespace from control words
@@ -158,7 +160,7 @@ Once you have loaded in the raw rtf this function will set the properties contai
         self.content = cleaned_text
         self.set_content() # Populates self.html || self.text
 
-    def validate_charset(self, fallback_to_default:bool =False) -&gt; str:
+    def validate_charset(self, fallback_to_default:bool =False) -&gt; bytes:
         &#34;&#34;&#34;Validate and return the RTF charset keyword from the RTF streams header.
 
 Args:
@@ -173,7 +175,7 @@ Returns:
         main_headers = self.get_header_control_words_before_first_group()
 
         for token in main_headers:
-            if token in [&#34;\\ansi&#34;, &#34;\\mac&#34;, &#34;\\pc&#34;, &#34;\\pca&#34;]:
+            if token.value in [b&#39;\\ansi&#39;, b&#39;\\mac&#39;, b&#39;\\pc&#39;, b&#39;\\pca&#39;]:
                 return token
 
         log.debug(&#34;Acceptable charset not found as the second token in the RTF stream. The control word for the character set must precede any plain text or any table control words. So, if this stream doesn&#39;t have one it is malformed or corrupted.&#34;)
@@ -183,7 +185,7 @@ Returns:
         log.warning(&#34;The fallback_to_default option on _get_charset is considered DANGEROUS if used on possibly malicious samples. Make sure you know what you are doing before using it.&#34;)
         log.info(&#34;Attempting to decode RTF using the default charset ansi. This is not recommended and could have unforeseen consequences for the resulting file and your systems security.&#34;)
         log.debug(&#34;You have a malformed RTF stream. Are you sure you really want to be parsing it? It might not just be corrupted. It could be maliciously constructed.&#34;)
-        return &#34;\\ansi&#34;
+        return b&#34;\\ansi&#34;
 
     def set_content(self):
         &#34;&#34;&#34;Populate the html or text content based on the content type. Populates self.html and/or self.text variables.&#34;&#34;&#34;
@@ -214,9 +216,9 @@ Raises:
 &#34;&#34;&#34;
         if self.content_type_token is None:
             self.validate_FROM_in_doc_header()
-        elif self.content_type_token == &#39;\\fromhtml1&#39;:
+        elif self.content_type_token == b&#39;\\fromhtml1&#39;:
             return &#39;html&#39;
-        elif self.content_type_token == &#39;\\fromtext&#39;:
+        elif self.content_type_token == b&#39;\\fromtext&#39;:
             return &#34;text&#34;
 
         raise NotEncapsulatedRtf(&#34;Data is missing encapsulated content type header (the FROM header).&#34;)
@@ -238,7 +240,7 @@ Returns:
 &#34;&#34;&#34;
         headers = self.get_header_control_words_before_first_group()
         for item in headers:
-            if item.value.startswith(&#39;\\ansicpg&#39;):
+            if item.value.startswith(b&#39;\\ansicpg&#39;):
                 return item
         return None
 
@@ -254,6 +256,7 @@ Args:
         self.parser = Lark(self.grammar,
                            parser=&#39;lalr&#39;,
                            keep_all_tokens=True,
+                           use_bytes=True,
                            # debug=True,
                            propagate_positions=True)
         self.full_tree = self.parser.parse(rtf)
@@ -344,11 +347,11 @@ Returns:
         found_token: The content_type_token found in the header.
 
         &#34;&#34;&#34;
-        from_cws = [&#39;\\fromhtml1&#39;, &#39;\\fromtext&#39;]
+        from_cws = [b&#39;\\fromhtml1&#39;, b&#39;\\fromtext&#39;]
         # This control word MUST appear before the \fonttbl control word and after the \rtf1 control word, as specified in [MSFT-RTF].
-        rtf1_cw = &#34;\\rtf1&#34;
+        rtf1_cw = b&#34;\\rtf1&#34;
         found_token = None
-        fonttbl_cw = &#34;\\fonttbl&#34;
+        fonttbl_cw = b&#34;\\fonttbl&#34;
         if token.type == &#34;CONTROLWORD&#34;:
             if token.value.strip() in from_cws:
                 if cw_found[&#39;from&#39;] is True:
@@ -381,7 +384,7 @@ Raises:
         MalformedRtf: The .rtf headers do not include \\rtf1.
 &#34;&#34;&#34;
         first_token = doc_tree.children[0].value
-        if first_token != &#34;\\rtf1&#34;:
+        if first_token != b&#34;\\rtf1&#34;:
             log.debug(&#34;RTF stream does not contain valid valid RTF document heading. The file must start with \&#34;{\\rtf1\&#34;&#34;)
             log_validators(f&#34;First child object in document tree is: {first_token!r}&#34;)
             raise MalformedRtf(&#34;RTF stream does not start with {\\rtf1&#34;)
@@ -398,10 +401,10 @@ Raises:
         MalformedRtf: The data passed is not a correctly formatted .rtf string.
 &#34;&#34;&#34;
         if isinstance(raw_rtf, BufferedReader):
-            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts strings and byte-strings.&#34;)
+            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts byte objects.&#34;)
         if raw_rtf is None:
             raise TypeError(&#34;Data passed as raw RTF file is a null object `None` keyword.&#34;)
-        if raw_rtf[:8] == b&#34;=\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
+        if raw_rtf[:8] == b&#34;\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
             raise TypeError(&#34;Data passed is a full MSG object. You must extract the encapsulated RTF body first.&#34;)
         if raw_rtf in (b&#39;&#39;, &#39;&#39;):
             raise MalformedRtf(&#34;Data passed as raw RTF file is an empty string.&#34;)</code></pre>
@@ -418,22 +421,24 @@ Raises:
 <dl>
 <dt id="RTFDE.deencapsulate.DeEncapsulator"><code class="flex name class">
 <span>class <span class="ident">DeEncapsulator</span></span>
-<span>(</span><span>raw_rtf: ~AnyStr, grammar: Optional[str] = None)</span>
+<span>(</span><span>raw_rtf: bytes, grammar: Optional[str] = None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>De-Encapsulating RTF converter of HTML/TEXT found in .msg files.</p>
 <p>De-encapsulation enables previously encapsulated HTML and plain text content to be extracted and rendered as HTML and plain text instead of the encapsulating RTF content. After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.</p>
 <h2 id="parameters">Parameters</h2>
-<p>raw_rtf: (str): It's the raw RTF string.
+<p>raw_rtf: (bytes): It's the raw RTF file as bytes.
 grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. <a href="https://github.com/lark-parser/lark">https://github.com/lark-parser/lark</a> If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.</p>
 <h2 id="attributes">Attributes</h2>
 <dl>
 <dt><strong><code>content</code></strong></dt>
-<dd>The deencapsulated content no matter what format it is in. Populated by the <code>deencapsulate</code> function.</dd>
+<dd>(bytes) The deencapsulated content no matter what format it is in. Populated by the <code>deencapsulate</code> function.</dd>
 <dt><strong><code>html</code></strong></dt>
-<dd>The deencapsulated content IF it is HTML content. Populated by the <code>set_content</code> function.</dd>
+<dd>(bytes) The deencapsulated content IF it is HTML content. Populated by the <code>set_content</code> function.</dd>
 <dt><strong><code>text</code></strong></dt>
-<dd>The deencapsulated content IF it is plain text content. Populated by the <code>set_content</code> function.</dd>
+<dd>(bytes) The deencapsulated content IF it is plain text content. Populated by the <code>set_content</code> function.</dd>
+<dt><strong><code>found_binary</code></strong></dt>
+<dd>List of dictionaries containing binary data extracted from the rtf file.</dd>
 <dt><strong><code>content_type</code></strong></dt>
 <dd>The type of content encapsulated in .rtf data (html or text). Populated by the <code>get_content_type</code> function.</dd>
 <dt><strong><code>full_tree</code></strong></dt>
@@ -441,7 +446,7 @@ grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. 
 <dt><strong><code>doc_tree</code></strong></dt>
 <dd>The <code>document</code> portion of the .rtf full_tree object.</dd>
 <dt><strong><code>raw_rtf</code></strong></dt>
-<dd>The raw encapsulated .rtf data in string format.</dd>
+<dd>The raw encapsulated .rtf data in byte format.</dd>
 <dt><strong><code>grammar</code></strong></dt>
 <dd>The Lark parsing grammer used to parse the .rtf data.</dd>
 <dt><strong><code>content_type_token</code></strong></dt>
@@ -452,7 +457,7 @@ grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. 
 <p>Load in the Encapsulated test and setup the grammar used to parse the encapsulated RTF.</p>
 <p>NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.</p>
 <h2 id="parameters_1">Parameters</h2>
-<p>raw_rtf: (str): It's the raw RTF string.
+<p>raw_rtf: (bytes): It's the raw RTF string.
 grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. <a href="https://github.com/lark-parser/lark">https://github.com/lark-parser/lark</a> If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.</p>
 <h2 id="raises">Raises</h2>
 <dl>
@@ -470,29 +475,30 @@ De-encapsulation enables previously encapsulated HTML and plain text content to 
 
 
 Parameters:
-    raw_rtf: (str): It&#39;s the raw RTF string.
+    raw_rtf: (bytes): It&#39;s the raw RTF file as bytes.
     grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
 
 Attributes:
-    content: The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
-    html: The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
-    text: The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+    content: (bytes) The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
+    html: (bytes) The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
+    text: (bytes) The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+    found_binary: List of dictionaries containing binary data extracted from the rtf file.
     content_type: The type of content encapsulated in .rtf data (html or text). Populated by the `get_content_type` function.
     full_tree: The full .rtf object parsed into an object Tree using the grammar. Populated by the `parse_rtf` function.
     doc_tree: The `document` portion of the .rtf full_tree object.
-    raw_rtf: The raw encapsulated .rtf data in string format.
+    raw_rtf: The raw encapsulated .rtf data in byte format.
     grammar: The Lark parsing grammer used to parse the .rtf data.
     content_type_token: The .rtf header token identifying the content type. (\\fromhtml1 OR \\fromtext)
     parser: The lark parser. Should not need to be manipulated directly. But, useful for debugging and saving the parsed object.
     &#34;&#34;&#34;
 
-    def __init__(self, raw_rtf:AnyStr, grammar: Union[str,None] = None):
+    def __init__(self, raw_rtf:bytes, grammar: Union[str,None] = None):
         &#34;&#34;&#34;Load in the Encapsulated test and setup the grammar used to parse the encapsulated RTF.
 
 NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.
 
 Parameters:
-        raw_rtf: (str): It&#39;s the raw RTF string.
+        raw_rtf: (bytes): It&#39;s the raw RTF string.
         grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
 
 Raises:
@@ -505,24 +511,18 @@ Raises:
 
         self.html: str
         self.text: str
-        self.simplified_rtf: AnyStr
+        self.found_binary: list
         self.full_tree: Tree
         self.doc_tree: Tree
         self.catch_common_validation_issues(raw_rtf)
         if isinstance(raw_rtf, bytes):
-            # Remove any null bytes at end of file.
-            raw_rtf = raw_rtf.rstrip(b&#39;\x00&#39;)
-            # Remove any windows newlines
-            raw_rtf = raw_rtf.replace(b&#39;\r\n&#39;,b&#39;\n&#39;)
-            raw_rtf = raw_rtf.replace(b&#39;\r&#39;,b&#39;\n&#39;)
-            self.raw_rtf: str = raw_rtf.decode()
-        elif isinstance(raw_rtf, str):
-            # Remove any windows newlines
-            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r\\n&#39;,r&#39;\\n&#39;)
-            self.raw_rtf = self.raw_rtf.replace(r&#39;\\r&#39;,r&#39;\\n&#39;)
-            self.raw_rtf = raw_rtf
+            raw_rtf_bytes = raw_rtf
         else:
             raise TypeError(&#34;DeEncapssulator only accepts RTF files in string or byte-string formats&#34;)
+        raw_rtf_bytes = raw_rtf_bytes.rstrip(b&#39;\x00&#39;)
+        raw_rtf_bytes = raw_rtf_bytes.replace(b&#39;\r\n&#39;,b&#39;\n&#39;)
+        raw_rtf_bytes = raw_rtf_bytes.replace(b&#39;\r&#39;,b&#39;\n&#39;)
+        self.raw_rtf: bytes = raw_rtf_bytes
         if grammar is not None:
             self.grammar: str = grammar
         else:
@@ -533,13 +533,20 @@ Raises:
 
 Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The `content` property will store the content no matter what format it is in. The `html` and `text` properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)
         &#34;&#34;&#34;
-        escaped_rtf = encode_escaped_control_chars(self.raw_rtf)
+        stripped_data = strip_binary_objects(self.raw_rtf)
+        non_binary_rtf = stripped_data[0]
+        found_binary = stripped_data[1]
+        if len(found_binary) &gt; 0:
+            self.found_binary = found_binary
+            log.info(&#34;Binary data found and extracted from rtf file.&#34;)
+        escaped_rtf = encode_escaped_control_chars(non_binary_rtf)
         log_transformations(escaped_rtf)
         self.parse_rtf(escaped_rtf)
         Decoder = TextDecoder()
         Decoder.update_children(self.full_tree)
         self.get_doc_tree()
         self.validate_encapsulation()
+
         # remove htmlrtf escaped values
         htmlrtf_stripped = self.strip_htmlrtf_tokens()
         # Strips whitespace from control words
@@ -557,7 +564,7 @@ Once you have loaded in the raw rtf this function will set the properties contai
         self.content = cleaned_text
         self.set_content() # Populates self.html || self.text
 
-    def validate_charset(self, fallback_to_default:bool =False) -&gt; str:
+    def validate_charset(self, fallback_to_default:bool =False) -&gt; bytes:
         &#34;&#34;&#34;Validate and return the RTF charset keyword from the RTF streams header.
 
 Args:
@@ -572,7 +579,7 @@ Returns:
         main_headers = self.get_header_control_words_before_first_group()
 
         for token in main_headers:
-            if token in [&#34;\\ansi&#34;, &#34;\\mac&#34;, &#34;\\pc&#34;, &#34;\\pca&#34;]:
+            if token.value in [b&#39;\\ansi&#39;, b&#39;\\mac&#39;, b&#39;\\pc&#39;, b&#39;\\pca&#39;]:
                 return token
 
         log.debug(&#34;Acceptable charset not found as the second token in the RTF stream. The control word for the character set must precede any plain text or any table control words. So, if this stream doesn&#39;t have one it is malformed or corrupted.&#34;)
@@ -582,7 +589,7 @@ Returns:
         log.warning(&#34;The fallback_to_default option on _get_charset is considered DANGEROUS if used on possibly malicious samples. Make sure you know what you are doing before using it.&#34;)
         log.info(&#34;Attempting to decode RTF using the default charset ansi. This is not recommended and could have unforeseen consequences for the resulting file and your systems security.&#34;)
         log.debug(&#34;You have a malformed RTF stream. Are you sure you really want to be parsing it? It might not just be corrupted. It could be maliciously constructed.&#34;)
-        return &#34;\\ansi&#34;
+        return b&#34;\\ansi&#34;
 
     def set_content(self):
         &#34;&#34;&#34;Populate the html or text content based on the content type. Populates self.html and/or self.text variables.&#34;&#34;&#34;
@@ -613,9 +620,9 @@ Raises:
 &#34;&#34;&#34;
         if self.content_type_token is None:
             self.validate_FROM_in_doc_header()
-        elif self.content_type_token == &#39;\\fromhtml1&#39;:
+        elif self.content_type_token == b&#39;\\fromhtml1&#39;:
             return &#39;html&#39;
-        elif self.content_type_token == &#39;\\fromtext&#39;:
+        elif self.content_type_token == b&#39;\\fromtext&#39;:
             return &#34;text&#34;
 
         raise NotEncapsulatedRtf(&#34;Data is missing encapsulated content type header (the FROM header).&#34;)
@@ -637,7 +644,7 @@ Returns:
 &#34;&#34;&#34;
         headers = self.get_header_control_words_before_first_group()
         for item in headers:
-            if item.value.startswith(&#39;\\ansicpg&#39;):
+            if item.value.startswith(b&#39;\\ansicpg&#39;):
                 return item
         return None
 
@@ -653,6 +660,7 @@ Args:
         self.parser = Lark(self.grammar,
                            parser=&#39;lalr&#39;,
                            keep_all_tokens=True,
+                           use_bytes=True,
                            # debug=True,
                            propagate_positions=True)
         self.full_tree = self.parser.parse(rtf)
@@ -743,11 +751,11 @@ Returns:
         found_token: The content_type_token found in the header.
 
         &#34;&#34;&#34;
-        from_cws = [&#39;\\fromhtml1&#39;, &#39;\\fromtext&#39;]
+        from_cws = [b&#39;\\fromhtml1&#39;, b&#39;\\fromtext&#39;]
         # This control word MUST appear before the \fonttbl control word and after the \rtf1 control word, as specified in [MSFT-RTF].
-        rtf1_cw = &#34;\\rtf1&#34;
+        rtf1_cw = b&#34;\\rtf1&#34;
         found_token = None
-        fonttbl_cw = &#34;\\fonttbl&#34;
+        fonttbl_cw = b&#34;\\fonttbl&#34;
         if token.type == &#34;CONTROLWORD&#34;:
             if token.value.strip() in from_cws:
                 if cw_found[&#39;from&#39;] is True:
@@ -780,7 +788,7 @@ Raises:
         MalformedRtf: The .rtf headers do not include \\rtf1.
 &#34;&#34;&#34;
         first_token = doc_tree.children[0].value
-        if first_token != &#34;\\rtf1&#34;:
+        if first_token != b&#34;\\rtf1&#34;:
             log.debug(&#34;RTF stream does not contain valid valid RTF document heading. The file must start with \&#34;{\\rtf1\&#34;&#34;)
             log_validators(f&#34;First child object in document tree is: {first_token!r}&#34;)
             raise MalformedRtf(&#34;RTF stream does not start with {\\rtf1&#34;)
@@ -797,10 +805,10 @@ Raises:
         MalformedRtf: The data passed is not a correctly formatted .rtf string.
 &#34;&#34;&#34;
         if isinstance(raw_rtf, BufferedReader):
-            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts strings and byte-strings.&#34;)
+            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts byte objects.&#34;)
         if raw_rtf is None:
             raise TypeError(&#34;Data passed as raw RTF file is a null object `None` keyword.&#34;)
-        if raw_rtf[:8] == b&#34;=\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
+        if raw_rtf[:8] == b&#34;\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
             raise TypeError(&#34;Data passed is a full MSG object. You must extract the encapsulated RTF body first.&#34;)
         if raw_rtf in (b&#39;&#39;, &#39;&#39;):
             raise MalformedRtf(&#34;Data passed as raw RTF file is an empty string.&#34;)</code></pre>
@@ -840,10 +848,10 @@ Raises:
         MalformedRtf: The data passed is not a correctly formatted .rtf string.
 &#34;&#34;&#34;
         if isinstance(raw_rtf, BufferedReader):
-            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts strings and byte-strings.&#34;)
+            raise TypeError(&#34;Data passed as file pointer. DeEncapsulator only accepts byte objects.&#34;)
         if raw_rtf is None:
             raise TypeError(&#34;Data passed as raw RTF file is a null object `None` keyword.&#34;)
-        if raw_rtf[:8] == b&#34;=\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
+        if raw_rtf[:8] == b&#34;\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1&#34;:
             raise TypeError(&#34;Data passed is a full MSG object. You must extract the encapsulated RTF body first.&#34;)
         if raw_rtf in (b&#39;&#39;, &#39;&#39;):
             raise MalformedRtf(&#34;Data passed as raw RTF file is an empty string.&#34;)</code></pre>
@@ -889,11 +897,11 @@ Returns:
         found_token: The content_type_token found in the header.
 
         &#34;&#34;&#34;
-        from_cws = [&#39;\\fromhtml1&#39;, &#39;\\fromtext&#39;]
+        from_cws = [b&#39;\\fromhtml1&#39;, b&#39;\\fromtext&#39;]
         # This control word MUST appear before the \fonttbl control word and after the \rtf1 control word, as specified in [MSFT-RTF].
-        rtf1_cw = &#34;\\rtf1&#34;
+        rtf1_cw = b&#34;\\rtf1&#34;
         found_token = None
-        fonttbl_cw = &#34;\\fonttbl&#34;
+        fonttbl_cw = b&#34;\\fonttbl&#34;
         if token.type == &#34;CONTROLWORD&#34;:
             if token.value.strip() in from_cws:
                 if cw_found[&#39;from&#39;] is True:
@@ -942,7 +950,7 @@ Raises:
         MalformedRtf: The .rtf headers do not include \\rtf1.
 &#34;&#34;&#34;
         first_token = doc_tree.children[0].value
-        if first_token != &#34;\\rtf1&#34;:
+        if first_token != b&#34;\\rtf1&#34;:
             log.debug(&#34;RTF stream does not contain valid valid RTF document heading. The file must start with \&#34;{\\rtf1\&#34;&#34;)
             log_validators(f&#34;First child object in document tree is: {first_token!r}&#34;)
             raise MalformedRtf(&#34;RTF stream does not start with {\\rtf1&#34;)</code></pre>
@@ -966,13 +974,20 @@ Raises:
 
 Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The `content` property will store the content no matter what format it is in. The `html` and `text` properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)
         &#34;&#34;&#34;
-        escaped_rtf = encode_escaped_control_chars(self.raw_rtf)
+        stripped_data = strip_binary_objects(self.raw_rtf)
+        non_binary_rtf = stripped_data[0]
+        found_binary = stripped_data[1]
+        if len(found_binary) &gt; 0:
+            self.found_binary = found_binary
+            log.info(&#34;Binary data found and extracted from rtf file.&#34;)
+        escaped_rtf = encode_escaped_control_chars(non_binary_rtf)
         log_transformations(escaped_rtf)
         self.parse_rtf(escaped_rtf)
         Decoder = TextDecoder()
         Decoder.update_children(self.full_tree)
         self.get_doc_tree()
         self.validate_encapsulation()
+
         # remove htmlrtf escaped values
         htmlrtf_stripped = self.strip_htmlrtf_tokens()
         # Strips whitespace from control words
@@ -1010,7 +1025,7 @@ Returns:
 &#34;&#34;&#34;
         headers = self.get_header_control_words_before_first_group()
         for item in headers:
-            if item.value.startswith(&#39;\\ansicpg&#39;):
+            if item.value.startswith(b&#39;\\ansicpg&#39;):
                 return item
         return None</code></pre>
 </details>
@@ -1040,9 +1055,9 @@ Raises:
 &#34;&#34;&#34;
         if self.content_type_token is None:
             self.validate_FROM_in_doc_header()
-        elif self.content_type_token == &#39;\\fromhtml1&#39;:
+        elif self.content_type_token == b&#39;\\fromhtml1&#39;:
             return &#39;html&#39;
-        elif self.content_type_token == &#39;\\fromtext&#39;:
+        elif self.content_type_token == b&#39;\\fromtext&#39;:
             return &#34;text&#34;
 
         raise NotEncapsulatedRtf(&#34;Data is missing encapsulated content type header (the FROM header).&#34;)</code></pre>
@@ -1129,6 +1144,7 @@ Args:
         self.parser = Lark(self.grammar,
                            parser=&#39;lalr&#39;,
                            keep_all_tokens=True,
+                           use_bytes=True,
                            # debug=True,
                            propagate_positions=True)
         self.full_tree = self.parser.parse(rtf)
@@ -1234,7 +1250,7 @@ Raises:
 </details>
 </dd>
 <dt id="RTFDE.deencapsulate.DeEncapsulator.validate_charset"><code class="name flex">
-<span>def <span class="ident">validate_charset</span></span>(<span>self, fallback_to_default: bool = False) ‑> str</span>
+<span>def <span class="ident">validate_charset</span></span>(<span>self, fallback_to_default: bool = False) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Validate and return the RTF charset keyword from the RTF streams header.</p>
@@ -1254,7 +1270,7 @@ Raises:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">    def validate_charset(self, fallback_to_default:bool =False) -&gt; str:
+<pre><code class="python">    def validate_charset(self, fallback_to_default:bool =False) -&gt; bytes:
         &#34;&#34;&#34;Validate and return the RTF charset keyword from the RTF streams header.
 
 Args:
@@ -1269,7 +1285,7 @@ Returns:
         main_headers = self.get_header_control_words_before_first_group()
 
         for token in main_headers:
-            if token in [&#34;\\ansi&#34;, &#34;\\mac&#34;, &#34;\\pc&#34;, &#34;\\pca&#34;]:
+            if token.value in [b&#39;\\ansi&#39;, b&#39;\\mac&#39;, b&#39;\\pc&#39;, b&#39;\\pca&#39;]:
                 return token
 
         log.debug(&#34;Acceptable charset not found as the second token in the RTF stream. The control word for the character set must precede any plain text or any table control words. So, if this stream doesn&#39;t have one it is malformed or corrupted.&#34;)
@@ -1279,7 +1295,7 @@ Returns:
         log.warning(&#34;The fallback_to_default option on _get_charset is considered DANGEROUS if used on possibly malicious samples. Make sure you know what you are doing before using it.&#34;)
         log.info(&#34;Attempting to decode RTF using the default charset ansi. This is not recommended and could have unforeseen consequences for the resulting file and your systems security.&#34;)
         log.debug(&#34;You have a malformed RTF stream. Are you sure you really want to be parsing it? It might not just be corrupted. It could be maliciously constructed.&#34;)
-        return &#34;\\ansi&#34;</code></pre>
+        return b&#34;\\ansi&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.deencapsulate.DeEncapsulator.validate_encapsulation"><code class="name flex">

--- a/docs/RTFDE/deencapsulate.md
+++ b/docs/RTFDE/deencapsulate.md
@@ -4,24 +4,25 @@ Module RTFDE.deencapsulate
 Classes
 -------
 
-`DeEncapsulator(raw_rtf: ~AnyStr, grammar: Optional[str] = None)`
+`DeEncapsulator(raw_rtf: bytes, grammar: Optional[str] = None)`
 :   De-Encapsulating RTF converter of HTML/TEXT found in .msg files.
     
     De-encapsulation enables previously encapsulated HTML and plain text content to be extracted and rendered as HTML and plain text instead of the encapsulating RTF content. After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.
     
     
     Parameters:
-        raw_rtf: (str): It's the raw RTF string.
+        raw_rtf: (bytes): It's the raw RTF file as bytes.
         grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
     
     Attributes:
-        content: The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
-        html: The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
-        text: The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+        content: (bytes) The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
+        html: (bytes) The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
+        text: (bytes) The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+        found_binary: List of dictionaries containing binary data extracted from the rtf file.
         content_type: The type of content encapsulated in .rtf data (html or text). Populated by the `get_content_type` function.
         full_tree: The full .rtf object parsed into an object Tree using the grammar. Populated by the `parse_rtf` function.
         doc_tree: The `document` portion of the .rtf full_tree object.
-        raw_rtf: The raw encapsulated .rtf data in string format.
+        raw_rtf: The raw encapsulated .rtf data in byte format.
         grammar: The Lark parsing grammer used to parse the .rtf data.
         content_type_token: The .rtf header token identifying the content type. (\fromhtml1 OR \fromtext)
         parser: The lark parser. Should not need to be manipulated directly. But, useful for debugging and saving the parsed object.
@@ -32,7 +33,7 @@ Classes
     NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.
     
     Parameters:
-            raw_rtf: (str): It's the raw RTF string.
+            raw_rtf: (bytes): It's the raw RTF string.
             grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
     
     Raises:
@@ -131,7 +132,7 @@ Classes
                 MalformedEncapsulatedRtf: The .rtf headers are malformed.
                 NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
 
-    `validate_charset(self, fallback_to_default: bool = False) ‑> str`
+    `validate_charset(self, fallback_to_default: bool = False) ‑> bytes`
     :   Validate and return the RTF charset keyword from the RTF streams header.
         
         Args:

--- a/docs/RTFDE/deencapsulate.md
+++ b/docs/RTFDE/deencapsulate.md
@@ -1,0 +1,147 @@
+Module RTFDE.deencapsulate
+==========================
+
+Classes
+-------
+
+`DeEncapsulator(raw_rtf: ~AnyStr, grammar: Optional[str] = None)`
+:   De-Encapsulating RTF converter of HTML/TEXT found in .msg files.
+    
+    De-encapsulation enables previously encapsulated HTML and plain text content to be extracted and rendered as HTML and plain text instead of the encapsulating RTF content. After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.
+    
+    
+    Parameters:
+        raw_rtf: (str): It's the raw RTF string.
+        grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
+    
+    Attributes:
+        content: The deencapsulated content no matter what format it is in. Populated by the `deencapsulate` function.
+        html: The deencapsulated content IF it is HTML content. Populated by the `set_content` function.
+        text: The deencapsulated content IF it is plain text content. Populated by the `set_content` function.
+        content_type: The type of content encapsulated in .rtf data (html or text). Populated by the `get_content_type` function.
+        full_tree: The full .rtf object parsed into an object Tree using the grammar. Populated by the `parse_rtf` function.
+        doc_tree: The `document` portion of the .rtf full_tree object.
+        raw_rtf: The raw encapsulated .rtf data in string format.
+        grammar: The Lark parsing grammer used to parse the .rtf data.
+        content_type_token: The .rtf header token identifying the content type. (\fromhtml1 OR \fromtext)
+        parser: The lark parser. Should not need to be manipulated directly. But, useful for debugging and saving the parsed object.
+        
+    
+    Load in the Encapsulated test and setup the grammar used to parse the encapsulated RTF.
+    
+    NOTE: This does not do the parsing in the init so that you can initiate the object and do the parsing step by step.
+    
+    Parameters:
+            raw_rtf: (str): It's the raw RTF string.
+            grammar: (str): OPTIONAL - Lark parsing grammar which defines the RTF language. https://github.com/lark-parser/lark If you think my grammar is shoddy this is your chance to test out a better one and make a pull request.
+    
+    Raises:
+            TypeError: The raw_rtf data passed is not the correct type of data (string/byte string).
+
+    ### Static methods
+
+    `catch_common_validation_issues(raw_rtf: ~AnyStr)`
+    :   Checks for likely common valid input mistakes that may occur when folks try to use this library and raises exceptions to try and help identify them.
+        
+        Args:
+                raw_rtf: A raw .rtf string or byte-string.
+        
+        Raises:
+                TypeError: The data passed is the wrong type of data.
+                MalformedRtf: The data passed is not a correctly formatted .rtf string.
+
+    `check_from_token(token: lark.lexer.Token, cw_found: dict) ‑> Tuple[Dict, Optional[None]]`
+    :   Checks if fromhtml1 or fromtext tokens are in the proper place in the header based on the state passed to it by the validate_FROM_in_doc_header function.
+        
+        Args:
+                token: The token to check for in the cw_found state dictionary.
+                cw_found: The state dictionary which is used to track the position of the from token within the header.
+        
+                `cw_found = {"rtf1":<BOOL>, "from":<BOOL>, "fonttbl":<BOOL>, "malformed":<BOOL>}`
+        
+        
+        Returns:
+                cw_found: Updated state dictionary
+                found_token: The content_type_token found in the header.
+
+    `validate_rtf_doc_header(doc_tree: lark.tree.Tree)`
+    :   Check if doc starts with a valid RTF header `\rtf1`.
+        
+                "Before the de-encapsulating RTF reader tries to recognize the encapsulation, the reader SHOULD ensure that the document has a valid RTF document heading according to [MSFT-RTF] (that is, it starts with the character sequence "{\rtf1")." - MS-OXRTFEX
+        
+        Raises:
+                MalformedRtf: The .rtf headers do not include \rtf1.
+
+    ### Methods
+
+    `deencapsulate(self)`
+    :   De-encapsulate the RTF content loaded into the De-Encapsulator.
+        
+        Once you have loaded in the raw rtf this function will set the properties containing the encapsulated content. The `content` property will store the content no matter what format it is in. The `html` and `text` properties will be populated based on the type of content that is extracted. (self.html will be populated if it is html and self.text if it is plain text.)
+
+    `get_ansicpg_header(self) ‑> Optional[lark.lexer.Token]`
+    :   Extract the ansicpg control word from the .rtf header.
+        
+        Returns:
+                A lark CONTROLWORD Token with the `\ansicpg` value. Returns None if the `\ansicpg` control word is not included as this is only required if there is Unicode which needs to be converted to ANSI within a .rtf file.
+
+    `get_content_type(self)`
+    :   Provide the type of content encapsulated in RTF.
+        
+        NOTE: This function will only work after the header validation has completed. Header validation also extracts the content type of the encapsulated data.
+        
+        Raises:
+                NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+
+    `get_doc_tree(self)`
+    :   Extract the document portion of the .rtf full_tree object. Populates the classes doc_tree attribute.
+        
+        Raises:
+                ValueError: The .rtf document object is missing or mis-located in the .rtf's full_tree object.
+
+    `get_header_control_words_before_first_group(self) ‑> list`
+    :   Extracts all the control words in the first 20 tokens of the document or all the tokens which occur before the first group (whichever comes first.)
+        
+        This is used to extract initial header values for validation functions.
+        
+        Returns:
+                A list containing the header tokens in the .rtf data.
+
+    `parse_rtf(self, rtf: str)`
+    :   Parse RTF file's header and document and extract the objects within the RTF into a Tree. Populates the self.full_tree attribute.
+        
+        Args:
+                rtf: The .rtf string to parse with the projects lark grammar.
+
+    `set_content(self)`
+    :   Populate the html or text content based on the content type. Populates self.html and/or self.text variables.
+
+    `strip_htmlrtf_tokens(self) ‑> lark.tree.Tree`
+    :   Strip tokens from with htmlrtf regions of the doc_tree as they were not part of the original HTML content.
+        
+        Returns:
+                .rtf doc_tree stripped of all non-original tokens.
+
+    `validate_FROM_in_doc_header(self)`
+    :   Inspect the header to identify what type of content (html/plain text) is encapsulated within the document.
+        
+        NOTE: The de-encapsulating RTF reader inspects no more than the first 10 RTF tokens (that is, begin group marks and control words) in the input RTF document, in sequence, starting from the beginning of the RTF document. If one of the control words is the FROMHTML control word, the de-encapsulating RTF reader will conclude that the RTF document contains an encapsulated HTML document and stop further inspection. If one of the control words is the FROMTEXT control word, the de-encapsulating RTF reader concludes that the RTF document was produced from a plain text document and stops further inspection. - MS-OXRTFEX
+        
+        Raises:
+                MalformedEncapsulatedRtf: The .rtf headers are malformed.
+                NotEncapsulatedRtf: The .rtf object is missing an encapsulated content type header. Which means that it is likely just a regular .rtf file.
+
+    `validate_charset(self, fallback_to_default: bool = False) ‑> str`
+    :   Validate and return the RTF charset keyword from the RTF streams header.
+        
+        Args:
+                fallback_to_default (bool): Allows you to force the use of the default charset "\ansi" if one is not found.
+        
+        Raises:
+                MalformedRtf: RTF stream does not include charset control word.
+        
+        Returns:
+                The RTF charset keyword from the RTF streams header.
+
+    `validate_encapsulation(self)`
+    :   Runs simple tests to validate that the file in question is an rtf document which contains encapsulation.

--- a/docs/RTFDE/exceptions.html
+++ b/docs/RTFDE/exceptions.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>RTFDE.exceptions API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>RTFDE.exceptions</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2020 seamus tuohy, &lt;code@seamustuohy.com&gt;
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+class UnsupportedRTFFormat(Exception):
+    &#34;&#34;&#34;An exception which signifies that the file might be a totally valid RTF encapsulation. But, that it is unsupported at this time.&#34;&#34;&#34;
+
+class NotEncapsulatedRtf(TypeError):
+    &#34;&#34;&#34;An exception which signifies that the data being provided in not a valid RTF encapsulation.
+
+    You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn&#39;t follow the spec so the encapsulation is incorrect. We&#39;ll give more information in the error message, but we&#39;re not going to try to de-encapsulate it.
+    &#34;&#34;&#34;
+
+class MalformedEncapsulatedRtf(TypeError):
+    &#34;&#34;&#34;An exception which signifies that the data being provided in not a valid RTF encapsulation.
+
+    You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn&#39;t follow the spec so the encapsulation is incorrect. We&#39;ll give more information in the error message, but we&#39;re not going to try to de-encapsulate it.
+    &#34;&#34;&#34;
+
+class MalformedRtf(TypeError):
+    &#34;&#34;&#34;An exception which signifies that the data being provided in not a valid RTF.
+
+    You might have passed us a new variation of RTF lazily created by someone who only read the spec in passing; it&#39;s possibly some polyglot file; a RTF file that is intended to be malicious; or even somthing that only looks like RTF in passing. We&#39;ll give more information in the error message, but we&#39;re not going to try to de-encapsulate it.
+    &#34;&#34;&#34;</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="RTFDE.exceptions.MalformedEncapsulatedRtf"><code class="flex name class">
+<span>class <span class="ident">MalformedEncapsulatedRtf</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An exception which signifies that the data being provided in not a valid RTF encapsulation.</p>
+<p>You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn't follow the spec so the encapsulation is incorrect. We'll give more information in the error message, but we're not going to try to de-encapsulate it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MalformedEncapsulatedRtf(TypeError):
+    &#34;&#34;&#34;An exception which signifies that the data being provided in not a valid RTF encapsulation.
+
+    You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn&#39;t follow the spec so the encapsulation is incorrect. We&#39;ll give more information in the error message, but we&#39;re not going to try to de-encapsulate it.
+    &#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.TypeError</li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="RTFDE.exceptions.MalformedRtf"><code class="flex name class">
+<span>class <span class="ident">MalformedRtf</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An exception which signifies that the data being provided in not a valid RTF.</p>
+<p>You might have passed us a new variation of RTF lazily created by someone who only read the spec in passing; it's possibly some polyglot file; a RTF file that is intended to be malicious; or even somthing that only looks like RTF in passing. We'll give more information in the error message, but we're not going to try to de-encapsulate it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MalformedRtf(TypeError):
+    &#34;&#34;&#34;An exception which signifies that the data being provided in not a valid RTF.
+
+    You might have passed us a new variation of RTF lazily created by someone who only read the spec in passing; it&#39;s possibly some polyglot file; a RTF file that is intended to be malicious; or even somthing that only looks like RTF in passing. We&#39;ll give more information in the error message, but we&#39;re not going to try to de-encapsulate it.
+    &#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.TypeError</li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="RTFDE.exceptions.NotEncapsulatedRtf"><code class="flex name class">
+<span>class <span class="ident">NotEncapsulatedRtf</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An exception which signifies that the data being provided in not a valid RTF encapsulation.</p>
+<p>You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn't follow the spec so the encapsulation is incorrect. We'll give more information in the error message, but we're not going to try to de-encapsulate it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NotEncapsulatedRtf(TypeError):
+    &#34;&#34;&#34;An exception which signifies that the data being provided in not a valid RTF encapsulation.
+
+    You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn&#39;t follow the spec so the encapsulation is incorrect. We&#39;ll give more information in the error message, but we&#39;re not going to try to de-encapsulate it.
+    &#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.TypeError</li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="RTFDE.exceptions.UnsupportedRTFFormat"><code class="flex name class">
+<span>class <span class="ident">UnsupportedRTFFormat</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An exception which signifies that the file might be a totally valid RTF encapsulation. But, that it is unsupported at this time.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class UnsupportedRTFFormat(Exception):
+    &#34;&#34;&#34;An exception which signifies that the file might be a totally valid RTF encapsulation. But, that it is unsupported at this time.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="RTFDE" href="index.html">RTFDE</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="RTFDE.exceptions.MalformedEncapsulatedRtf" href="#RTFDE.exceptions.MalformedEncapsulatedRtf">MalformedEncapsulatedRtf</a></code></h4>
+</li>
+<li>
+<h4><code><a title="RTFDE.exceptions.MalformedRtf" href="#RTFDE.exceptions.MalformedRtf">MalformedRtf</a></code></h4>
+</li>
+<li>
+<h4><code><a title="RTFDE.exceptions.NotEncapsulatedRtf" href="#RTFDE.exceptions.NotEncapsulatedRtf">NotEncapsulatedRtf</a></code></h4>
+</li>
+<li>
+<h4><code><a title="RTFDE.exceptions.UnsupportedRTFFormat" href="#RTFDE.exceptions.UnsupportedRTFFormat">UnsupportedRTFFormat</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/RTFDE/exceptions.md
+++ b/docs/RTFDE/exceptions.md
@@ -1,0 +1,46 @@
+Module RTFDE.exceptions
+=======================
+
+Classes
+-------
+
+`MalformedEncapsulatedRtf(*args, **kwargs)`
+:   An exception which signifies that the data being provided in not a valid RTF encapsulation.
+    
+    You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn't follow the spec so the encapsulation is incorrect. We'll give more information in the error message, but we're not going to try to de-encapsulate it.
+
+    ### Ancestors (in MRO)
+
+    * builtins.TypeError
+    * builtins.Exception
+    * builtins.BaseException
+
+`MalformedRtf(*args, **kwargs)`
+:   An exception which signifies that the data being provided in not a valid RTF.
+    
+    You might have passed us a new variation of RTF lazily created by someone who only read the spec in passing; it's possibly some polyglot file; a RTF file that is intended to be malicious; or even somthing that only looks like RTF in passing. We'll give more information in the error message, but we're not going to try to de-encapsulate it.
+
+    ### Ancestors (in MRO)
+
+    * builtins.TypeError
+    * builtins.Exception
+    * builtins.BaseException
+
+`NotEncapsulatedRtf(*args, **kwargs)`
+:   An exception which signifies that the data being provided in not a valid RTF encapsulation.
+    
+    You might have passed us a RTF file with no HTML/RTF encapsulation or it may simply be that the tool which did the encapsulation didn't follow the spec so the encapsulation is incorrect. We'll give more information in the error message, but we're not going to try to de-encapsulate it.
+
+    ### Ancestors (in MRO)
+
+    * builtins.TypeError
+    * builtins.Exception
+    * builtins.BaseException
+
+`UnsupportedRTFFormat(*args, **kwargs)`
+:   An exception which signifies that the file might be a totally valid RTF encapsulation. But, that it is unsupported at this time.
+
+    ### Ancestors (in MRO)
+
+    * builtins.Exception
+    * builtins.BaseException

--- a/docs/RTFDE/grammar.html
+++ b/docs/RTFDE/grammar.html
@@ -1,0 +1,598 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>RTFDE.grammar API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>RTFDE.grammar</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2020 seamus tuohy, &lt;code@seamustuohy.com&gt;
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+
+# TODO: Remove
+HTMLRTF_GRAMMAR = &#34;&#34;&#34;
+start : obj+
+obj : HTMLRTF | OTHER | WS
+%import common.DIGIT
+%import common.LETTER
+%import common.WS
+_SPACE_DELETE : &#34; &#34;
+HTMLRTF : &#34;\\htmlrtf&#34; DIGIT~0..3
+OTHER : /((?!\\\\htmlrtf).)+/s
+&#34;&#34;&#34;
+
+
+GRAMMAR = {
+    &#34;imports&#34;: r&#34;&#34;&#34;
+%import common.ESCAPED_STRING
+%import common.SIGNED_NUMBER
+%import common.DIGIT
+%import common.NEWLINE
+%import common.LETTER&#34;&#34;&#34;,
+    &#34;ignore&#34;: r&#34;&#34;&#34;%ignore NEWLINE&#34;&#34;&#34;,
+    &#34;_LBRACE&#34;: r&#39;&#34;{&#34;&#39;,
+    &#34;_RBRACE&#34;: r&#39;&#34;}&#34;&#39;,
+    &#34;BACKSLASH&#34;: r&#39;&#34;\\&#34;&#39;,
+    &#34;start&#34;: r&#34;_LBRACE document _RBRACE&#34;,
+    &#34;document&#34;: r&#34;&#34;&#34;(CONTROLWORD
+                    | control_symbol
+                    | string
+                    | group
+                    | HTMLRTF
+                    | hexarray
+                    | _SPACE_DELETE
+                    | SPACE_SAVE
+                    | UNICODE)+&#34;&#34;&#34;,
+    &#34;group&#34;: r&#34;&#34;&#34;_LBRACE (CONTROLWORD
+                        | control_symbol
+                        | string
+                        | htmltag_group
+                        | mhtmltag_group
+                        | group
+                        | SPACE_SAVE
+                        | _SPACE_DELETE
+                        | HTMLRTF
+                        | UNICODE
+                        | hexarray
+                        | NEWLINE )* _RBRACE&#34;&#34;&#34;,
+    &#34;htmltag_group&#34;: r&#34;STAR_ESCAPE HTMLTAG ( string | group )*&#34;,
+    &#34;HTMLTAG&#34;: r&#39;&#34;\\htmltag&#34; DIGIT~0..3 _SPACE_DELETE?&#39;,
+    &#34;MHTMLTAG&#34;: r&#39;&#34;\\mhtmltag&#34; DIGIT~0..3 _SPACE_DELETE?&#39;,
+    &#34;mhtmltag_group&#34;: r&#34;STAR_ESCAPE MHTMLTAG ( string | group )*&#34;,
+    &#34;NUMERICALDEL&#34;: r&#34;SIGNED_NUMBER*&#34;,
+    &#34;_SPACE_DELETE&#34;: r&#39;&#34; &#34;&#39;,
+    &#34;SPACE_SAVE&#34;: r&#39;&#34; &#34;&#39;,
+    &#34;DELIMITER&#34;: r&#34;NUMERICALDEL _SPACE_DELETE?&#34;,
+    &#34;ASCIILETTERSEQUENCE&#34; : r&#34;LETTER+&#34;,
+    &#34;CONTROLWORD&#34;: &#34;BACKSLASH ASCIILETTERSEQUENCE~1..32 DELIMITER&#34;,
+    &#34;STAR_ESCAPE&#34;: r&#39;BACKSLASH &#34;*&#34;&#39;,
+    &#34;NONBREAKING_HYPHEN&#34;: r&#39;BACKSLASH &#34;_&#34;&#39;,
+    &#34;OPTIONAL_HYPHEN&#34;: r&#39;BACKSLASH &#34;-&#34;&#39;,
+    &#34;NONBREAKING_SPACE&#34;: r&#39;BACKSLASH &#34;~&#34;&#39;,
+    &#34;FORMULA_CHARACTER&#34;: r&#39;BACKSLASH &#34;|&#34;&#39;,
+    &#34;INDEX_SUBENTRY&#34;: r&#39;BACKSLASH &#34;:&#34;&#39;,
+    &#34;control_symbol&#34;: r&#34;(STAR_ESCAPE | INDEX_SUBENTRY | FORMULA_CHARACTER | NONBREAKING_SPACE | OPTIONAL_HYPHEN | NONBREAKING_HYPHEN )&#34;,
+    &#34;STRING&#34;: r&#39;/.+?/&#39;,
+    &#34;?string&#34;: r&#34;STRING+ SPACE_SAVE?&#34;,
+    &#34;_QUESTION_MARK&#34;: r&#39;&#34;?&#34;&#39;,
+    &#34;UNICODE&#34; : r&#34;&#34;&#34;(&#34;\\u&#34; /[-]*[0-9]+/)+&#34;&#34;&#34;,
+    &#34;HEXENCODED&#34;: &#34;&#34;&#34;(&#34;\\&#39;&#34; /[0-9A-Fa-f]/~2)&#34;&#34;&#34;,
+    &#34;hexarray&#34;: &#34;HEXENCODED+&#34;,
+    &#34;HTMLRTF&#34;: r&#39;&#34;\\htmlrtf&#34; DIGIT~0..3 _SPACE_DELETE?&#39;,
+   }
+
+
+# // == Priority Levels ==
+# This dictionary sets the priority level for each type of object in the lexer.
+# Higher numbers give a greater priority.
+# All must start with a period
+# EXPLICIT IS BETTER THEN RELYING ON DEFAULTS
+# // 0 = Raw String Matching // text should defer to everything else if conflicting
+# // 1 = Generic undefined object (i.e. group, CONTROL_WORD, CONTROL_SYMBOL, etc.)
+# // 2 = Specific instances of objects (i.e. HTMLTAG, MHTMLTAG, etc.)
+
+PRIORITY_LEVELS = {
+    &#34;_LBRACE&#34;: &#34;.2&#34;,
+    &#34;_RBRACE&#34;: &#34;.2&#34;,
+    &#34;BACKSLASH&#34; : &#34;.1&#34;,
+    &#34;start&#34; : &#34;.1&#34;,
+    &#34;document&#34;: &#34;.1&#34;,
+    &#34;group&#34;: &#34;.1&#34;,
+    &#34;htmltag_group&#34; : &#34;.2&#34;,
+    &#34;HTMLRTF&#34; : &#34;.2&#34;,
+    &#34;HTMLTAG&#34; : &#34;.2&#34;,
+    &#34;MHTMLTAG&#34; : &#34;.2&#34;,
+    &#34;mhtmltag_group&#34; : &#34;.2&#34;,
+    &#34;NUMERICALDEL&#34; : &#34;.1&#34;,
+    &#34;_SPACE_DELETE&#34; : &#34;.1&#34;,
+    &#34;SPACE_SAVE&#34; : &#34;.1&#34;,
+    &#34;DELIMITER&#34; : &#34;.1&#34;,
+    &#34;ASCIILETTERSEQUENCE&#34; : &#34;.1&#34;,
+    &#34;CONTROLWORD&#34;: &#34;.1&#34;,
+    &#34;STAR_ESCAPE&#34;: &#34;.1&#34;,
+    &#34;NONBREAKING_HYPHEN&#34;: &#34;.1&#34;,
+    &#34;OPTIONAL_HYPHEN&#34;: &#34;.1&#34;,
+    &#34;NONBREAKING_SPACE&#34;: &#34;.1&#34;,
+    &#34;FORMULA_CHARACTER&#34;: &#34;.1&#34;,
+    &#34;INDEX_SUBENTRY&#34;: &#34;.1&#34;,
+    &#34;control_symbol&#34;: &#34;.1&#34;,
+    &#34;STRING&#34; : &#34;.0&#34;,
+    &#34;_QUESTION_MARK&#34;: &#34;.1&#34;,
+    &#34;?string&#34; : &#34;.0&#34;,
+    &#34;UNICODE&#34; : &#34;.2&#34;,
+    &#34;HEXENCODED&#34; : &#34;.1&#34;,
+    &#34;hexarray&#34; : &#34;.2&#34;,
+}
+
+def make_concise_grammar():
+    &#34;&#34;&#34;Make a grammar string to use with the lexer.
+    &#34;&#34;&#34;
+    grammar = r&#34;&#34;&#34;&#34;&#34;&#34;
+    for key, priority in PRIORITY_LEVELS.items():
+        grammar += &#34;{0}{1} : {2}\n&#34;.format(key,priority,GRAMMAR[key])
+    grammar += GRAMMAR[&#39;imports&#39;] + &#34;\n&#34;
+    grammar += GRAMMAR[&#39;ignore&#39;] + &#34;\n&#34;
+    return (grammar)
+
+
+
+def make_literate_grammar():
+    &#34;&#34;&#34;Create a VERBOSE grammar string which can be used to understand the grammar.
+
+    This SHOULD be updated to include and changes to the grammar.
+    This is valuable when debugging and/or otherwise trying to understand the grammar.
+    &#34;&#34;&#34;
+    grammar = r&#34;&#34;&#34;
+
+// ===== Precedence =========
+// Literals are matched according to the following precedence:
+// 1. Highest priority first (priority is specified as: TERM.number: …)
+// 2. Length of match (for regexps, the longest theoretical match is used)
+// 3. Length of literal / pattern definition
+// 4. Name
+//
+// == Priority Levels ==
+// WARNING: Priority Levels are not shown in this literate grammar.
+// NOTE: Look at PRIORITY_LEVELS for the prioritized levels used in production.
+// 0 = Raw String Matching // text should defer to everything else if conflicting
+// 1 = Generic undefined object (i.e. group, CONTROL_WORD, CONTROL_SYMBOL, etc.)
+// 2 = Specific instances of objects (i.e. HTMLTAG, MHTMLTAG, etc.)
+
+// ====== GRAMMAR OBJECT IMPORTS FROM LARK COMMONS ======
+// https://github.com/lark-parser/lark/blob/master/lark/grammars/common.lark
+{imports}
+
+
+// ====== Ignore Newlines ======
+// The real carriage returns are stored in \par or \line tags.
+{ignore}
+
+// ====== SIMPLE GRAMMAR OBJECTS USED THROUGHOUT ======
+// RTF is braces all the way down
+// We don&#39;t have to worry about escaped braces since we are pre-processing out escaped braces already
+_LBRACE: {_LBRACE}
+_RBRACE: {_RBRACE}
+
+// We don&#39;t have to worry about escaped backslashes since we are pre-processing out escaped braces already
+BACKSLASH: {BACKSLASH}
+
+// RTF control words are made up of ASCII alphabetical characters (a through z and A through Z)
+ASCIILETTERSEQUENCE: {ASCIILETTERSEQUENCE}
+
+// A space that should be deleted (See Delimiters below)
+_SPACE_DELETE: {_SPACE_DELETE}
+
+// But, we want to save spaces within strings. So, we have a special space for that.
+SPACE_SAVE : {SPACE_SAVE}
+
+// ====== UNMATCHED RAW TEXT ======
+// In order to split out everything that is simply plain text and not a special RTF object I&#39;ve had to match all raw text characters individually. This allows us to store them all in their own rule branch (string) for tranformation later on.
+
+STRING : {STRING}
+
+// We use the ? char to inline this rule to remove the branch and replace it with its children if it has one match. This will make it easier to parse later and remove uneccesary matches of it.
+?string: {?string}
+
+
+
+
+// ====== HIGH LEVEL DOCUMENT PARSING ======
+
+// The start object is the top level object in the tree
+// An RTF file has the following syntax: &#39;{{&#39; &lt;header &amp; document&gt; &#39;}}&#39;
+start: {start}
+
+// Parse &lt;header &amp; document&gt;
+document: {document}
+
+// A group consists of text and control words or control symbols enclosed in braces ({{}}).
+// The opening brace ({{ ) indicates the start of the group and the closing brace ( }}) indicates the end of the group.
+group: {group}
+
+
+// ====== CONTROL WORD(s) ======
+
+// A control word is defined by: \&lt;ASCII Letter Sequence&gt;&lt;Delimiter&gt;
+// A control word’s name cannot be longer than 32 letters.
+CONTROLWORD: {CONTROLWORD}
+
+// === Delimiter ==
+
+DELIMITER: {DELIMITER}
+
+// The &lt;Delimiter&gt; can be one of the following:
+// 1. A numeric digit or an ASCII minus sign (-), which indicates that a numeric parameter is associated with the control word.
+NUMERICALDEL: {NUMERICALDEL}
+// 2. A space: When a space is used as a the delimiter, it is discarded. This means that it’s not included in subsequent processing. So, we are using a discarded terminal (by putting a underscore in front of the name) to ensure it is tossed.
+// See: &#34;_SPACE_DELETE&#34; under SIMPLE GRAMMAR OBJECTS
+
+// 3. Any character other than a letter or a digit. In this case, the delimiting character terminates the control word and is not part of the control word. So, it&#39;s not included in the grammar here.
+
+
+// ====== CONTROL SYMBOLS(s) ======
+
+// A control symbol consists of a backslash followed by a single, nonalphabetic character.
+// For example, \~ represents a nonbreaking space.
+
+// The STAR_ESCAPE special construct means that if the program understands the \command, it takes this to mean {\command ...}, but if it doesn’t understand \command, the program ignores not just \command (as it would anyway) but everything in this group.
+STAR_ESCAPE: {STAR_ESCAPE}
+NONBREAKING_HYPHEN: {NONBREAKING_HYPHEN}
+OPTIONAL_HYPHEN: {OPTIONAL_HYPHEN}
+NONBREAKING_SPACE: {NONBREAKING_SPACE}
+FORMULA_CHARACTER: {FORMULA_CHARACTER}
+INDEX_SUBENTRY: {INDEX_SUBENTRY}
+
+// Control symbols take no delimiters.
+control_symbol: {control_symbol}
+
+
+
+
+
+// ====== SPECIAL CONTROL WORD(s) ======
+
+// ====== HEADER OBJECTS ======
+
+// The FROMHTML control word specifies that the RTF document contains encapsulated HTML text.
+// This control word MUST be \fromhtml1. Any other form, such as \fromhtml or \fromhtml0, will not be considered encapsulated
+// FROMTEXT: {FROMTEXT}
+
+//The FROMHTML control word specifies that the RTF document contains encapsulated HTML text.
+// This control word MUST be \fromhtml1. Any other form, such as \fromhtml or \fromhtml0, will not be considered encapsulated.
+//FROMHTML : {FROMHTML}
+
+
+// ====== SPECIFIC CONTROL WORD OBJECTS ======
+
+// HTMLRTF Toggle Control Word
+// The HTMLRTF control word identifies fragments of RTF that were not in the original HTML content
+// If the flag is &#34;\htmlrtf&#34; or &#34;\htmlrtf1&#34; then do not process anything else until you encounter &#34;\htmlrtf0&#34; which will toggle this off again.
+// A de-encapsulating RTF reader MUST support the HTMLRTF control word within nested groups. The state of the HTMLRTF control word MUST transfer when entering groups and be restored when exiting groups.
+// This means that you can only turn this off on it&#39;s own level (turning it off in an object nested within it does nothing). And, if the object it&#39;s in ends then it doesn&#39;t transfer up the tree to objects that contain it. So, if you don&#39;t find a closing &#34;\htmlrtf0&#34; you can delete from the opening &#34;\htmlrtf&#34; all the way until the end of the current object, but not above.
+HTMLRTF : {HTMLRTF}
+
+// The HTMLTAG destination group encapsulates HTML fragments that cannot be directly represented in RTF
+htmltag_group: {htmltag_group}
+
+// The &#34;DIGIT~0..3&#34; in the following definition is the HTMLTagParameter from the spec.
+    // A space MUST be used to separate the CONTENT HTML fragment from the HTMLTagParameter HTML fragment if the text starts with a DIGIT, or if the HTMLTagParameter HTML fragment is omitted. As such, we throw away this space by using _SPACE_DELETE if we encounter one.
+HTMLTAG: {HTMLTAG}
+
+
+
+content : {content}
+
+// \*\mhtmltag[HTMLTagParameter] [CONTENT]
+// The values and format of the numeric parameter are identical to the numeric parameter in the HTMLTAG destination group.
+// This RTF control word SHOULD be skipped on de-encapsulation and SHOULD NOT be written when encapsulating.
+# TODO: https://datatracker.ietf.org/doc/html/draft-ietf-mhtml-cid-00#section-1
+// NOTE: mhtmltag&#39;s contain original URL which has been replaced in the corresponding  htmltag with the CID of an object. As such, it contains possibly useful URI data that, while not useful for the direct output, should be saved.
+MHTMLTAG : {MHTMLTAG}
+mhtmltag_group: {mhtmltag_group}
+
+
+// TODO: Check if really neeeded
+// Increased priority of escape chars to make unescaping easier
+// Multiple char acceptance is important here because if you just catch one escape at a time you mess up multi-byte values.
+_QUESTION_MARK: {_QUESTION_MARK}
+
+// TODO Define these objects
+
+// RTFESCAPE no longer used
+// RTFESCAPE : {RTFESCAPE}
+
+// UNICODE unicode chars
+UNICODE : {UNICODE}
+
+// Hex chars [HEXENCODED] are stored in an array [hexarray]
+// We often need to parse hex chars as a set so this is the easiest way
+HEXENCODED : {HEXENCODED}
+hexarray : {hexarray}
+
+    &#34;&#34;&#34;.format(**GRAMMAR)
+    return grammar
+
+
+if __name__ == &#39;__main__&#39;:
+    # print(make_literate_grammar())
+    print(make_concise_grammar())</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="RTFDE.grammar.make_concise_grammar"><code class="name flex">
+<span>def <span class="ident">make_concise_grammar</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Make a grammar string to use with the lexer.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def make_concise_grammar():
+    &#34;&#34;&#34;Make a grammar string to use with the lexer.
+    &#34;&#34;&#34;
+    grammar = r&#34;&#34;&#34;&#34;&#34;&#34;
+    for key, priority in PRIORITY_LEVELS.items():
+        grammar += &#34;{0}{1} : {2}\n&#34;.format(key,priority,GRAMMAR[key])
+    grammar += GRAMMAR[&#39;imports&#39;] + &#34;\n&#34;
+    grammar += GRAMMAR[&#39;ignore&#39;] + &#34;\n&#34;
+    return (grammar)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.grammar.make_literate_grammar"><code class="name flex">
+<span>def <span class="ident">make_literate_grammar</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Create a VERBOSE grammar string which can be used to understand the grammar.</p>
+<p>This SHOULD be updated to include and changes to the grammar.
+This is valuable when debugging and/or otherwise trying to understand the grammar.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def make_literate_grammar():
+    &#34;&#34;&#34;Create a VERBOSE grammar string which can be used to understand the grammar.
+
+    This SHOULD be updated to include and changes to the grammar.
+    This is valuable when debugging and/or otherwise trying to understand the grammar.
+    &#34;&#34;&#34;
+    grammar = r&#34;&#34;&#34;
+
+// ===== Precedence =========
+// Literals are matched according to the following precedence:
+// 1. Highest priority first (priority is specified as: TERM.number: …)
+// 2. Length of match (for regexps, the longest theoretical match is used)
+// 3. Length of literal / pattern definition
+// 4. Name
+//
+// == Priority Levels ==
+// WARNING: Priority Levels are not shown in this literate grammar.
+// NOTE: Look at PRIORITY_LEVELS for the prioritized levels used in production.
+// 0 = Raw String Matching // text should defer to everything else if conflicting
+// 1 = Generic undefined object (i.e. group, CONTROL_WORD, CONTROL_SYMBOL, etc.)
+// 2 = Specific instances of objects (i.e. HTMLTAG, MHTMLTAG, etc.)
+
+// ====== GRAMMAR OBJECT IMPORTS FROM LARK COMMONS ======
+// https://github.com/lark-parser/lark/blob/master/lark/grammars/common.lark
+{imports}
+
+
+// ====== Ignore Newlines ======
+// The real carriage returns are stored in \par or \line tags.
+{ignore}
+
+// ====== SIMPLE GRAMMAR OBJECTS USED THROUGHOUT ======
+// RTF is braces all the way down
+// We don&#39;t have to worry about escaped braces since we are pre-processing out escaped braces already
+_LBRACE: {_LBRACE}
+_RBRACE: {_RBRACE}
+
+// We don&#39;t have to worry about escaped backslashes since we are pre-processing out escaped braces already
+BACKSLASH: {BACKSLASH}
+
+// RTF control words are made up of ASCII alphabetical characters (a through z and A through Z)
+ASCIILETTERSEQUENCE: {ASCIILETTERSEQUENCE}
+
+// A space that should be deleted (See Delimiters below)
+_SPACE_DELETE: {_SPACE_DELETE}
+
+// But, we want to save spaces within strings. So, we have a special space for that.
+SPACE_SAVE : {SPACE_SAVE}
+
+// ====== UNMATCHED RAW TEXT ======
+// In order to split out everything that is simply plain text and not a special RTF object I&#39;ve had to match all raw text characters individually. This allows us to store them all in their own rule branch (string) for tranformation later on.
+
+STRING : {STRING}
+
+// We use the ? char to inline this rule to remove the branch and replace it with its children if it has one match. This will make it easier to parse later and remove uneccesary matches of it.
+?string: {?string}
+
+
+
+
+// ====== HIGH LEVEL DOCUMENT PARSING ======
+
+// The start object is the top level object in the tree
+// An RTF file has the following syntax: &#39;{{&#39; &lt;header &amp; document&gt; &#39;}}&#39;
+start: {start}
+
+// Parse &lt;header &amp; document&gt;
+document: {document}
+
+// A group consists of text and control words or control symbols enclosed in braces ({{}}).
+// The opening brace ({{ ) indicates the start of the group and the closing brace ( }}) indicates the end of the group.
+group: {group}
+
+
+// ====== CONTROL WORD(s) ======
+
+// A control word is defined by: \&lt;ASCII Letter Sequence&gt;&lt;Delimiter&gt;
+// A control word’s name cannot be longer than 32 letters.
+CONTROLWORD: {CONTROLWORD}
+
+// === Delimiter ==
+
+DELIMITER: {DELIMITER}
+
+// The &lt;Delimiter&gt; can be one of the following:
+// 1. A numeric digit or an ASCII minus sign (-), which indicates that a numeric parameter is associated with the control word.
+NUMERICALDEL: {NUMERICALDEL}
+// 2. A space: When a space is used as a the delimiter, it is discarded. This means that it’s not included in subsequent processing. So, we are using a discarded terminal (by putting a underscore in front of the name) to ensure it is tossed.
+// See: &#34;_SPACE_DELETE&#34; under SIMPLE GRAMMAR OBJECTS
+
+// 3. Any character other than a letter or a digit. In this case, the delimiting character terminates the control word and is not part of the control word. So, it&#39;s not included in the grammar here.
+
+
+// ====== CONTROL SYMBOLS(s) ======
+
+// A control symbol consists of a backslash followed by a single, nonalphabetic character.
+// For example, \~ represents a nonbreaking space.
+
+// The STAR_ESCAPE special construct means that if the program understands the \command, it takes this to mean {\command ...}, but if it doesn’t understand \command, the program ignores not just \command (as it would anyway) but everything in this group.
+STAR_ESCAPE: {STAR_ESCAPE}
+NONBREAKING_HYPHEN: {NONBREAKING_HYPHEN}
+OPTIONAL_HYPHEN: {OPTIONAL_HYPHEN}
+NONBREAKING_SPACE: {NONBREAKING_SPACE}
+FORMULA_CHARACTER: {FORMULA_CHARACTER}
+INDEX_SUBENTRY: {INDEX_SUBENTRY}
+
+// Control symbols take no delimiters.
+control_symbol: {control_symbol}
+
+
+
+
+
+// ====== SPECIAL CONTROL WORD(s) ======
+
+// ====== HEADER OBJECTS ======
+
+// The FROMHTML control word specifies that the RTF document contains encapsulated HTML text.
+// This control word MUST be \fromhtml1. Any other form, such as \fromhtml or \fromhtml0, will not be considered encapsulated
+// FROMTEXT: {FROMTEXT}
+
+//The FROMHTML control word specifies that the RTF document contains encapsulated HTML text.
+// This control word MUST be \fromhtml1. Any other form, such as \fromhtml or \fromhtml0, will not be considered encapsulated.
+//FROMHTML : {FROMHTML}
+
+
+// ====== SPECIFIC CONTROL WORD OBJECTS ======
+
+// HTMLRTF Toggle Control Word
+// The HTMLRTF control word identifies fragments of RTF that were not in the original HTML content
+// If the flag is &#34;\htmlrtf&#34; or &#34;\htmlrtf1&#34; then do not process anything else until you encounter &#34;\htmlrtf0&#34; which will toggle this off again.
+// A de-encapsulating RTF reader MUST support the HTMLRTF control word within nested groups. The state of the HTMLRTF control word MUST transfer when entering groups and be restored when exiting groups.
+// This means that you can only turn this off on it&#39;s own level (turning it off in an object nested within it does nothing). And, if the object it&#39;s in ends then it doesn&#39;t transfer up the tree to objects that contain it. So, if you don&#39;t find a closing &#34;\htmlrtf0&#34; you can delete from the opening &#34;\htmlrtf&#34; all the way until the end of the current object, but not above.
+HTMLRTF : {HTMLRTF}
+
+// The HTMLTAG destination group encapsulates HTML fragments that cannot be directly represented in RTF
+htmltag_group: {htmltag_group}
+
+// The &#34;DIGIT~0..3&#34; in the following definition is the HTMLTagParameter from the spec.
+    // A space MUST be used to separate the CONTENT HTML fragment from the HTMLTagParameter HTML fragment if the text starts with a DIGIT, or if the HTMLTagParameter HTML fragment is omitted. As such, we throw away this space by using _SPACE_DELETE if we encounter one.
+HTMLTAG: {HTMLTAG}
+
+
+
+content : {content}
+
+// \*\mhtmltag[HTMLTagParameter] [CONTENT]
+// The values and format of the numeric parameter are identical to the numeric parameter in the HTMLTAG destination group.
+// This RTF control word SHOULD be skipped on de-encapsulation and SHOULD NOT be written when encapsulating.
+# TODO: https://datatracker.ietf.org/doc/html/draft-ietf-mhtml-cid-00#section-1
+// NOTE: mhtmltag&#39;s contain original URL which has been replaced in the corresponding  htmltag with the CID of an object. As such, it contains possibly useful URI data that, while not useful for the direct output, should be saved.
+MHTMLTAG : {MHTMLTAG}
+mhtmltag_group: {mhtmltag_group}
+
+
+// TODO: Check if really neeeded
+// Increased priority of escape chars to make unescaping easier
+// Multiple char acceptance is important here because if you just catch one escape at a time you mess up multi-byte values.
+_QUESTION_MARK: {_QUESTION_MARK}
+
+// TODO Define these objects
+
+// RTFESCAPE no longer used
+// RTFESCAPE : {RTFESCAPE}
+
+// UNICODE unicode chars
+UNICODE : {UNICODE}
+
+// Hex chars [HEXENCODED] are stored in an array [hexarray]
+// We often need to parse hex chars as a set so this is the easiest way
+HEXENCODED : {HEXENCODED}
+hexarray : {hexarray}
+
+    &#34;&#34;&#34;.format(**GRAMMAR)
+    return grammar</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="RTFDE" href="index.html">RTFDE</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="RTFDE.grammar.make_concise_grammar" href="#RTFDE.grammar.make_concise_grammar">make_concise_grammar</a></code></li>
+<li><code><a title="RTFDE.grammar.make_literate_grammar" href="#RTFDE.grammar.make_literate_grammar">make_literate_grammar</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/RTFDE/grammar.md
+++ b/docs/RTFDE/grammar.md
@@ -1,0 +1,16 @@
+Module RTFDE.grammar
+====================
+
+Functions
+---------
+
+    
+`make_concise_grammar()`
+:   Make a grammar string to use with the lexer.
+
+    
+`make_literate_grammar()`
+:   Create a VERBOSE grammar string which can be used to understand the grammar.
+    
+    This SHOULD be updated to include and changes to the grammar.
+    This is valuable when debugging and/or otherwise trying to understand the grammar.

--- a/docs/RTFDE/index.html
+++ b/docs/RTFDE/index.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>RTFDE API documentation</title>
+<meta name="description" content="RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Package <code>RTFDE</code></h1>
+</header>
+<section id="section-intro">
+<p>RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML.</p>
+<p><a href="https://github.com/seamustuohy/RTF_De-Encapsulator">https://github.com/seamustuohy/RTF_De-Encapsulator</a></p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Date Format: YYYY-MM-DD
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2020 seamus tuohy, &lt;code@seamustuohy.com&gt;
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+&#34;&#34;&#34;
+RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML.
+
+https://github.com/seamustuohy/RTF_De-Encapsulator
+&#34;&#34;&#34;
+
+__author__ = &#39;seamus tuohy&#39;
+__date__ = &#39;2020-12-05&#39;
+__version__ = &#39;0.00.1&#39;
+
+import logging
+from logging import NullHandler
+
+logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__ + &#34;.tree_logger&#34;).addHandler(NullHandler())
+
+
+
+from RTFDE.deencapsulate import DeEncapsulator</code></pre>
+</details>
+</section>
+<section>
+<h2 class="section-title" id="header-submodules">Sub-modules</h2>
+<dl>
+<dt><code class="name"><a title="RTFDE.deencapsulate" href="deencapsulate.html">RTFDE.deencapsulate</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="RTFDE.exceptions" href="exceptions.html">RTFDE.exceptions</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="RTFDE.grammar" href="grammar.html">RTFDE.grammar</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="RTFDE.text_extraction" href="text_extraction.html">RTFDE.text_extraction</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="RTFDE.transformers" href="transformers.html">RTFDE.transformers</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="RTFDE.utils" href="utils.html">RTFDE.utils</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3><a href="#header-submodules">Sub-modules</a></h3>
+<ul>
+<li><code><a title="RTFDE.deencapsulate" href="deencapsulate.html">RTFDE.deencapsulate</a></code></li>
+<li><code><a title="RTFDE.exceptions" href="exceptions.html">RTFDE.exceptions</a></code></li>
+<li><code><a title="RTFDE.grammar" href="grammar.html">RTFDE.grammar</a></code></li>
+<li><code><a title="RTFDE.text_extraction" href="text_extraction.html">RTFDE.text_extraction</a></code></li>
+<li><code><a title="RTFDE.transformers" href="transformers.html">RTFDE.transformers</a></code></li>
+<li><code><a title="RTFDE.utils" href="utils.html">RTFDE.utils</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/RTFDE/index.html
+++ b/docs/RTFDE/index.html
@@ -23,7 +23,7 @@
 </header>
 <section id="section-intro">
 <p>RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML.</p>
-<p><a href="https://github.com/seamustuohy/RTF_De-Encapsulator">https://github.com/seamustuohy/RTF_De-Encapsulator</a></p>
+<p><a href="https://github.com/seamustuohy/RTFDE">https://github.com/seamustuohy/RTFDE</a></p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -47,12 +47,12 @@
 &#34;&#34;&#34;
 RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML.
 
-https://github.com/seamustuohy/RTF_De-Encapsulator
+https://github.com/seamustuohy/RTFDE
 &#34;&#34;&#34;
 
 __author__ = &#39;seamus tuohy&#39;
-__date__ = &#39;2020-12-05&#39;
-__version__ = &#39;0.00.1&#39;
+__date__ = &#39;2023-06-18&#39;
+__version__ = &#39;0.1.0&#39;
 
 import logging
 from logging import NullHandler

--- a/docs/RTFDE/index.md
+++ b/docs/RTFDE/index.md
@@ -2,7 +2,7 @@ Module RTFDE
 ============
 RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML.
 
-https://github.com/seamustuohy/RTF_De-Encapsulator
+https://github.com/seamustuohy/RTFDE
 
 Sub-modules
 -----------

--- a/docs/RTFDE/index.md
+++ b/docs/RTFDE/index.md
@@ -1,0 +1,14 @@
+Module RTFDE
+============
+RTFDE: A python3 library for extracting HTML content from RTF encapsulated HTML.
+
+https://github.com/seamustuohy/RTF_De-Encapsulator
+
+Sub-modules
+-----------
+* RTFDE.deencapsulate
+* RTFDE.exceptions
+* RTFDE.grammar
+* RTFDE.text_extraction
+* RTFDE.transformers
+* RTFDE.utils

--- a/docs/RTFDE/text_extraction.html
+++ b/docs/RTFDE/text_extraction.html
@@ -1,0 +1,2028 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>RTFDE.text_extraction API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>RTFDE.text_extraction</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2022 seamus tuohy, &lt;code@seamustuohy.com&gt;
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+import re
+from collections import namedtuple
+from typing import Union, Any, List, Tuple, Dict
+
+from oletools.common import codepages
+
+from lark.lexer import Token
+from lark.tree import Tree
+
+from RTFDE.exceptions import MalformedRtf
+from RTFDE.utils import is_codeword_with_numeric_arg
+from RTFDE.utils import flatten_tree_to_string_array
+
+import logging
+log = logging.getLogger(&#34;RTFDE&#34;)
+
+fontdef = namedtuple(&#34;fontdef&#34;, [&#34;fnum&#34;, &#34;codepage&#34;, &#34;codec&#34;, &#34;fontdef_tree&#34;])
+
+
+def get_font_table(tree: Tree) -&gt; Tree:
+    &#34;&#34;&#34;Extract the font table group from the first 20 tokens of a .rtf document.
+
+Args:
+    tree (Tree): A .rtf document object parsed into a Tree object
+
+Raises:
+    ValueError: If no group with a `\\fonttbl` token as its first controlword is found.
+
+Returns:
+    {&#39;\\f0&#39;: fontdef(fnum=&#39;\\f0&#39;, codepage=932, codec=&#39;cp932&#39;, fontdef_tree=&#39;{\\f0\\fswiss\\fcharset128 MS PGothic;}&#39;),
+    &#39;\\f1&#39;: fontdef(fnum=&#39;\\f1&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f1\\fmodern MS Gothic;}&#39;),
+    &#39;\\f2&#39;: fontdef(fnum=&#39;\\f2&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f2\\fnil\\fcharset2 Symbol;}&#39;),
+    &#39;\\f3&#39;: fontdef(fnum=&#39;\\f3&#39;, codepage=1252, codec=&#39;cp1252&#39;, fontdef_tree=&#39;{\\f3\\fmodern\\fcharset0 Courier New;}&#39;),
+    &#39;\\f4&#39;: fontdef(fnum=&#39;\\f4&#39;, codepage=932, codec=&#39;cp932&#39;, fontdef_tree=&#39;{\\f4\\fswiss\\fcharset128 &#34;PMingLiU&#34;;}&#39;),
+    &#39;\\f5&#39;: fontdef(fnum=&#39;\\f5&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f5\\fswiss &#34;Amnesty Trade Gothic&#34;;}&#39;),
+    &#39;\\f6&#39;: fontdef(fnum=&#39;\\f6&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f6\\fswiss &#34;Arial&#34;;}&#39;)}
+    &#34;&#34;&#34;
+    for item in tree.children[:20]:
+        if isinstance(item, Tree):
+            try:
+                ctrl_value = item.children[1]
+            except IndexError as _e:
+                continue
+            if isinstance(ctrl_value, Token):
+                table_type = ctrl_value.value.strip()
+                if table_type == &#34;\\fonttbl&#34;:
+                    return item
+    raise ValueError(&#34;No font table found in tree&#34;)
+
+
+def is_font_number(token: Token) -&gt; bool:
+    &#34;&#34;&#34;Checks if an object is a &#34;font number&#34;.
+
+Returns:
+    True if an object is a &#34;font number&#34; controlword `\\fN`. False if not.
+
+&#34;&#34;&#34;
+    try:
+        if is_codeword_with_numeric_arg(token, &#39;\\f&#39;):
+            return True
+    except AttributeError: # pragma: no cover
+        return False
+    return False
+
+def get_codepage_num_from_fcharset(fcharsetN: int) -&gt; Union[int,None]:
+    &#34;&#34;&#34;Return the codepage to use with a specific fcharsetN.
+
+Args:
+    fcharsetN (int): The numeric argument N for a \fcharsetN control word.
+
+Returns:
+    (int OR None) Returns the int for a codepage if known. Returns None for unknown charsets or charsets with no corresponding codepage (such as OEM or DEFAULT.)
+
+    &#34;&#34;&#34;
+    # Charset table retrieved on 2022-08-19
+    # https://web.archive.org/web/20220819215334/https://docs.microsoft.com/en-us/previous-versions/cc194829%28v=msdn.10%29?redirectedfrom=MSDN
+    charsets: dict[int,dict[str,Any]] = {
+        0:{&#34;name&#34;:&#34;ANSI_CHARSET&#34;,&#34;hex&#34;:&#34;0x00&#34;,&#34;decimal&#34;:0,&#34;id&#34;:1252},
+        1:{&#34;name&#34;:&#34;DEFAULT_CHARSET&#34;,&#34;hex&#34;:&#34;0x01&#34;,&#34;decimal&#34;:1,&#34;id&#34;:None},
+        2:{&#34;name&#34;:&#34;SYMBOL_CHARSET&#34;,&#34;hex&#34;:&#34;0x02&#34;,&#34;decimal&#34;:2,&#34;id&#34;:None},
+        128:{&#34;name&#34;:&#34;SHIFTJIS_CHARSET&#34;,&#34;hex&#34;:&#34;0x80&#34;,&#34;decimal&#34;:128,&#34;id&#34;:932},
+        129:{&#34;name&#34;:&#34;HANGUL_CHARSET&#34;,&#34;hex&#34;:&#34;0x81&#34;,&#34;decimal&#34;:129,&#34;id&#34;:949},
+        134:{&#34;name&#34;:&#34;GB2312_CHARSET&#34;,&#34;hex&#34;:&#34;0x86&#34;,&#34;decimal&#34;:134,&#34;id&#34;:936},
+        136:{&#34;name&#34;:&#34;CHINESEBIG5_CHARSET&#34;,&#34;hex&#34;:&#34;0x88&#34;,&#34;decimal&#34;:136,&#34;id&#34;:950},
+        161:{&#34;name&#34;:&#34;GREEK_CHARSET&#34;,&#34;hex&#34;:&#34;0xA1&#34;,&#34;decimal&#34;:161,&#34;id&#34;:1253},
+        162:{&#34;name&#34;:&#34;TURKISH_CHARSET&#34;,&#34;hex&#34;:&#34;0xA2&#34;,&#34;decimal&#34;:162,&#34;id&#34;:1254},
+        177:{&#34;name&#34;:&#34;HEBREW_CHARSET&#34;,&#34;hex&#34;:&#34;0xB1&#34;,&#34;decimal&#34;:177,&#34;id&#34;:1255},
+        178:{&#34;name&#34;:&#34;ARABIC_CHARSET&#34;,&#34;hex&#34;:&#34;0xB2&#34;,&#34;decimal&#34;:178,&#34;id&#34;:1256},
+        186:{&#34;name&#34;:&#34;BALTIC_CHARSET&#34;,&#34;hex&#34;:&#34;0xBA&#34;,&#34;decimal&#34;:186,&#34;id&#34;:1257},
+        204:{&#34;name&#34;:&#34;RUSSIAN_CHARSET&#34;,&#34;hex&#34;:&#34;0xCC&#34;,&#34;decimal&#34;:204,&#34;id&#34;:1251},
+        222:{&#34;name&#34;:&#34;THAI_CHARSET&#34;,&#34;hex&#34;:&#34;0xDE&#34;,&#34;decimal&#34;:222,&#34;id&#34;:874},
+        238:{&#34;name&#34;:&#34;EE_CHARSET&#34;,&#34;hex&#34;:&#34;0xEE&#34;,&#34;decimal&#34;:238,&#34;id&#34;:1250},
+        255:{&#34;name&#34;:&#34;OEM_CHARSET&#34;,&#34;hex&#34;:&#34;0xFF&#34;,&#34;decimal&#34;:255,&#34;id&#34;:None},
+}
+    # print(f&#34;Getting charset for {fcharsetN}&#34;)
+    charset = charsets.get(fcharsetN, None)
+    if charset is not None:
+        charset_id = charset.get(&#39;id&#39;, None)
+        return charset_id
+    return None
+
+
+def get_default_font(tree: Tree) -&gt; Union[str,None]:
+    &#34;&#34;&#34;Extract the font number controlword default font if it exists.
+
+If an RTF file uses a default font, the default font number is specified with the \\deffN control word, which must precede the font-table group.
+
+Args:
+    tree (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree object.
+
+Returns:
+    The default font control number if it exists from the first `\\deffN`. None if not found.
+&#34;&#34;&#34;
+    deff_gen = tree.scan_values(
+        lambda v: is_codeword_with_numeric_arg(v, &#39;\\deff&#39;)
+    )
+    deff_options = list(deff_gen)
+    try:
+        # We just want the first \\deffN. It shouldn&#39;t be set multiple times.
+        deff = deff_options[0]
+        deff_num = deff.value[5:]
+        return &#39;\\f&#39; + deff_num
+    except IndexError:
+        return None
+
+def parse_font_tree(font_tree: Tree) -&gt; dict:
+    &#34;&#34;&#34;Create a font tree dictionary with appropriate codeces to decode text.
+
+Args:
+    font_tree (Tree): The .rtf font table object decoded as a tree.
+
+Returns:
+    A dictionary which maps font numbers to appropriate python codeces needed to decode text.
+&#34;&#34;&#34;
+    parsed_font_tree = {}
+    for tree in font_tree.children:
+        if isinstance(tree, Tree):
+            fnum = None
+            fcharset = None
+            cpg_num = None
+            for tok in tree.children:
+                if is_codeword_with_numeric_arg(tok, &#39;\\f&#39;):
+                    fnum = tok.value
+                elif is_codeword_with_numeric_arg(tok, &#39;\\fcharset&#39;):
+                    fchar_num = int(tok.value[9:])
+                    fcharset = get_codepage_num_from_fcharset(fchar_num)
+                elif is_codeword_with_numeric_arg(tok, &#39;\\cpg&#39;):
+                    cpg_num = int(tok.value[4:])
+            if fnum is not None:
+                # get the codepage
+                codepage_num = None
+
+                if fcharset is not None:
+                    try:
+                        codepage_num = check_codepage_num(fcharset)
+                    except ValueError: # pragma: no cover
+                        codepage_num = None
+                # if both \\fcharset and \\cpg appear in the font table, \\cpg is ignored.
+                if ((codepage_num is None) and (cpg_num is not None)):
+                    try:
+                        codepage_num = check_codepage_num(cpg_num)
+                    except ValueError: # pragma: no cover
+                        codepage_num = None
+                # Get the appropriate codec
+                if codepage_num is not None:
+                    codec = get_python_codec(codepage_num)
+                else:
+                    codec = None
+                # Only add if there is a font definition
+                tree_str =  &#34;&#34;.join(list(flatten_tree_to_string_array(tree)))
+                parsed_font_tree[fnum] = fontdef(fnum, codepage_num, codec, tree_str)
+    return parsed_font_tree
+
+
+def get_python_codec(codepage_num: int) -&gt; str:
+    &#34;&#34;&#34;Returns the python codec needed to decode bytes to unicode.
+
+Args:
+    codepage_num (int): A codepage number.
+
+Returns:
+    The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
+&#34;&#34;&#34;
+    text_codec = codepages.codepage2codec(codepage_num)
+    log.debug(&#39;Found python codec corresponding to code page {0}: {1}&#39;.format(codepage_num, text_codec))
+    return text_codec
+
+def check_codepage_num(codepage_num: int) -&gt; int:
+    &#34;&#34;&#34;Provide the codepage number back to you if it is valid.
+
+Args:
+    codepage_num (int): A possible codepage number.
+
+Returns:
+    The codepage number IF it is a valid codepage number
+
+Raises:
+    ValueError: The codepage_num provided isn&#39;t a valid codepage number.
+
+&#34;&#34;&#34;
+    # This keyword should be emitted in the RTF header section right after the \ansi, \mac, \pc or \pca keyword. But, various document tags like \fbids often are thrown all over the header so we have to check the first group of headers for it.
+    # Code page names from https://docs.microsoft.com/en-gb/windows/desktop/Intl/code-page-identifiers
+    # Retrieved on 2020-12-18
+    allowed_codepage_nums = set([37, 437, 500, 708, 709, 710, 720, 737, 775, 850, 852, 855, 857, 858, 860, 861, 862, 863, 864, 865, 866, 869, 870, 874, 875, 932, 936, 949, 950, 1026, 1047, 1140, 1141, 1142, 1143, 1144, 1145, 1146, 1147, 1148, 1149, 1200, 1201, 1250, 1251, 1252, 1253, 1254, 1255, 1256, 1257, 1258, 1361, 10000, 10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10010, 10017, 10021, 10029, 10079, 10081, 10082, 12000, 12001, 20000, 20001, 20002, 20003, 20004, 20005, 20105, 20106, 20107, 20108, 20127, 20261, 20269, 20273, 20277, 20278, 20280, 20284, 20285, 20290, 20297, 20420, 20423, 20424, 20833, 20838, 20866, 20871, 20880, 20905, 20924, 20932, 20936, 20949, 21025, 21027, 21866, 28591, 28592, 28593, 28594, 28595, 28596, 28597, 28598, 28599, 28603, 28605, 29001, 38598, 50220, 50221, 50222, 50225, 50227, 50229, 50930, 50931, 50933, 50935, 50936, 50937, 50939, 51932, 51936, 51949, 51950, 52936, 54936, 57002, 57003, 57004, 57005, 57006, 57007, 57008, 57009, 57010, 57011, 65000, 65001])
+    if codepage_num in allowed_codepage_nums:
+        return codepage_num
+    # Note: If support for a specific codepage ever becomes an issue we can look at add support using the actual code-pages.
+    # Conversion tables for codepages can be retrieved from here: https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/
+    raise ValueError(f&#34;Unsupported unicode codepage number `{codepage_num}` found in the header&#34;)
+
+
+def validate_ansi_cpg(header: str) -&gt; None:
+    &#34;&#34;&#34;Check an &#39;\\ansicpgNNNN&#39; string to see if the number NNNN is an actual codepage.
+
+Args:
+    header (str): The value from the lark `\\ansicpg` CONTROLWORD Token.
+
+Raises:
+    MalformedRtf: If the value passed is not a valid ansi codepage.
+&#34;&#34;&#34;
+    try:
+        possible_cpg_num = int(header.strip()[8:])
+        check_codepage_num(possible_cpg_num)
+    except ValueError as _e:
+        raise MalformedRtf(f&#34;Unsupported unicode codepage number `{header}` found in the header&#34;) from _e
+
+
+# UNICODE CHARS
+def unicode_escape_to_chr(item: str) -&gt; str:
+    &#34;&#34;&#34;Convert unicode char from it&#39;s decimal to its unicode character representation. From &#34;\\u[-]NNNNN&#34; to the string representing the character whose Unicode code point that decimal represents.
+
+Args:
+    item (str): A RTF Escape in the format \\u[-]NNNNN.
+
+Returns:
+    The unicode character representation of the identified character
+
+Raises:
+    ValueError: The escaped unicode character is not valid.
+&#34;&#34;&#34;
+    try:
+        nnnn = int(item.removeprefix(&#39;\\u&#39;)) # raises ValueError if not int.
+    except ValueError as _e:
+        raise ValueError(f&#34;`{item}` is not a valid escaped unicode character.&#34;) from _e
+    if nnnn &lt; 0: # § -NNNNN is a negative integer expressed in decimal digits
+        ncr = 65536 + nnnn
+    else: # § NNNNN is a positive integer expressed in decimal digits
+        ncr = nnnn
+    # § HHHH is the hexadecimal equivalent of NNNNN or -NNNNN
+    return chr(ncr)
+
+def is_hex_encoded(item: Token) -&gt; bool:
+    &#34;&#34;&#34;Identify if a token contains a HEXENCODED token.
+Args:
+    item (token): A token to check if it is HEXENCODED.
+
+Return:
+    True if HEXENCODED. False if not.
+    &#34;&#34;&#34;
+    if isinstance(item, Token):
+        if item.type == &#34;HEXENCODED&#34;:
+            return True
+    return False
+
+def is_valid_ANSI_representation_char(item: Token) -&gt; bool:
+    &#34;&#34;&#34;Is token contain a valid ANSI representation string for a Unicode char.
+
+Args:
+    item (token): A token to check if it is a valid ANSI representation.
+
+Return:
+    True if token is an ansi representation of a unicode char. False if not.
+&#34;&#34;&#34;
+    if isinstance(item, Token):
+        # print(f&#34;found TOKEN posssible ansi {repr(item)}&#34;)
+        if is_hex_encoded(item):
+            # print(f&#34;found hex posssible ansi {repr(item)}&#34;)
+            return True
+        if item.type == &#39;STRING&#39;:
+            # print(f&#34;found STRING posssible ansi {repr(item)}&#34;)
+            if not item.value.isspace(): # whitespace doesn&#39;t count.
+                # print(f&#34;found posssible ansi {repr(item)}&#34;)
+                return True
+            # else:
+            #     print(f&#34;found SPACE posssible ansi {repr(item)}&#34;)
+    # print(f&#34;found NON TOKEN posssible ansi {repr(item)}&#34;)
+    return False
+
+def is_unicode_encoded(item: Token) -&gt; bool:
+    &#34;&#34;&#34;Is token contain a unicode char.
+
+Args:
+    item (token): A token to check if contains a unicode char.
+
+Return:
+    True if token contains a unicode char. False if not.
+&#34;&#34;&#34;
+    if isinstance(item, Token):
+        if item.type == &#34;UNICODE&#34;:
+            return True
+    return False
+
+def includes_unicode_chars(children: List[Token]) -&gt; bool:
+    &#34;&#34;&#34;Does a list include Tokens which contain unicode characters. Not recursive.
+
+Args:
+    children (list): A Tree.children list to check to see if it includes unicode characters.
+
+Returns:
+    True if list includes tokens which contain unicode chars. False if not.
+&#34;&#34;&#34;
+    for child in children:
+        if is_unicode_encoded(child):
+            return True
+    return False
+
+
+def remove_unicode_replacements(children: List[Token],
+                                return_ascii_map: bool = True,
+                                byte_count: int = 1) -&gt; Union[
+                                    Tuple[List[Token], Dict[Token,List[Token]]],
+                                    List[Token]]:
+    &#34;&#34;&#34;Remove all unicode replacement characters from a list of Tokens.
+
+Args:
+    children (list): A Tree.children list to remove unicode replacement characters from.
+    return_ascii_map (bool): On True, have this function return a map of the ASCII token that were removed.
+    byte_count (int): The number of bytes corresponding to a given \\uN Unicode character.  A default of 1 should be assumed if no \\uc keyword has been seen in the current or outer scopes.
+
+Returns:
+    new_children (list): The list of Tokens with all unicode replacement characters removed.
+    ascii_map (dict): All the Tokens which were removed from the provided children list keyed by
+
+&#34;&#34;&#34;
+    byte_count = 1
+    ascii_map: Dict[Token,List[Token]]  = {}
+    new_children = []
+    removal_map: List[Token] = []
+    # print(f&#34;Removing unicode replacements on {repr(children)}&#34;)
+    for child in children:
+        if len(removal_map) &gt; 0:
+            if isinstance(child, Token):
+                # Delete all spaces between a unicode char and the last ANSI representation
+                # print(f&#34;FOUND SPACE STRING with RM: {removal_map}&#34;)
+                if child.value.isspace():
+                    ascii_map.setdefault(removal_map[0], []).append(child)
+                    continue
+            if is_valid_ANSI_representation_char(child):
+                # Found an ansi representation removing unicode char from removal map.
+                # print(f&#34;FOUND ASCII STRING {child} to RM with RM: {removal_map}&#34;)
+                ascii_map.setdefault(removal_map.pop(), []).append(child)
+                continue
+            elif isinstance(child, Tree) and (
+                    (child.data == &#34;string&#34;) or (child.data == &#34;hexarray&#34;)):
+                # print(f&#34;FOUND ASCII STRING {child} with RM: {removal_map}&#34;)
+                ansi_children = child.children
+                new_ansi_children = []
+                for aci,ac in enumerate(ansi_children):
+                    # print(f&#34;AC CHILD {repr(ac)}&#34;)
+                    if is_valid_ANSI_representation_char(ac):
+                        # print(f&#34;AC CHILD VALID {repr(ac)}&#34;)
+                        if len(removal_map) &gt; 0:
+                            # print(f&#34;AC CHILD MAP &gt;0 {repr(ac)}&#34;)
+                            # print(f&#34;Popping removal for {repr(ac)}&#34;)
+                            ascii_map.setdefault(removal_map.pop(), []).append(ac)
+                        else:
+                            # print(f&#34;AC CHILD MAP &lt; 0 {repr(ac)}&#34;)
+                            new_ansi_children.append(ac)
+                    else:
+                        # print(f&#34;AC CHILD NOT VALID {repr(ac)}&#34;)
+                        new_ansi_children.append(ac)
+                child.children = new_ansi_children
+                # print(f&#34;NEW Tree = {child}&#34;)
+            # else:
+                # print(f&#34;FOUND ASCII STRING {child} with RM: {removal_map}&#34;)
+                # print(f&#34;{repr(child)} not a valid ANSI representation? with RM: {removal_map}&#34;)
+        # Modify char byte count if we encounter it.
+        if is_unicode_char_byte_count(child):
+            byte_count = get_unicode_char_byte_count(child)
+            # print(f&#34;Changing byte count because {child} to {byte_count}&#34;)
+        if is_unicode_encoded(child):
+            # print(f&#34;Found unicode {child}&#34;)
+            for j in range(byte_count):
+                # Add the unicode key to the removal map once per byte
+                # This ensures we remove the right number of ANSI representation chars
+                removal_map.append(child)
+        new_children.append(child)
+    if return_ascii_map is True:
+        return new_children, ascii_map
+    return new_children
+
+
+# UNICODE SURROGATE CHARACTERS
+def is_surrogate_high_char(item):
+    &#34;&#34;&#34;Check&#39;s if chr is a is in the high-surrogate code point rage. &#34;High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF.&#34; High-surrogate also sometimes known as the leading surrogate.
+
+        item (str): A string representing a unicode character. &#34;\\u-10179&#34;
+    &#34;&#34;&#34;
+    if item.startswith(&#34;\\u&#34;):
+        item = item[2:]
+    if 0xD800 &lt;= ord(chr(65536+int(item))) &lt;= 0xDBFF:
+        return True
+    return False
+
+def is_surrogate_low_char(item):
+    &#34;&#34;&#34;Check&#39;s if chr is a is in the low-surrogate code point rage. &#34;Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF.&#34;  Low-surrogate also sometimes known as following surrogates.
+
+        item (str): A string representing a unicode character.
+    &#34;&#34;&#34;
+    if item.startswith(&#34;\\u&#34;):
+        item = item[2:]
+    if 0xDC00 &lt;= ord(chr(65536+int(item))) &lt;= 0xDFFF:
+        return True
+    return False
+
+def is_surrogate_pair(first, second):
+    &#34;&#34;&#34;Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.
+    &#34;&#34;&#34;
+    if is_surrogate_high_char(first):
+        if is_surrogate_low_char(second):
+            return True
+        else:
+            log.info(&#34;RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}&#34;.format(first, second))
+    return False
+
+def decode_surrogate_pair(high, low, encoding=&#39;utf-16-le&#39;):
+    &#34;&#34;&#34; Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.
+
+        high (chr): the high-surrogate code point
+        low (chr): the low-surrogate code point
+        encoding (str): The encoding to apply to the final value. Defaults to &#39;utf-16-le&#39; because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
+    &#34;&#34;&#34;
+    # Equation for turning surrogate pairs into a unicode scalar value which be used with utl-16 can ONLY found in Unicode 3.0.0 standard.
+    # Unicode scalar value means the same thing as &#34;code position&#34; or &#34;code point&#34;
+     # https://www.unicode.org/versions/Unicode3.0.0/
+     # section 3.7 https://www.unicode.org/versions/Unicode3.0.0/ch03.pdf#page=9
+    if high.startswith(&#34;\\u&#34;):
+        high = high[2:]
+    if low.startswith(&#34;\\u&#34;):
+        low = low[2:]
+    high = chr(65536+int(high))
+    low = chr(65536+int(low))
+    unicode_scalar_value = ((ord(high) - 0xD800) * 0x400) + (ord(low) - 0xDC00) + 0x10000
+    unicode_bytes = chr(unicode_scalar_value).encode(encoding)
+    return unicode_bytes.decode(encoding)
+
+def merge_surrogate_chars(children, ascii_map,
+                          use_ASCII_alternatives_on_unicode_decode_failure = False):
+    &#34;&#34;&#34;
+
+
+Raises:
+    ValueError:  A Standalone high-surrogate was found. High surrogate followed by a illegal low-surrogate character.
+    &#34;&#34;&#34;
+    surrogate_start = None
+    surrogate_high = None
+    for i,c in enumerate(children):
+        if isinstance(c, Tree):
+            continue
+        if is_unicode_encoded(c):
+            if is_surrogate_high_char(c.value):
+                surrogate_start = i
+                surrogate_high = c
+            elif surrogate_start is not None:
+                if is_surrogate_low_char(c.value):
+                    surrogate_low = c
+                    try:
+                        surrogate_value = decode_surrogate_pair(surrogate_high.value,
+                                                                surrogate_low.value)
+                        # Convert into STRING token
+                        surrogate_tok = Token(&#39;STRING&#39;,
+                                              surrogate_value,
+                                              start_pos=surrogate_high.start_pos,
+                                              end_pos=surrogate_low.end_pos,
+                                              line=surrogate_high.line,
+                                              end_line=surrogate_low.end_line,
+                                              column=surrogate_high.column,
+                                              end_column=surrogate_low.end_column)
+                        children[surrogate_start] = surrogate_tok
+                        children[i] = &#34;&#34;
+                        surrogate_start = None
+                        surrogate_high = None
+                    except UnicodeDecodeError as _e:
+                        if use_ASCII_alternatives_on_unicode_decode_failure is True:
+                            children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                            children[i] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_low]])
+                        else:
+                            raise _e
+                else:
+                    log.info(&#34;RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}&#34;.format(surrogate_high, surrogate_low))
+                    if use_ASCII_alternatives_on_unicode_decode_failure is True:
+                        children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                    else:
+                        raise ValueError(&#34;Standalone high-surrogate found. High surrogate followed by a illegal low-surrogate character.&#34;)
+    return children
+
+
+
+def is_unicode_char_byte_count(item: Token) -&gt; bool:
+    if isinstance(item, Token):
+        if item.type == &#34;CONTROLWORD&#34;:
+            if item.value.startswith(&#39;\\uc&#39;):
+                return True
+    return False
+
+def get_unicode_char_byte_count(item):
+    cur_uc = int(item[3:])
+    return cur_uc
+
+
+# Hex Encoded Chars
+def has_hexarray(children):
+    &#34;&#34;&#34;Checks if an tree&#39;s children includes a hexarray tree.
+
+    children (array): the children object from a tree.
+    &#34;&#34;&#34;
+    for item in children:
+        if is_hexarray(item):
+            return True
+    return False
+
+def is_hexarray(item):
+    &#34;&#34;&#34;Checks if an item is a hexarray tree.
+
+    item (Tree or Token): an item to check to see if its a hex array
+    &#34;&#34;&#34;
+    if isinstance(item, Tree):
+        if item.data.value == &#39;hexarray&#39;:
+            return True
+    return False
+
+def get_bytes_from_hex_encoded(item):
+    &#34;&#34;&#34;Convert hex encoded string to bytes.
+
+    item (str): a hex encoded string in format \\&#39;XX
+    &#34;&#34;&#34;
+    hexstring = item.replace(&#34;\\&#39;&#34;, &#34;&#34;)
+    hex_bytes = bytes.fromhex(hexstring)
+    return hex_bytes
+
+def decode_hex_char(item, codec):
+    &#34;&#34;&#34;Decode a bytes object using a specified codec.
+
+    item (bytes): A bytes object.
+    codec (str): The name of the codec to use to decode the bytes
+    &#34;&#34;&#34;
+    # print(&#34;decoding char {0} with font {1}&#34;.format(item, codec))
+    if codec is None:
+        # Default to U.S. Windows default codepage
+        codec = &#39;CP1252&#39;
+    decoded = item.decode(codec)
+    # print(&#34;char {0} decoded into {1} using codec {2}&#34;.format(item, decoded, codec))
+    return decoded
+
+
+
+
+
+class TextDecoder:
+
+    def __init__(self, keep_fontdef=False,
+               initial_byte_count=None, use_ASCII_alternatives_on_unicode_decode_failure=False):
+        &#34;&#34;&#34;
+        keep_fontdef: (bool) If False (default), will remove fontdef&#39;s from object tree once they are processed.
+        initial_byte_count: (int) The initial Unicode Character Byte Count. Does not need to be set unless you are only providing a RTF snippet which does not contain the RTF header which sets the  information.
+        use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors when decoding unicode chars we will use the ASCII alternative since that&#39;s what they are included for.
+
+        &#34;&#34;&#34;
+        self.keep_fontdef = keep_fontdef
+        self.ucbc = initial_byte_count
+        self.use_ASCII_alternatives_on_unicode_decode_failure = use_ASCII_alternatives_on_unicode_decode_failure
+
+        # Font table values set set_font_info
+        self.default_font = None
+        self.font_stack = []
+        self.font_table = {}
+
+
+    def set_font_info(self, obj):
+        &#34;&#34;&#34;
+
+        obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+        &#34;&#34;&#34;
+        self.default_font = get_default_font(obj)
+        self.font_stack = [self.default_font]
+        raw_fonttbl = get_font_table(obj.children[1])
+        self.font_table = parse_font_tree(raw_fonttbl)
+        # print(raw_fonttbl)
+
+
+    def update_children(self, obj):
+        &#34;&#34;&#34;
+
+        obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+        &#34;&#34;&#34;
+        # Reset font info
+        self.set_font_info(obj)
+        children = obj.children
+        obj.children = [i for i in self.iterate_on_children(children)]
+
+    def prep_unicode(self, children):
+        if includes_unicode_chars(children):
+            # Clean out all replacement chars
+            # print(&#34;\n===\nORIGINAL:&#34; + repr(children))
+            children, ascii_map = remove_unicode_replacements(children,
+                                                              byte_count=self.ucbc)
+            # print(&#34;===\nCHILD:&#34; + repr(children))
+            # print(&#34;===\nASCII:&#34; + repr(ascii_map))
+            # Merge all surrogate pairs
+            children = merge_surrogate_chars(children,
+                                             ascii_map,
+                                             self.use_ASCII_alternatives_on_unicode_decode_failure)
+            # print(&#34;FINAL CHILDREN&#34;)
+            # print(repr(children))
+        return children
+
+
+    def iterate_on_children(self, children):
+        set_fonts = []
+        # print(&#34;Starting to iterate on children&#34;)
+        # print(&#34;PREP-B4: &#34;+repr(children))
+        children = self.prep_unicode(children)
+        # print(&#34;PREP-AFTER: &#34;+repr(children))
+
+
+        for item in children:
+            if is_font_number(item): # Font Definitions
+                self.font_stack.append(item.value.strip())
+                set_fonts.append(item.value)
+                if self.keep_fontdef is True:
+                    yield item
+            elif is_unicode_char_byte_count(item):
+                bc = get_unicode_char_byte_count(item)
+            elif is_unicode_encoded(item): # Unicode Chars
+                decoded = unicode_escape_to_chr(item.value)
+                # Convert into STRING token
+                decoded_tok = Token(&#39;STRING&#39;,
+                                    decoded,
+                                    start_pos=item.start_pos,
+                                    end_pos=item.end_pos,
+                                    line=item.line,
+                                    end_line=item.end_line,
+                                    column=item.column,
+                                    end_column=item.end_column)
+                # print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
+                yield decoded_tok
+            # Decode a hex array
+            elif is_hexarray(item):
+                # print(&#34;IS Hex?? {0}&#34;.format(item))
+                base_bytes = None
+                for hexchild in item.children:
+                    if base_bytes is None:
+                        base_bytes = get_bytes_from_hex_encoded(hexchild.value)
+                    else:
+                        base_bytes += get_bytes_from_hex_encoded(hexchild.value)
+                current_fontdef = self.font_table[self.font_stack[-1]]
+                current_codec = current_fontdef.codec
+                # print(current_fontdef)
+                decoded_hex = decode_hex_char(base_bytes, current_codec)
+                # We are replacing a Tree. So, need item.data to access it&#39;s info token
+                decoded_hex_tok = Token(&#39;STRING&#39;,
+                                        decoded_hex,
+                                        start_pos=item.data.start_pos,
+                                        end_pos=item.data.end_pos,
+                                        line=item.data.line,
+                                        end_line=item.data.end_line,
+                                        column=item.data.column,
+                                        end_column=item.data.end_column)
+                yield decoded_hex_tok
+            elif isinstance(item, Tree):
+                # Run this same function recursively on nested trees
+                item.children = [i for i in self.iterate_on_children(item.children)]
+                yield item
+            else:
+                yield item
+        for i in set_fonts:
+            # Remove all fonts defined while in this group
+            self.font_stack.pop()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="RTFDE.text_extraction.check_codepage_num"><code class="name flex">
+<span>def <span class="ident">check_codepage_num</span></span>(<span>codepage_num: int) ‑> int</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Provide the codepage number back to you if it is valid.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>codepage_num</code></strong> :&ensp;<code>int</code></dt>
+<dd>A possible codepage number.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The codepage number IF it is a valid codepage number</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>The codepage_num provided isn't a valid codepage number.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def check_codepage_num(codepage_num: int) -&gt; int:
+    &#34;&#34;&#34;Provide the codepage number back to you if it is valid.
+
+Args:
+    codepage_num (int): A possible codepage number.
+
+Returns:
+    The codepage number IF it is a valid codepage number
+
+Raises:
+    ValueError: The codepage_num provided isn&#39;t a valid codepage number.
+
+&#34;&#34;&#34;
+    # This keyword should be emitted in the RTF header section right after the \ansi, \mac, \pc or \pca keyword. But, various document tags like \fbids often are thrown all over the header so we have to check the first group of headers for it.
+    # Code page names from https://docs.microsoft.com/en-gb/windows/desktop/Intl/code-page-identifiers
+    # Retrieved on 2020-12-18
+    allowed_codepage_nums = set([37, 437, 500, 708, 709, 710, 720, 737, 775, 850, 852, 855, 857, 858, 860, 861, 862, 863, 864, 865, 866, 869, 870, 874, 875, 932, 936, 949, 950, 1026, 1047, 1140, 1141, 1142, 1143, 1144, 1145, 1146, 1147, 1148, 1149, 1200, 1201, 1250, 1251, 1252, 1253, 1254, 1255, 1256, 1257, 1258, 1361, 10000, 10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10010, 10017, 10021, 10029, 10079, 10081, 10082, 12000, 12001, 20000, 20001, 20002, 20003, 20004, 20005, 20105, 20106, 20107, 20108, 20127, 20261, 20269, 20273, 20277, 20278, 20280, 20284, 20285, 20290, 20297, 20420, 20423, 20424, 20833, 20838, 20866, 20871, 20880, 20905, 20924, 20932, 20936, 20949, 21025, 21027, 21866, 28591, 28592, 28593, 28594, 28595, 28596, 28597, 28598, 28599, 28603, 28605, 29001, 38598, 50220, 50221, 50222, 50225, 50227, 50229, 50930, 50931, 50933, 50935, 50936, 50937, 50939, 51932, 51936, 51949, 51950, 52936, 54936, 57002, 57003, 57004, 57005, 57006, 57007, 57008, 57009, 57010, 57011, 65000, 65001])
+    if codepage_num in allowed_codepage_nums:
+        return codepage_num
+    # Note: If support for a specific codepage ever becomes an issue we can look at add support using the actual code-pages.
+    # Conversion tables for codepages can be retrieved from here: https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/
+    raise ValueError(f&#34;Unsupported unicode codepage number `{codepage_num}` found in the header&#34;)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.decode_hex_char"><code class="name flex">
+<span>def <span class="ident">decode_hex_char</span></span>(<span>item, codec)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Decode a bytes object using a specified codec.</p>
+<p>item (bytes): A bytes object.
+codec (str): The name of the codec to use to decode the bytes</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def decode_hex_char(item, codec):
+    &#34;&#34;&#34;Decode a bytes object using a specified codec.
+
+    item (bytes): A bytes object.
+    codec (str): The name of the codec to use to decode the bytes
+    &#34;&#34;&#34;
+    # print(&#34;decoding char {0} with font {1}&#34;.format(item, codec))
+    if codec is None:
+        # Default to U.S. Windows default codepage
+        codec = &#39;CP1252&#39;
+    decoded = item.decode(codec)
+    # print(&#34;char {0} decoded into {1} using codec {2}&#34;.format(item, decoded, codec))
+    return decoded</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.decode_surrogate_pair"><code class="name flex">
+<span>def <span class="ident">decode_surrogate_pair</span></span>(<span>high, low, encoding='utf-16-le')</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.</p>
+<p>high (chr): the high-surrogate code point
+low (chr): the low-surrogate code point
+encoding (str): The encoding to apply to the final value. Defaults to 'utf-16-le' because:
+Microsoft uses UTF-16, little endian byte order. ( <a href="https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks">https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks</a> ) The Msg format is a Microsoft standard. Therefore, man is mortal.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def decode_surrogate_pair(high, low, encoding=&#39;utf-16-le&#39;):
+    &#34;&#34;&#34; Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.
+
+        high (chr): the high-surrogate code point
+        low (chr): the low-surrogate code point
+        encoding (str): The encoding to apply to the final value. Defaults to &#39;utf-16-le&#39; because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
+    &#34;&#34;&#34;
+    # Equation for turning surrogate pairs into a unicode scalar value which be used with utl-16 can ONLY found in Unicode 3.0.0 standard.
+    # Unicode scalar value means the same thing as &#34;code position&#34; or &#34;code point&#34;
+     # https://www.unicode.org/versions/Unicode3.0.0/
+     # section 3.7 https://www.unicode.org/versions/Unicode3.0.0/ch03.pdf#page=9
+    if high.startswith(&#34;\\u&#34;):
+        high = high[2:]
+    if low.startswith(&#34;\\u&#34;):
+        low = low[2:]
+    high = chr(65536+int(high))
+    low = chr(65536+int(low))
+    unicode_scalar_value = ((ord(high) - 0xD800) * 0x400) + (ord(low) - 0xDC00) + 0x10000
+    unicode_bytes = chr(unicode_scalar_value).encode(encoding)
+    return unicode_bytes.decode(encoding)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.get_bytes_from_hex_encoded"><code class="name flex">
+<span>def <span class="ident">get_bytes_from_hex_encoded</span></span>(<span>item)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert hex encoded string to bytes.</p>
+<p>item (str): a hex encoded string in format 'XX</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_bytes_from_hex_encoded(item):
+    &#34;&#34;&#34;Convert hex encoded string to bytes.
+
+    item (str): a hex encoded string in format \\&#39;XX
+    &#34;&#34;&#34;
+    hexstring = item.replace(&#34;\\&#39;&#34;, &#34;&#34;)
+    hex_bytes = bytes.fromhex(hexstring)
+    return hex_bytes</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.get_codepage_num_from_fcharset"><code class="name flex">
+<span>def <span class="ident">get_codepage_num_from_fcharset</span></span>(<span>fcharsetN: int) ‑> Optional[int]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the codepage to use with a specific fcharsetN.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>fcharsetN</code></strong> :&ensp;<code>int</code></dt>
+<dd>The numeric argument N for a
+charsetN control word.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>(int OR None) Returns the int for a codepage if known. Returns None for unknown charsets or charsets with no corresponding codepage (such as OEM or DEFAULT.)</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_codepage_num_from_fcharset(fcharsetN: int) -&gt; Union[int,None]:
+    &#34;&#34;&#34;Return the codepage to use with a specific fcharsetN.
+
+Args:
+    fcharsetN (int): The numeric argument N for a \fcharsetN control word.
+
+Returns:
+    (int OR None) Returns the int for a codepage if known. Returns None for unknown charsets or charsets with no corresponding codepage (such as OEM or DEFAULT.)
+
+    &#34;&#34;&#34;
+    # Charset table retrieved on 2022-08-19
+    # https://web.archive.org/web/20220819215334/https://docs.microsoft.com/en-us/previous-versions/cc194829%28v=msdn.10%29?redirectedfrom=MSDN
+    charsets: dict[int,dict[str,Any]] = {
+        0:{&#34;name&#34;:&#34;ANSI_CHARSET&#34;,&#34;hex&#34;:&#34;0x00&#34;,&#34;decimal&#34;:0,&#34;id&#34;:1252},
+        1:{&#34;name&#34;:&#34;DEFAULT_CHARSET&#34;,&#34;hex&#34;:&#34;0x01&#34;,&#34;decimal&#34;:1,&#34;id&#34;:None},
+        2:{&#34;name&#34;:&#34;SYMBOL_CHARSET&#34;,&#34;hex&#34;:&#34;0x02&#34;,&#34;decimal&#34;:2,&#34;id&#34;:None},
+        128:{&#34;name&#34;:&#34;SHIFTJIS_CHARSET&#34;,&#34;hex&#34;:&#34;0x80&#34;,&#34;decimal&#34;:128,&#34;id&#34;:932},
+        129:{&#34;name&#34;:&#34;HANGUL_CHARSET&#34;,&#34;hex&#34;:&#34;0x81&#34;,&#34;decimal&#34;:129,&#34;id&#34;:949},
+        134:{&#34;name&#34;:&#34;GB2312_CHARSET&#34;,&#34;hex&#34;:&#34;0x86&#34;,&#34;decimal&#34;:134,&#34;id&#34;:936},
+        136:{&#34;name&#34;:&#34;CHINESEBIG5_CHARSET&#34;,&#34;hex&#34;:&#34;0x88&#34;,&#34;decimal&#34;:136,&#34;id&#34;:950},
+        161:{&#34;name&#34;:&#34;GREEK_CHARSET&#34;,&#34;hex&#34;:&#34;0xA1&#34;,&#34;decimal&#34;:161,&#34;id&#34;:1253},
+        162:{&#34;name&#34;:&#34;TURKISH_CHARSET&#34;,&#34;hex&#34;:&#34;0xA2&#34;,&#34;decimal&#34;:162,&#34;id&#34;:1254},
+        177:{&#34;name&#34;:&#34;HEBREW_CHARSET&#34;,&#34;hex&#34;:&#34;0xB1&#34;,&#34;decimal&#34;:177,&#34;id&#34;:1255},
+        178:{&#34;name&#34;:&#34;ARABIC_CHARSET&#34;,&#34;hex&#34;:&#34;0xB2&#34;,&#34;decimal&#34;:178,&#34;id&#34;:1256},
+        186:{&#34;name&#34;:&#34;BALTIC_CHARSET&#34;,&#34;hex&#34;:&#34;0xBA&#34;,&#34;decimal&#34;:186,&#34;id&#34;:1257},
+        204:{&#34;name&#34;:&#34;RUSSIAN_CHARSET&#34;,&#34;hex&#34;:&#34;0xCC&#34;,&#34;decimal&#34;:204,&#34;id&#34;:1251},
+        222:{&#34;name&#34;:&#34;THAI_CHARSET&#34;,&#34;hex&#34;:&#34;0xDE&#34;,&#34;decimal&#34;:222,&#34;id&#34;:874},
+        238:{&#34;name&#34;:&#34;EE_CHARSET&#34;,&#34;hex&#34;:&#34;0xEE&#34;,&#34;decimal&#34;:238,&#34;id&#34;:1250},
+        255:{&#34;name&#34;:&#34;OEM_CHARSET&#34;,&#34;hex&#34;:&#34;0xFF&#34;,&#34;decimal&#34;:255,&#34;id&#34;:None},
+}
+    # print(f&#34;Getting charset for {fcharsetN}&#34;)
+    charset = charsets.get(fcharsetN, None)
+    if charset is not None:
+        charset_id = charset.get(&#39;id&#39;, None)
+        return charset_id
+    return None</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.get_default_font"><code class="name flex">
+<span>def <span class="ident">get_default_font</span></span>(<span>tree: lark.tree.Tree) ‑> Optional[str]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extract the font number controlword default font if it exists.</p>
+<p>If an RTF file uses a default font, the default font number is specified with the \deffN control word, which must precede the font-table group.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>tree</code></strong> :&ensp;<code>Tree</code></dt>
+<dd>A lark Tree object. Should be the DeEncapsulator.full_tree object.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The default font control number if it exists from the first <code>\deffN</code>. None if not found.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_default_font(tree: Tree) -&gt; Union[str,None]:
+    &#34;&#34;&#34;Extract the font number controlword default font if it exists.
+
+If an RTF file uses a default font, the default font number is specified with the \\deffN control word, which must precede the font-table group.
+
+Args:
+    tree (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree object.
+
+Returns:
+    The default font control number if it exists from the first `\\deffN`. None if not found.
+&#34;&#34;&#34;
+    deff_gen = tree.scan_values(
+        lambda v: is_codeword_with_numeric_arg(v, &#39;\\deff&#39;)
+    )
+    deff_options = list(deff_gen)
+    try:
+        # We just want the first \\deffN. It shouldn&#39;t be set multiple times.
+        deff = deff_options[0]
+        deff_num = deff.value[5:]
+        return &#39;\\f&#39; + deff_num
+    except IndexError:
+        return None</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.get_font_table"><code class="name flex">
+<span>def <span class="ident">get_font_table</span></span>(<span>tree: lark.tree.Tree) ‑> lark.tree.Tree</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extract the font table group from the first 20 tokens of a .rtf document.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>tree</code></strong> :&ensp;<code>Tree</code></dt>
+<dd>A .rtf document object parsed into a Tree object</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If no group with a <code>\fonttbl</code> token as its first controlword is found.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>{'\f0': fontdef(fnum='\f0', codepage=932, codec='cp932', fontdef_tree='{\f0\fswiss\fcharset128 MS PGothic;}'),
+'\f1': fontdef(fnum='\f1', codepage=None, codec=None, fontdef_tree='{\f1\fmodern MS Gothic;}'),
+'\f2': fontdef(fnum='\f2', codepage=None, codec=None, fontdef_tree='{\f2\fnil\fcharset2 Symbol;}'),
+'\f3': fontdef(fnum='\f3', codepage=1252, codec='cp1252', fontdef_tree='{\f3\fmodern\fcharset0 Courier New;}'),
+'\f4': fontdef(fnum='\f4', codepage=932, codec='cp932', fontdef_tree='{\f4\fswiss\fcharset128 "PMingLiU";}'),
+'\f5': fontdef(fnum='\f5', codepage=None, codec=None, fontdef_tree='{\f5\fswiss "Amnesty Trade Gothic";}'),
+'\f6': fontdef(fnum='\f6', codepage=None, codec=None, fontdef_tree='{\f6\fswiss "Arial";}')}</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_font_table(tree: Tree) -&gt; Tree:
+    &#34;&#34;&#34;Extract the font table group from the first 20 tokens of a .rtf document.
+
+Args:
+    tree (Tree): A .rtf document object parsed into a Tree object
+
+Raises:
+    ValueError: If no group with a `\\fonttbl` token as its first controlword is found.
+
+Returns:
+    {&#39;\\f0&#39;: fontdef(fnum=&#39;\\f0&#39;, codepage=932, codec=&#39;cp932&#39;, fontdef_tree=&#39;{\\f0\\fswiss\\fcharset128 MS PGothic;}&#39;),
+    &#39;\\f1&#39;: fontdef(fnum=&#39;\\f1&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f1\\fmodern MS Gothic;}&#39;),
+    &#39;\\f2&#39;: fontdef(fnum=&#39;\\f2&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f2\\fnil\\fcharset2 Symbol;}&#39;),
+    &#39;\\f3&#39;: fontdef(fnum=&#39;\\f3&#39;, codepage=1252, codec=&#39;cp1252&#39;, fontdef_tree=&#39;{\\f3\\fmodern\\fcharset0 Courier New;}&#39;),
+    &#39;\\f4&#39;: fontdef(fnum=&#39;\\f4&#39;, codepage=932, codec=&#39;cp932&#39;, fontdef_tree=&#39;{\\f4\\fswiss\\fcharset128 &#34;PMingLiU&#34;;}&#39;),
+    &#39;\\f5&#39;: fontdef(fnum=&#39;\\f5&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f5\\fswiss &#34;Amnesty Trade Gothic&#34;;}&#39;),
+    &#39;\\f6&#39;: fontdef(fnum=&#39;\\f6&#39;, codepage=None, codec=None, fontdef_tree=&#39;{\\f6\\fswiss &#34;Arial&#34;;}&#39;)}
+    &#34;&#34;&#34;
+    for item in tree.children[:20]:
+        if isinstance(item, Tree):
+            try:
+                ctrl_value = item.children[1]
+            except IndexError as _e:
+                continue
+            if isinstance(ctrl_value, Token):
+                table_type = ctrl_value.value.strip()
+                if table_type == &#34;\\fonttbl&#34;:
+                    return item
+    raise ValueError(&#34;No font table found in tree&#34;)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.get_python_codec"><code class="name flex">
+<span>def <span class="ident">get_python_codec</span></span>(<span>codepage_num: int) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the python codec needed to decode bytes to unicode.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>codepage_num</code></strong> :&ensp;<code>int</code></dt>
+<dd>A codepage number.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_python_codec(codepage_num: int) -&gt; str:
+    &#34;&#34;&#34;Returns the python codec needed to decode bytes to unicode.
+
+Args:
+    codepage_num (int): A codepage number.
+
+Returns:
+    The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
+&#34;&#34;&#34;
+    text_codec = codepages.codepage2codec(codepage_num)
+    log.debug(&#39;Found python codec corresponding to code page {0}: {1}&#39;.format(codepage_num, text_codec))
+    return text_codec</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.get_unicode_char_byte_count"><code class="name flex">
+<span>def <span class="ident">get_unicode_char_byte_count</span></span>(<span>item)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_unicode_char_byte_count(item):
+    cur_uc = int(item[3:])
+    return cur_uc</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.has_hexarray"><code class="name flex">
+<span>def <span class="ident">has_hexarray</span></span>(<span>children)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks if an tree's children includes a hexarray tree.</p>
+<p>children (array): the children object from a tree.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def has_hexarray(children):
+    &#34;&#34;&#34;Checks if an tree&#39;s children includes a hexarray tree.
+
+    children (array): the children object from a tree.
+    &#34;&#34;&#34;
+    for item in children:
+        if is_hexarray(item):
+            return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.includes_unicode_chars"><code class="name flex">
+<span>def <span class="ident">includes_unicode_chars</span></span>(<span>children: List[lark.lexer.Token]) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Does a list include Tokens which contain unicode characters. Not recursive.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>children</code></strong> :&ensp;<code>list</code></dt>
+<dd>A Tree.children list to check to see if it includes unicode characters.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>True if list includes tokens which contain unicode chars. False if not.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def includes_unicode_chars(children: List[Token]) -&gt; bool:
+    &#34;&#34;&#34;Does a list include Tokens which contain unicode characters. Not recursive.
+
+Args:
+    children (list): A Tree.children list to check to see if it includes unicode characters.
+
+Returns:
+    True if list includes tokens which contain unicode chars. False if not.
+&#34;&#34;&#34;
+    for child in children:
+        if is_unicode_encoded(child):
+            return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_font_number"><code class="name flex">
+<span>def <span class="ident">is_font_number</span></span>(<span>token: lark.lexer.Token) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks if an object is a "font number".</p>
+<h2 id="returns">Returns</h2>
+<p>True if an object is a "font number" controlword <code>\fN</code>. False if not.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_font_number(token: Token) -&gt; bool:
+    &#34;&#34;&#34;Checks if an object is a &#34;font number&#34;.
+
+Returns:
+    True if an object is a &#34;font number&#34; controlword `\\fN`. False if not.
+
+&#34;&#34;&#34;
+    try:
+        if is_codeword_with_numeric_arg(token, &#39;\\f&#39;):
+            return True
+    except AttributeError: # pragma: no cover
+        return False
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_hex_encoded"><code class="name flex">
+<span>def <span class="ident">is_hex_encoded</span></span>(<span>item: lark.lexer.Token) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Identify if a token contains a HEXENCODED token.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item</code></strong> :&ensp;<code>token</code></dt>
+<dd>A token to check if it is HEXENCODED.</dd>
+</dl>
+<h2 id="return">Return</h2>
+<p>True if HEXENCODED. False if not.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_hex_encoded(item: Token) -&gt; bool:
+    &#34;&#34;&#34;Identify if a token contains a HEXENCODED token.
+Args:
+    item (token): A token to check if it is HEXENCODED.
+
+Return:
+    True if HEXENCODED. False if not.
+    &#34;&#34;&#34;
+    if isinstance(item, Token):
+        if item.type == &#34;HEXENCODED&#34;:
+            return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_hexarray"><code class="name flex">
+<span>def <span class="ident">is_hexarray</span></span>(<span>item)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks if an item is a hexarray tree.</p>
+<p>item (Tree or Token): an item to check to see if its a hex array</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_hexarray(item):
+    &#34;&#34;&#34;Checks if an item is a hexarray tree.
+
+    item (Tree or Token): an item to check to see if its a hex array
+    &#34;&#34;&#34;
+    if isinstance(item, Tree):
+        if item.data.value == &#39;hexarray&#39;:
+            return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_surrogate_high_char"><code class="name flex">
+<span>def <span class="ident">is_surrogate_high_char</span></span>(<span>item)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check's if chr is a is in the high-surrogate code point rage. "High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF." High-surrogate also sometimes known as the leading surrogate.</p>
+<p>item (str): A string representing a unicode character. "\u-10179"</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_surrogate_high_char(item):
+    &#34;&#34;&#34;Check&#39;s if chr is a is in the high-surrogate code point rage. &#34;High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF.&#34; High-surrogate also sometimes known as the leading surrogate.
+
+        item (str): A string representing a unicode character. &#34;\\u-10179&#34;
+    &#34;&#34;&#34;
+    if item.startswith(&#34;\\u&#34;):
+        item = item[2:]
+    if 0xD800 &lt;= ord(chr(65536+int(item))) &lt;= 0xDBFF:
+        return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_surrogate_low_char"><code class="name flex">
+<span>def <span class="ident">is_surrogate_low_char</span></span>(<span>item)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check's if chr is a is in the low-surrogate code point rage. "Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF."
+Low-surrogate also sometimes known as following surrogates.</p>
+<p>item (str): A string representing a unicode character.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_surrogate_low_char(item):
+    &#34;&#34;&#34;Check&#39;s if chr is a is in the low-surrogate code point rage. &#34;Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF.&#34;  Low-surrogate also sometimes known as following surrogates.
+
+        item (str): A string representing a unicode character.
+    &#34;&#34;&#34;
+    if item.startswith(&#34;\\u&#34;):
+        item = item[2:]
+    if 0xDC00 &lt;= ord(chr(65536+int(item))) &lt;= 0xDFFF:
+        return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_surrogate_pair"><code class="name flex">
+<span>def <span class="ident">is_surrogate_pair</span></span>(<span>first, second)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_surrogate_pair(first, second):
+    &#34;&#34;&#34;Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.
+    &#34;&#34;&#34;
+    if is_surrogate_high_char(first):
+        if is_surrogate_low_char(second):
+            return True
+        else:
+            log.info(&#34;RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}&#34;.format(first, second))
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_unicode_char_byte_count"><code class="name flex">
+<span>def <span class="ident">is_unicode_char_byte_count</span></span>(<span>item: lark.lexer.Token) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_unicode_char_byte_count(item: Token) -&gt; bool:
+    if isinstance(item, Token):
+        if item.type == &#34;CONTROLWORD&#34;:
+            if item.value.startswith(&#39;\\uc&#39;):
+                return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_unicode_encoded"><code class="name flex">
+<span>def <span class="ident">is_unicode_encoded</span></span>(<span>item: lark.lexer.Token) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Is token contain a unicode char.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item</code></strong> :&ensp;<code>token</code></dt>
+<dd>A token to check if contains a unicode char.</dd>
+</dl>
+<h2 id="return">Return</h2>
+<p>True if token contains a unicode char. False if not.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_unicode_encoded(item: Token) -&gt; bool:
+    &#34;&#34;&#34;Is token contain a unicode char.
+
+Args:
+    item (token): A token to check if contains a unicode char.
+
+Return:
+    True if token contains a unicode char. False if not.
+&#34;&#34;&#34;
+    if isinstance(item, Token):
+        if item.type == &#34;UNICODE&#34;:
+            return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_valid_ANSI_representation_char"><code class="name flex">
+<span>def <span class="ident">is_valid_ANSI_representation_char</span></span>(<span>item: lark.lexer.Token) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Is token contain a valid ANSI representation string for a Unicode char.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item</code></strong> :&ensp;<code>token</code></dt>
+<dd>A token to check if it is a valid ANSI representation.</dd>
+</dl>
+<h2 id="return">Return</h2>
+<p>True if token is an ansi representation of a unicode char. False if not.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_valid_ANSI_representation_char(item: Token) -&gt; bool:
+    &#34;&#34;&#34;Is token contain a valid ANSI representation string for a Unicode char.
+
+Args:
+    item (token): A token to check if it is a valid ANSI representation.
+
+Return:
+    True if token is an ansi representation of a unicode char. False if not.
+&#34;&#34;&#34;
+    if isinstance(item, Token):
+        # print(f&#34;found TOKEN posssible ansi {repr(item)}&#34;)
+        if is_hex_encoded(item):
+            # print(f&#34;found hex posssible ansi {repr(item)}&#34;)
+            return True
+        if item.type == &#39;STRING&#39;:
+            # print(f&#34;found STRING posssible ansi {repr(item)}&#34;)
+            if not item.value.isspace(): # whitespace doesn&#39;t count.
+                # print(f&#34;found posssible ansi {repr(item)}&#34;)
+                return True
+            # else:
+            #     print(f&#34;found SPACE posssible ansi {repr(item)}&#34;)
+    # print(f&#34;found NON TOKEN posssible ansi {repr(item)}&#34;)
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.merge_surrogate_chars"><code class="name flex">
+<span>def <span class="ident">merge_surrogate_chars</span></span>(<span>children, ascii_map, use_ASCII_alternatives_on_unicode_decode_failure=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>A Standalone high-surrogate was found. High surrogate followed by a illegal low-surrogate character.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def merge_surrogate_chars(children, ascii_map,
+                          use_ASCII_alternatives_on_unicode_decode_failure = False):
+    &#34;&#34;&#34;
+
+
+Raises:
+    ValueError:  A Standalone high-surrogate was found. High surrogate followed by a illegal low-surrogate character.
+    &#34;&#34;&#34;
+    surrogate_start = None
+    surrogate_high = None
+    for i,c in enumerate(children):
+        if isinstance(c, Tree):
+            continue
+        if is_unicode_encoded(c):
+            if is_surrogate_high_char(c.value):
+                surrogate_start = i
+                surrogate_high = c
+            elif surrogate_start is not None:
+                if is_surrogate_low_char(c.value):
+                    surrogate_low = c
+                    try:
+                        surrogate_value = decode_surrogate_pair(surrogate_high.value,
+                                                                surrogate_low.value)
+                        # Convert into STRING token
+                        surrogate_tok = Token(&#39;STRING&#39;,
+                                              surrogate_value,
+                                              start_pos=surrogate_high.start_pos,
+                                              end_pos=surrogate_low.end_pos,
+                                              line=surrogate_high.line,
+                                              end_line=surrogate_low.end_line,
+                                              column=surrogate_high.column,
+                                              end_column=surrogate_low.end_column)
+                        children[surrogate_start] = surrogate_tok
+                        children[i] = &#34;&#34;
+                        surrogate_start = None
+                        surrogate_high = None
+                    except UnicodeDecodeError as _e:
+                        if use_ASCII_alternatives_on_unicode_decode_failure is True:
+                            children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                            children[i] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_low]])
+                        else:
+                            raise _e
+                else:
+                    log.info(&#34;RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}&#34;.format(surrogate_high, surrogate_low))
+                    if use_ASCII_alternatives_on_unicode_decode_failure is True:
+                        children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                    else:
+                        raise ValueError(&#34;Standalone high-surrogate found. High surrogate followed by a illegal low-surrogate character.&#34;)
+    return children</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.parse_font_tree"><code class="name flex">
+<span>def <span class="ident">parse_font_tree</span></span>(<span>font_tree: lark.tree.Tree) ‑> dict</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Create a font tree dictionary with appropriate codeces to decode text.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>font_tree</code></strong> :&ensp;<code>Tree</code></dt>
+<dd>The .rtf font table object decoded as a tree.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A dictionary which maps font numbers to appropriate python codeces needed to decode text.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def parse_font_tree(font_tree: Tree) -&gt; dict:
+    &#34;&#34;&#34;Create a font tree dictionary with appropriate codeces to decode text.
+
+Args:
+    font_tree (Tree): The .rtf font table object decoded as a tree.
+
+Returns:
+    A dictionary which maps font numbers to appropriate python codeces needed to decode text.
+&#34;&#34;&#34;
+    parsed_font_tree = {}
+    for tree in font_tree.children:
+        if isinstance(tree, Tree):
+            fnum = None
+            fcharset = None
+            cpg_num = None
+            for tok in tree.children:
+                if is_codeword_with_numeric_arg(tok, &#39;\\f&#39;):
+                    fnum = tok.value
+                elif is_codeword_with_numeric_arg(tok, &#39;\\fcharset&#39;):
+                    fchar_num = int(tok.value[9:])
+                    fcharset = get_codepage_num_from_fcharset(fchar_num)
+                elif is_codeword_with_numeric_arg(tok, &#39;\\cpg&#39;):
+                    cpg_num = int(tok.value[4:])
+            if fnum is not None:
+                # get the codepage
+                codepage_num = None
+
+                if fcharset is not None:
+                    try:
+                        codepage_num = check_codepage_num(fcharset)
+                    except ValueError: # pragma: no cover
+                        codepage_num = None
+                # if both \\fcharset and \\cpg appear in the font table, \\cpg is ignored.
+                if ((codepage_num is None) and (cpg_num is not None)):
+                    try:
+                        codepage_num = check_codepage_num(cpg_num)
+                    except ValueError: # pragma: no cover
+                        codepage_num = None
+                # Get the appropriate codec
+                if codepage_num is not None:
+                    codec = get_python_codec(codepage_num)
+                else:
+                    codec = None
+                # Only add if there is a font definition
+                tree_str =  &#34;&#34;.join(list(flatten_tree_to_string_array(tree)))
+                parsed_font_tree[fnum] = fontdef(fnum, codepage_num, codec, tree_str)
+    return parsed_font_tree</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.remove_unicode_replacements"><code class="name flex">
+<span>def <span class="ident">remove_unicode_replacements</span></span>(<span>children: List[lark.lexer.Token], return_ascii_map: bool = True, byte_count: int = 1) ‑> Union[Tuple[List[lark.lexer.Token], Dict[lark.lexer.Token, List[lark.lexer.Token]]], List[lark.lexer.Token]]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Remove all unicode replacement characters from a list of Tokens.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>children</code></strong> :&ensp;<code>list</code></dt>
+<dd>A Tree.children list to remove unicode replacement characters from.</dd>
+<dt><strong><code>return_ascii_map</code></strong> :&ensp;<code>bool</code></dt>
+<dd>On True, have this function return a map of the ASCII token that were removed.</dd>
+<dt><strong><code>byte_count</code></strong> :&ensp;<code>int</code></dt>
+<dd>The number of bytes corresponding to a given \uN Unicode character.
+A default of 1 should be assumed if no \uc keyword has been seen in the current or outer scopes.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>new_children (list): The list of Tokens with all unicode replacement characters removed.
+ascii_map (dict): All the Tokens which were removed from the provided children list keyed by</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def remove_unicode_replacements(children: List[Token],
+                                return_ascii_map: bool = True,
+                                byte_count: int = 1) -&gt; Union[
+                                    Tuple[List[Token], Dict[Token,List[Token]]],
+                                    List[Token]]:
+    &#34;&#34;&#34;Remove all unicode replacement characters from a list of Tokens.
+
+Args:
+    children (list): A Tree.children list to remove unicode replacement characters from.
+    return_ascii_map (bool): On True, have this function return a map of the ASCII token that were removed.
+    byte_count (int): The number of bytes corresponding to a given \\uN Unicode character.  A default of 1 should be assumed if no \\uc keyword has been seen in the current or outer scopes.
+
+Returns:
+    new_children (list): The list of Tokens with all unicode replacement characters removed.
+    ascii_map (dict): All the Tokens which were removed from the provided children list keyed by
+
+&#34;&#34;&#34;
+    byte_count = 1
+    ascii_map: Dict[Token,List[Token]]  = {}
+    new_children = []
+    removal_map: List[Token] = []
+    # print(f&#34;Removing unicode replacements on {repr(children)}&#34;)
+    for child in children:
+        if len(removal_map) &gt; 0:
+            if isinstance(child, Token):
+                # Delete all spaces between a unicode char and the last ANSI representation
+                # print(f&#34;FOUND SPACE STRING with RM: {removal_map}&#34;)
+                if child.value.isspace():
+                    ascii_map.setdefault(removal_map[0], []).append(child)
+                    continue
+            if is_valid_ANSI_representation_char(child):
+                # Found an ansi representation removing unicode char from removal map.
+                # print(f&#34;FOUND ASCII STRING {child} to RM with RM: {removal_map}&#34;)
+                ascii_map.setdefault(removal_map.pop(), []).append(child)
+                continue
+            elif isinstance(child, Tree) and (
+                    (child.data == &#34;string&#34;) or (child.data == &#34;hexarray&#34;)):
+                # print(f&#34;FOUND ASCII STRING {child} with RM: {removal_map}&#34;)
+                ansi_children = child.children
+                new_ansi_children = []
+                for aci,ac in enumerate(ansi_children):
+                    # print(f&#34;AC CHILD {repr(ac)}&#34;)
+                    if is_valid_ANSI_representation_char(ac):
+                        # print(f&#34;AC CHILD VALID {repr(ac)}&#34;)
+                        if len(removal_map) &gt; 0:
+                            # print(f&#34;AC CHILD MAP &gt;0 {repr(ac)}&#34;)
+                            # print(f&#34;Popping removal for {repr(ac)}&#34;)
+                            ascii_map.setdefault(removal_map.pop(), []).append(ac)
+                        else:
+                            # print(f&#34;AC CHILD MAP &lt; 0 {repr(ac)}&#34;)
+                            new_ansi_children.append(ac)
+                    else:
+                        # print(f&#34;AC CHILD NOT VALID {repr(ac)}&#34;)
+                        new_ansi_children.append(ac)
+                child.children = new_ansi_children
+                # print(f&#34;NEW Tree = {child}&#34;)
+            # else:
+                # print(f&#34;FOUND ASCII STRING {child} with RM: {removal_map}&#34;)
+                # print(f&#34;{repr(child)} not a valid ANSI representation? with RM: {removal_map}&#34;)
+        # Modify char byte count if we encounter it.
+        if is_unicode_char_byte_count(child):
+            byte_count = get_unicode_char_byte_count(child)
+            # print(f&#34;Changing byte count because {child} to {byte_count}&#34;)
+        if is_unicode_encoded(child):
+            # print(f&#34;Found unicode {child}&#34;)
+            for j in range(byte_count):
+                # Add the unicode key to the removal map once per byte
+                # This ensures we remove the right number of ANSI representation chars
+                removal_map.append(child)
+        new_children.append(child)
+    if return_ascii_map is True:
+        return new_children, ascii_map
+    return new_children</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.unicode_escape_to_chr"><code class="name flex">
+<span>def <span class="ident">unicode_escape_to_chr</span></span>(<span>item: str) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert unicode char from it's decimal to its unicode character representation. From "\u[-]NNNNN" to the string representing the character whose Unicode code point that decimal represents.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item</code></strong> :&ensp;<code>str</code></dt>
+<dd>A RTF Escape in the format \u[-]NNNNN.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The unicode character representation of the identified character</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>The escaped unicode character is not valid.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def unicode_escape_to_chr(item: str) -&gt; str:
+    &#34;&#34;&#34;Convert unicode char from it&#39;s decimal to its unicode character representation. From &#34;\\u[-]NNNNN&#34; to the string representing the character whose Unicode code point that decimal represents.
+
+Args:
+    item (str): A RTF Escape in the format \\u[-]NNNNN.
+
+Returns:
+    The unicode character representation of the identified character
+
+Raises:
+    ValueError: The escaped unicode character is not valid.
+&#34;&#34;&#34;
+    try:
+        nnnn = int(item.removeprefix(&#39;\\u&#39;)) # raises ValueError if not int.
+    except ValueError as _e:
+        raise ValueError(f&#34;`{item}` is not a valid escaped unicode character.&#34;) from _e
+    if nnnn &lt; 0: # § -NNNNN is a negative integer expressed in decimal digits
+        ncr = 65536 + nnnn
+    else: # § NNNNN is a positive integer expressed in decimal digits
+        ncr = nnnn
+    # § HHHH is the hexadecimal equivalent of NNNNN or -NNNNN
+    return chr(ncr)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.validate_ansi_cpg"><code class="name flex">
+<span>def <span class="ident">validate_ansi_cpg</span></span>(<span>header: str) ‑> None</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check an '\ansicpgNNNN' string to see if the number NNNN is an actual codepage.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>header</code></strong> :&ensp;<code>str</code></dt>
+<dd>The value from the lark <code>\ansicpg</code> CONTROLWORD Token.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>MalformedRtf</code></dt>
+<dd>If the value passed is not a valid ansi codepage.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def validate_ansi_cpg(header: str) -&gt; None:
+    &#34;&#34;&#34;Check an &#39;\\ansicpgNNNN&#39; string to see if the number NNNN is an actual codepage.
+
+Args:
+    header (str): The value from the lark `\\ansicpg` CONTROLWORD Token.
+
+Raises:
+    MalformedRtf: If the value passed is not a valid ansi codepage.
+&#34;&#34;&#34;
+    try:
+        possible_cpg_num = int(header.strip()[8:])
+        check_codepage_num(possible_cpg_num)
+    except ValueError as _e:
+        raise MalformedRtf(f&#34;Unsupported unicode codepage number `{header}` found in the header&#34;) from _e</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="RTFDE.text_extraction.TextDecoder"><code class="flex name class">
+<span>class <span class="ident">TextDecoder</span></span>
+<span>(</span><span>keep_fontdef=False, initial_byte_count=None, use_ASCII_alternatives_on_unicode_decode_failure=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>keep_fontdef: (bool) If False (default), will remove fontdef's from object tree once they are processed.
+initial_byte_count: (int) The initial Unicode Character Byte Count. Does not need to be set unless you are only providing a RTF snippet which does not contain the RTF header which sets the
+information.
+use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors when decoding unicode chars we will use the ASCII alternative since that's what they are included for.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TextDecoder:
+
+    def __init__(self, keep_fontdef=False,
+               initial_byte_count=None, use_ASCII_alternatives_on_unicode_decode_failure=False):
+        &#34;&#34;&#34;
+        keep_fontdef: (bool) If False (default), will remove fontdef&#39;s from object tree once they are processed.
+        initial_byte_count: (int) The initial Unicode Character Byte Count. Does not need to be set unless you are only providing a RTF snippet which does not contain the RTF header which sets the  information.
+        use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors when decoding unicode chars we will use the ASCII alternative since that&#39;s what they are included for.
+
+        &#34;&#34;&#34;
+        self.keep_fontdef = keep_fontdef
+        self.ucbc = initial_byte_count
+        self.use_ASCII_alternatives_on_unicode_decode_failure = use_ASCII_alternatives_on_unicode_decode_failure
+
+        # Font table values set set_font_info
+        self.default_font = None
+        self.font_stack = []
+        self.font_table = {}
+
+
+    def set_font_info(self, obj):
+        &#34;&#34;&#34;
+
+        obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+        &#34;&#34;&#34;
+        self.default_font = get_default_font(obj)
+        self.font_stack = [self.default_font]
+        raw_fonttbl = get_font_table(obj.children[1])
+        self.font_table = parse_font_tree(raw_fonttbl)
+        # print(raw_fonttbl)
+
+
+    def update_children(self, obj):
+        &#34;&#34;&#34;
+
+        obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+        &#34;&#34;&#34;
+        # Reset font info
+        self.set_font_info(obj)
+        children = obj.children
+        obj.children = [i for i in self.iterate_on_children(children)]
+
+    def prep_unicode(self, children):
+        if includes_unicode_chars(children):
+            # Clean out all replacement chars
+            # print(&#34;\n===\nORIGINAL:&#34; + repr(children))
+            children, ascii_map = remove_unicode_replacements(children,
+                                                              byte_count=self.ucbc)
+            # print(&#34;===\nCHILD:&#34; + repr(children))
+            # print(&#34;===\nASCII:&#34; + repr(ascii_map))
+            # Merge all surrogate pairs
+            children = merge_surrogate_chars(children,
+                                             ascii_map,
+                                             self.use_ASCII_alternatives_on_unicode_decode_failure)
+            # print(&#34;FINAL CHILDREN&#34;)
+            # print(repr(children))
+        return children
+
+
+    def iterate_on_children(self, children):
+        set_fonts = []
+        # print(&#34;Starting to iterate on children&#34;)
+        # print(&#34;PREP-B4: &#34;+repr(children))
+        children = self.prep_unicode(children)
+        # print(&#34;PREP-AFTER: &#34;+repr(children))
+
+
+        for item in children:
+            if is_font_number(item): # Font Definitions
+                self.font_stack.append(item.value.strip())
+                set_fonts.append(item.value)
+                if self.keep_fontdef is True:
+                    yield item
+            elif is_unicode_char_byte_count(item):
+                bc = get_unicode_char_byte_count(item)
+            elif is_unicode_encoded(item): # Unicode Chars
+                decoded = unicode_escape_to_chr(item.value)
+                # Convert into STRING token
+                decoded_tok = Token(&#39;STRING&#39;,
+                                    decoded,
+                                    start_pos=item.start_pos,
+                                    end_pos=item.end_pos,
+                                    line=item.line,
+                                    end_line=item.end_line,
+                                    column=item.column,
+                                    end_column=item.end_column)
+                # print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
+                yield decoded_tok
+            # Decode a hex array
+            elif is_hexarray(item):
+                # print(&#34;IS Hex?? {0}&#34;.format(item))
+                base_bytes = None
+                for hexchild in item.children:
+                    if base_bytes is None:
+                        base_bytes = get_bytes_from_hex_encoded(hexchild.value)
+                    else:
+                        base_bytes += get_bytes_from_hex_encoded(hexchild.value)
+                current_fontdef = self.font_table[self.font_stack[-1]]
+                current_codec = current_fontdef.codec
+                # print(current_fontdef)
+                decoded_hex = decode_hex_char(base_bytes, current_codec)
+                # We are replacing a Tree. So, need item.data to access it&#39;s info token
+                decoded_hex_tok = Token(&#39;STRING&#39;,
+                                        decoded_hex,
+                                        start_pos=item.data.start_pos,
+                                        end_pos=item.data.end_pos,
+                                        line=item.data.line,
+                                        end_line=item.data.end_line,
+                                        column=item.data.column,
+                                        end_column=item.data.end_column)
+                yield decoded_hex_tok
+            elif isinstance(item, Tree):
+                # Run this same function recursively on nested trees
+                item.children = [i for i in self.iterate_on_children(item.children)]
+                yield item
+            else:
+                yield item
+        for i in set_fonts:
+            # Remove all fonts defined while in this group
+            self.font_stack.pop()</code></pre>
+</details>
+<h3>Methods</h3>
+<dl>
+<dt id="RTFDE.text_extraction.TextDecoder.iterate_on_children"><code class="name flex">
+<span>def <span class="ident">iterate_on_children</span></span>(<span>self, children)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def iterate_on_children(self, children):
+    set_fonts = []
+    # print(&#34;Starting to iterate on children&#34;)
+    # print(&#34;PREP-B4: &#34;+repr(children))
+    children = self.prep_unicode(children)
+    # print(&#34;PREP-AFTER: &#34;+repr(children))
+
+
+    for item in children:
+        if is_font_number(item): # Font Definitions
+            self.font_stack.append(item.value.strip())
+            set_fonts.append(item.value)
+            if self.keep_fontdef is True:
+                yield item
+        elif is_unicode_char_byte_count(item):
+            bc = get_unicode_char_byte_count(item)
+        elif is_unicode_encoded(item): # Unicode Chars
+            decoded = unicode_escape_to_chr(item.value)
+            # Convert into STRING token
+            decoded_tok = Token(&#39;STRING&#39;,
+                                decoded,
+                                start_pos=item.start_pos,
+                                end_pos=item.end_pos,
+                                line=item.line,
+                                end_line=item.end_line,
+                                column=item.column,
+                                end_column=item.end_column)
+            # print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
+            yield decoded_tok
+        # Decode a hex array
+        elif is_hexarray(item):
+            # print(&#34;IS Hex?? {0}&#34;.format(item))
+            base_bytes = None
+            for hexchild in item.children:
+                if base_bytes is None:
+                    base_bytes = get_bytes_from_hex_encoded(hexchild.value)
+                else:
+                    base_bytes += get_bytes_from_hex_encoded(hexchild.value)
+            current_fontdef = self.font_table[self.font_stack[-1]]
+            current_codec = current_fontdef.codec
+            # print(current_fontdef)
+            decoded_hex = decode_hex_char(base_bytes, current_codec)
+            # We are replacing a Tree. So, need item.data to access it&#39;s info token
+            decoded_hex_tok = Token(&#39;STRING&#39;,
+                                    decoded_hex,
+                                    start_pos=item.data.start_pos,
+                                    end_pos=item.data.end_pos,
+                                    line=item.data.line,
+                                    end_line=item.data.end_line,
+                                    column=item.data.column,
+                                    end_column=item.data.end_column)
+            yield decoded_hex_tok
+        elif isinstance(item, Tree):
+            # Run this same function recursively on nested trees
+            item.children = [i for i in self.iterate_on_children(item.children)]
+            yield item
+        else:
+            yield item
+    for i in set_fonts:
+        # Remove all fonts defined while in this group
+        self.font_stack.pop()</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.TextDecoder.prep_unicode"><code class="name flex">
+<span>def <span class="ident">prep_unicode</span></span>(<span>self, children)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def prep_unicode(self, children):
+    if includes_unicode_chars(children):
+        # Clean out all replacement chars
+        # print(&#34;\n===\nORIGINAL:&#34; + repr(children))
+        children, ascii_map = remove_unicode_replacements(children,
+                                                          byte_count=self.ucbc)
+        # print(&#34;===\nCHILD:&#34; + repr(children))
+        # print(&#34;===\nASCII:&#34; + repr(ascii_map))
+        # Merge all surrogate pairs
+        children = merge_surrogate_chars(children,
+                                         ascii_map,
+                                         self.use_ASCII_alternatives_on_unicode_decode_failure)
+        # print(&#34;FINAL CHILDREN&#34;)
+        # print(repr(children))
+    return children</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.TextDecoder.set_font_info"><code class="name flex">
+<span>def <span class="ident">set_font_info</span></span>(<span>self, obj)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_font_info(self, obj):
+    &#34;&#34;&#34;
+
+    obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+    &#34;&#34;&#34;
+    self.default_font = get_default_font(obj)
+    self.font_stack = [self.default_font]
+    raw_fonttbl = get_font_table(obj.children[1])
+    self.font_table = parse_font_tree(raw_fonttbl)
+    # print(raw_fonttbl)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.TextDecoder.update_children"><code class="name flex">
+<span>def <span class="ident">update_children</span></span>(<span>self, obj)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def update_children(self, obj):
+    &#34;&#34;&#34;
+
+    obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+    &#34;&#34;&#34;
+    # Reset font info
+    self.set_font_info(obj)
+    children = obj.children
+    obj.children = [i for i in self.iterate_on_children(children)]</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="RTFDE.text_extraction.fontdef"><code class="flex name class">
+<span>class <span class="ident">fontdef</span></span>
+<span>(</span><span>fnum, codepage, codec, fontdef_tree)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>fontdef(fnum, codepage, codec, fontdef_tree)</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.tuple</li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="RTFDE.text_extraction.fontdef.codec"><code class="name">var <span class="ident">codec</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 2</p></div>
+</dd>
+<dt id="RTFDE.text_extraction.fontdef.codepage"><code class="name">var <span class="ident">codepage</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 1</p></div>
+</dd>
+<dt id="RTFDE.text_extraction.fontdef.fnum"><code class="name">var <span class="ident">fnum</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 0</p></div>
+</dd>
+<dt id="RTFDE.text_extraction.fontdef.fontdef_tree"><code class="name">var <span class="ident">fontdef_tree</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 3</p></div>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="RTFDE" href="index.html">RTFDE</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="RTFDE.text_extraction.check_codepage_num" href="#RTFDE.text_extraction.check_codepage_num">check_codepage_num</a></code></li>
+<li><code><a title="RTFDE.text_extraction.decode_hex_char" href="#RTFDE.text_extraction.decode_hex_char">decode_hex_char</a></code></li>
+<li><code><a title="RTFDE.text_extraction.decode_surrogate_pair" href="#RTFDE.text_extraction.decode_surrogate_pair">decode_surrogate_pair</a></code></li>
+<li><code><a title="RTFDE.text_extraction.get_bytes_from_hex_encoded" href="#RTFDE.text_extraction.get_bytes_from_hex_encoded">get_bytes_from_hex_encoded</a></code></li>
+<li><code><a title="RTFDE.text_extraction.get_codepage_num_from_fcharset" href="#RTFDE.text_extraction.get_codepage_num_from_fcharset">get_codepage_num_from_fcharset</a></code></li>
+<li><code><a title="RTFDE.text_extraction.get_default_font" href="#RTFDE.text_extraction.get_default_font">get_default_font</a></code></li>
+<li><code><a title="RTFDE.text_extraction.get_font_table" href="#RTFDE.text_extraction.get_font_table">get_font_table</a></code></li>
+<li><code><a title="RTFDE.text_extraction.get_python_codec" href="#RTFDE.text_extraction.get_python_codec">get_python_codec</a></code></li>
+<li><code><a title="RTFDE.text_extraction.get_unicode_char_byte_count" href="#RTFDE.text_extraction.get_unicode_char_byte_count">get_unicode_char_byte_count</a></code></li>
+<li><code><a title="RTFDE.text_extraction.has_hexarray" href="#RTFDE.text_extraction.has_hexarray">has_hexarray</a></code></li>
+<li><code><a title="RTFDE.text_extraction.includes_unicode_chars" href="#RTFDE.text_extraction.includes_unicode_chars">includes_unicode_chars</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_font_number" href="#RTFDE.text_extraction.is_font_number">is_font_number</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_hex_encoded" href="#RTFDE.text_extraction.is_hex_encoded">is_hex_encoded</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_hexarray" href="#RTFDE.text_extraction.is_hexarray">is_hexarray</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_surrogate_high_char" href="#RTFDE.text_extraction.is_surrogate_high_char">is_surrogate_high_char</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_surrogate_low_char" href="#RTFDE.text_extraction.is_surrogate_low_char">is_surrogate_low_char</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_surrogate_pair" href="#RTFDE.text_extraction.is_surrogate_pair">is_surrogate_pair</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_unicode_char_byte_count" href="#RTFDE.text_extraction.is_unicode_char_byte_count">is_unicode_char_byte_count</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_unicode_encoded" href="#RTFDE.text_extraction.is_unicode_encoded">is_unicode_encoded</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_valid_ANSI_representation_char" href="#RTFDE.text_extraction.is_valid_ANSI_representation_char">is_valid_ANSI_representation_char</a></code></li>
+<li><code><a title="RTFDE.text_extraction.merge_surrogate_chars" href="#RTFDE.text_extraction.merge_surrogate_chars">merge_surrogate_chars</a></code></li>
+<li><code><a title="RTFDE.text_extraction.parse_font_tree" href="#RTFDE.text_extraction.parse_font_tree">parse_font_tree</a></code></li>
+<li><code><a title="RTFDE.text_extraction.remove_unicode_replacements" href="#RTFDE.text_extraction.remove_unicode_replacements">remove_unicode_replacements</a></code></li>
+<li><code><a title="RTFDE.text_extraction.unicode_escape_to_chr" href="#RTFDE.text_extraction.unicode_escape_to_chr">unicode_escape_to_chr</a></code></li>
+<li><code><a title="RTFDE.text_extraction.validate_ansi_cpg" href="#RTFDE.text_extraction.validate_ansi_cpg">validate_ansi_cpg</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="RTFDE.text_extraction.TextDecoder" href="#RTFDE.text_extraction.TextDecoder">TextDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="RTFDE.text_extraction.TextDecoder.iterate_on_children" href="#RTFDE.text_extraction.TextDecoder.iterate_on_children">iterate_on_children</a></code></li>
+<li><code><a title="RTFDE.text_extraction.TextDecoder.prep_unicode" href="#RTFDE.text_extraction.TextDecoder.prep_unicode">prep_unicode</a></code></li>
+<li><code><a title="RTFDE.text_extraction.TextDecoder.set_font_info" href="#RTFDE.text_extraction.TextDecoder.set_font_info">set_font_info</a></code></li>
+<li><code><a title="RTFDE.text_extraction.TextDecoder.update_children" href="#RTFDE.text_extraction.TextDecoder.update_children">update_children</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="RTFDE.text_extraction.fontdef" href="#RTFDE.text_extraction.fontdef">fontdef</a></code></h4>
+<ul class="">
+<li><code><a title="RTFDE.text_extraction.fontdef.codec" href="#RTFDE.text_extraction.fontdef.codec">codec</a></code></li>
+<li><code><a title="RTFDE.text_extraction.fontdef.codepage" href="#RTFDE.text_extraction.fontdef.codepage">codepage</a></code></li>
+<li><code><a title="RTFDE.text_extraction.fontdef.fnum" href="#RTFDE.text_extraction.fontdef.fnum">fnum</a></code></li>
+<li><code><a title="RTFDE.text_extraction.fontdef.fontdef_tree" href="#RTFDE.text_extraction.fontdef.fontdef_tree">fontdef_tree</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/RTFDE/text_extraction.html
+++ b/docs/RTFDE/text_extraction.html
@@ -53,6 +53,7 @@ from lark.tree import Tree
 from RTFDE.exceptions import MalformedRtf
 from RTFDE.utils import is_codeword_with_numeric_arg
 from RTFDE.utils import flatten_tree_to_string_array
+from RTFDE.utils import log_text_extraction
 
 import logging
 log = logging.getLogger(&#34;RTFDE&#34;)
@@ -86,7 +87,7 @@ Returns:
                 continue
             if isinstance(ctrl_value, Token):
                 table_type = ctrl_value.value.strip()
-                if table_type == &#34;\\fonttbl&#34;:
+                if table_type == b&#34;\\fonttbl&#34;:
                     return item
     raise ValueError(&#34;No font table found in tree&#34;)
 
@@ -99,7 +100,7 @@ Returns:
 
 &#34;&#34;&#34;
     try:
-        if is_codeword_with_numeric_arg(token, &#39;\\f&#39;):
+        if is_codeword_with_numeric_arg(token, b&#39;\\f&#39;):
             return True
     except AttributeError: # pragma: no cover
         return False
@@ -135,7 +136,7 @@ Returns:
         238:{&#34;name&#34;:&#34;EE_CHARSET&#34;,&#34;hex&#34;:&#34;0xEE&#34;,&#34;decimal&#34;:238,&#34;id&#34;:1250},
         255:{&#34;name&#34;:&#34;OEM_CHARSET&#34;,&#34;hex&#34;:&#34;0xFF&#34;,&#34;decimal&#34;:255,&#34;id&#34;:None},
 }
-    # print(f&#34;Getting charset for {fcharsetN}&#34;)
+    log_text_extraction(f&#34;Getting charset for {fcharsetN}&#34;)
     charset = charsets.get(fcharsetN, None)
     if charset is not None:
         charset_id = charset.get(&#39;id&#39;, None)
@@ -155,14 +156,14 @@ Returns:
     The default font control number if it exists from the first `\\deffN`. None if not found.
 &#34;&#34;&#34;
     deff_gen = tree.scan_values(
-        lambda v: is_codeword_with_numeric_arg(v, &#39;\\deff&#39;)
+        lambda v: is_codeword_with_numeric_arg(v, b&#39;\\deff&#39;)
     )
     deff_options = list(deff_gen)
     try:
         # We just want the first \\deffN. It shouldn&#39;t be set multiple times.
         deff = deff_options[0]
         deff_num = deff.value[5:]
-        return &#39;\\f&#39; + deff_num
+        return b&#39;\\f&#39; + deff_num
     except IndexError:
         return None
 
@@ -182,12 +183,12 @@ Returns:
             fcharset = None
             cpg_num = None
             for tok in tree.children:
-                if is_codeword_with_numeric_arg(tok, &#39;\\f&#39;):
+                if is_codeword_with_numeric_arg(tok, b&#39;\\f&#39;):
                     fnum = tok.value
-                elif is_codeword_with_numeric_arg(tok, &#39;\\fcharset&#39;):
+                elif is_codeword_with_numeric_arg(tok, b&#39;\\fcharset&#39;):
                     fchar_num = int(tok.value[9:])
                     fcharset = get_codepage_num_from_fcharset(fchar_num)
-                elif is_codeword_with_numeric_arg(tok, &#39;\\cpg&#39;):
+                elif is_codeword_with_numeric_arg(tok, b&#39;\\cpg&#39;):
                     cpg_num = int(tok.value[4:])
             if fnum is not None:
                 # get the codepage
@@ -210,7 +211,7 @@ Returns:
                 else:
                     codec = None
                 # Only add if there is a font definition
-                tree_str =  &#34;&#34;.join(list(flatten_tree_to_string_array(tree)))
+                tree_str =  b&#34;&#34;.join(list(flatten_tree_to_string_array(tree)))
                 parsed_font_tree[fnum] = fontdef(fnum, codepage_num, codec, tree_str)
     return parsed_font_tree
 
@@ -269,7 +270,7 @@ Raises:
 
 
 # UNICODE CHARS
-def unicode_escape_to_chr(item: str) -&gt; str:
+def unicode_escape_to_chr(item: bytes) -&gt; str:
     &#34;&#34;&#34;Convert unicode char from it&#39;s decimal to its unicode character representation. From &#34;\\u[-]NNNNN&#34; to the string representing the character whose Unicode code point that decimal represents.
 
 Args:
@@ -282,7 +283,7 @@ Raises:
     ValueError: The escaped unicode character is not valid.
 &#34;&#34;&#34;
     try:
-        nnnn = int(item.removeprefix(&#39;\\u&#39;)) # raises ValueError if not int.
+        nnnn = int(item.removeprefix(b&#39;\\u&#39;)) # raises ValueError if not int.
     except ValueError as _e:
         raise ValueError(f&#34;`{item}` is not a valid escaped unicode character.&#34;) from _e
     if nnnn &lt; 0: # § -NNNNN is a negative integer expressed in decimal digits
@@ -379,7 +380,7 @@ Returns:
     ascii_map: Dict[Token,List[Token]]  = {}
     new_children = []
     removal_map: List[Token] = []
-    # print(f&#34;Removing unicode replacements on {repr(children)}&#34;)
+    log_text_extraction(f&#34;Removing unicode replacements on {repr(children)}&#34;)
     for child in children:
         if len(removal_map) &gt; 0:
             if isinstance(child, Token):
@@ -412,7 +413,14 @@ Returns:
                     else:
                         # print(f&#34;AC CHILD NOT VALID {repr(ac)}&#34;)
                         new_ansi_children.append(ac)
-                child.children = new_ansi_children
+                # print(f&#34;NEW Children = {new_ansi_children}&#34;)
+                if new_ansi_children == []:
+                    from RTFDE.utils import make_token_replacement
+                    # from RTFDE.utils import embed
+                    # embed()
+                    child = make_token_replacement(&#34;STRING&#34;, b&#34;&#34;, child)
+                else:
+                    child.children = new_ansi_children
                 # print(f&#34;NEW Tree = {child}&#34;)
             # else:
                 # print(f&#34;FOUND ASCII STRING {child} with RM: {removal_map}&#34;)
@@ -434,30 +442,58 @@ Returns:
 
 
 # UNICODE SURROGATE CHARACTERS
-def is_surrogate_high_char(item):
+def is_surrogate_high_char(item: bytes) -&gt; bool:
     &#34;&#34;&#34;Check&#39;s if chr is a is in the high-surrogate code point rage. &#34;High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF.&#34; High-surrogate also sometimes known as the leading surrogate.
 
-        item (str): A string representing a unicode character. &#34;\\u-10179&#34;
+        item (bytes): A bytes representation of a string representing a unicode character. &#34;\\u-10179&#34;
     &#34;&#34;&#34;
-    if item.startswith(&#34;\\u&#34;):
+    if item.startswith(b&#34;\\u&#34;):
         item = item[2:]
     if 0xD800 &lt;= ord(chr(65536+int(item))) &lt;= 0xDBFF:
         return True
-    return False
-
-def is_surrogate_low_char(item):
-    &#34;&#34;&#34;Check&#39;s if chr is a is in the low-surrogate code point rage. &#34;Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF.&#34;  Low-surrogate also sometimes known as following surrogates.
-
-        item (str): A string representing a unicode character.
-    &#34;&#34;&#34;
-    if item.startswith(&#34;\\u&#34;):
-        item = item[2:]
-    if 0xDC00 &lt;= ord(chr(65536+int(item))) &lt;= 0xDFFF:
+    # In case unicode is NOT using the 16 bit signed integer
+    elif 0xD800 &lt;= int(item) &lt;= 0xDBFF:
         return True
     return False
 
-def is_surrogate_pair(first, second):
+def is_surrogate_low_char(item: bytes) -&gt; bool:
+    &#34;&#34;&#34;Check&#39;s if chr is a is in the low-surrogate code point rage. &#34;Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF.&#34;  Low-surrogate also sometimes known as following surrogates.
+
+        item (bytes): A bytes representation of a string representing a unicode character.
+    &#34;&#34;&#34;
+    if item.startswith(b&#34;\\u&#34;):
+        item = item[2:]
+    if 0xDC00 &lt;= ord(chr(65536+int(item))) &lt;= 0xDFFF:
+        return True
+    # In case unicode is NOT using the 16 bit signed integer
+    elif 0xDC00 &lt;= int(item) &lt;= 0xDFFF:
+        return True
+    return False
+
+def is_surrogate_16bit(item: bytes, cp_range) -&gt; bool:
+    &#34;&#34;&#34;Checks if a unicode char is 16 bit signed integer or the raw unicode char. This should first check if it is a surrogate code using the is_surrogate_XXXX_char functions.
+
+Args:
+    item (bytes): A bytes representation of a string representing a unicode character.
+    cp_range (str): [&#39;low&#39; OR &#39;high&#39;] The code point range (low-surrogate or high-surrogate).
+    &#34;&#34;&#34;
+    if cp_range == &#39;low&#39;:
+        if 0xDC00 &lt;= ord(chr(65536+int(item))) &lt;= 0xDFFF:
+            return True
+    elif cp_range == &#39;high&#39;:
+        if 0xD800 &lt;= ord(chr(65536+int(item))) &lt;= 0xDBFF:
+            return True
+    else:
+        raise ValueError(&#34;cp_range must be either &#39;low&#39; or &#39;high&#39;&#34;)
+    return False
+
+
+def is_surrogate_pair(first: bytes, second: bytes) -&gt; bool:
     &#34;&#34;&#34;Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.
+
+Args:
+    first (bytes): A bytes representation of a string representing the high-order byte in a surrogate char.
+    second (bytes): A bytes representation of a string representing the low-order byte in a surrogate char.
     &#34;&#34;&#34;
     if is_surrogate_high_char(first):
         if is_surrogate_low_char(second):
@@ -466,28 +502,36 @@ def is_surrogate_pair(first, second):
             log.info(&#34;RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}&#34;.format(first, second))
     return False
 
-def decode_surrogate_pair(high, low, encoding=&#39;utf-16-le&#39;):
+def decode_surrogate_pair(high: bytes, low: bytes, encoding: str =&#39;utf-16-le&#39;) -&gt; bytes:
     &#34;&#34;&#34; Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.
 
-        high (chr): the high-surrogate code point
-        low (chr): the low-surrogate code point
+Args:
+        high (bytes): the high-surrogate code point
+        low (bytes): the low-surrogate code point
         encoding (str): The encoding to apply to the final value. Defaults to &#39;utf-16-le&#39; because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
     &#34;&#34;&#34;
     # Equation for turning surrogate pairs into a unicode scalar value which be used with utl-16 can ONLY found in Unicode 3.0.0 standard.
     # Unicode scalar value means the same thing as &#34;code position&#34; or &#34;code point&#34;
      # https://www.unicode.org/versions/Unicode3.0.0/
      # section 3.7 https://www.unicode.org/versions/Unicode3.0.0/ch03.pdf#page=9
-    if high.startswith(&#34;\\u&#34;):
+    if high.startswith(b&#34;\\u&#34;):
         high = high[2:]
-    if low.startswith(&#34;\\u&#34;):
+    if low.startswith(b&#34;\\u&#34;):
         low = low[2:]
-    high = chr(65536+int(high))
-    low = chr(65536+int(low))
-    unicode_scalar_value = ((ord(high) - 0xD800) * 0x400) + (ord(low) - 0xDC00) + 0x10000
+    if is_surrogate_16bit(high, &#34;high&#34;):
+        char_high = chr(65536+int(high))
+    else:
+        char_high = chr(int(high))
+    if is_surrogate_16bit(low, &#34;low&#34;):
+        char_low = chr(65536+int(low))
+    else:
+        char_low = chr(int(low))
+    unicode_scalar_value = ((ord(char_high) - 0xD800) * 0x400) + (ord(char_low) - 0xDC00) + 0x10000
     unicode_bytes = chr(unicode_scalar_value).encode(encoding)
-    return unicode_bytes.decode(encoding)
+    return unicode_bytes.decode(encoding).encode()
 
-def merge_surrogate_chars(children, ascii_map,
+def merge_surrogate_chars(children,
+                          ascii_map,
                           use_ASCII_alternatives_on_unicode_decode_failure = False):
     &#34;&#34;&#34;
 
@@ -520,19 +564,27 @@ Raises:
                                               column=surrogate_high.column,
                                               end_column=surrogate_low.end_column)
                         children[surrogate_start] = surrogate_tok
-                        children[i] = &#34;&#34;
+                        blank_tok = Token(&#39;STRING&#39;,
+                                          b&#34;&#34;,
+                                          start_pos=surrogate_high.start_pos+1,
+                                          end_pos=surrogate_low.end_pos+1,
+                                          line=surrogate_high.line,
+                                          end_line=surrogate_low.end_line,
+                                          column=surrogate_high.column,
+                                          end_column=surrogate_low.end_column)
+                        children[i] = blank_tok
                         surrogate_start = None
                         surrogate_high = None
                     except UnicodeDecodeError as _e:
                         if use_ASCII_alternatives_on_unicode_decode_failure is True:
-                            children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
-                            children[i] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_low]])
+                            children[surrogate_start] = b&#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                            children[i] = b&#34;&#34;.join([i.value for i in ascii_map[surrogate_low]])
                         else:
                             raise _e
                 else:
                     log.info(&#34;RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}&#34;.format(surrogate_high, surrogate_low))
                     if use_ASCII_alternatives_on_unicode_decode_failure is True:
-                        children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                        children[surrogate_start] = b&#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
                     else:
                         raise ValueError(&#34;Standalone high-surrogate found. High surrogate followed by a illegal low-surrogate character.&#34;)
     return children
@@ -542,17 +594,18 @@ Raises:
 def is_unicode_char_byte_count(item: Token) -&gt; bool:
     if isinstance(item, Token):
         if item.type == &#34;CONTROLWORD&#34;:
-            if item.value.startswith(&#39;\\uc&#39;):
+            if item.value.startswith(b&#39;\\uc&#39;):
                 return True
     return False
 
-def get_unicode_char_byte_count(item):
+def get_unicode_char_byte_count(item: Token) -&gt; int:
+    item = item.value.decode()
     cur_uc = int(item[3:])
     return cur_uc
 
 
 # Hex Encoded Chars
-def has_hexarray(children):
+def has_hexarray(children: List[Union[Token, Tree]]) -&gt; bool:
     &#34;&#34;&#34;Checks if an tree&#39;s children includes a hexarray tree.
 
     children (array): the children object from a tree.
@@ -577,8 +630,8 @@ def get_bytes_from_hex_encoded(item):
 
     item (str): a hex encoded string in format \\&#39;XX
     &#34;&#34;&#34;
-    hexstring = item.replace(&#34;\\&#39;&#34;, &#34;&#34;)
-    hex_bytes = bytes.fromhex(hexstring)
+    hexstring = item.replace(b&#34;\\&#39;&#34;, b&#34;&#34;)
+    hex_bytes = bytes.fromhex(hexstring.decode())
     return hex_bytes
 
 def decode_hex_char(item, codec):
@@ -587,16 +640,14 @@ def decode_hex_char(item, codec):
     item (bytes): A bytes object.
     codec (str): The name of the codec to use to decode the bytes
     &#34;&#34;&#34;
-    # print(&#34;decoding char {0} with font {1}&#34;.format(item, codec))
+    log_text_extraction(&#34;decoding char {0} with font {1}&#34;.format(item, codec))
     if codec is None:
         # Default to U.S. Windows default codepage
         codec = &#39;CP1252&#39;
     decoded = item.decode(codec)
-    # print(&#34;char {0} decoded into {1} using codec {2}&#34;.format(item, decoded, codec))
+    decoded = decoded.encode()
+    log_text_extraction(&#34;char {0} decoded into {1} using codec {2}&#34;.format(item, decoded, codec))
     return decoded
-
-
-
 
 
 class TextDecoder:
@@ -619,7 +670,7 @@ class TextDecoder:
         self.font_table = {}
 
 
-    def set_font_info(self, obj):
+    def set_font_info(self, obj: Tree):
         &#34;&#34;&#34;
 
         obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
@@ -628,10 +679,10 @@ class TextDecoder:
         self.font_stack = [self.default_font]
         raw_fonttbl = get_font_table(obj.children[1])
         self.font_table = parse_font_tree(raw_fonttbl)
-        # print(raw_fonttbl)
+        log_text_extraction(f&#34;FONT TABLE FOUND: {raw_fonttbl}&#34;)
 
 
-    def update_children(self, obj):
+    def update_children(self, obj: Tree):
         &#34;&#34;&#34;
 
         obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
@@ -641,10 +692,10 @@ class TextDecoder:
         children = obj.children
         obj.children = [i for i in self.iterate_on_children(children)]
 
-    def prep_unicode(self, children):
+    def prep_unicode(self, children: List[Token]):
         if includes_unicode_chars(children):
             # Clean out all replacement chars
-            # print(&#34;\n===\nORIGINAL:&#34; + repr(children))
+            # log_text_extraction(&#34;Prepping Unicode Chars:&#34; + repr(children))
             children, ascii_map = remove_unicode_replacements(children,
                                                               byte_count=self.ucbc)
             # print(&#34;===\nCHILD:&#34; + repr(children))
@@ -654,17 +705,15 @@ class TextDecoder:
                                              ascii_map,
                                              self.use_ASCII_alternatives_on_unicode_decode_failure)
             # print(&#34;FINAL CHILDREN&#34;)
-            # print(repr(children))
+            # log_text_extraction(&#34;Replaced Unicode Chars With: &#34; + repr(children))
         return children
 
-
-    def iterate_on_children(self, children):
+    def iterate_on_children(self, children): # Children should be &#39;List[Union[Token,Tree]]&#39; but lark&#39;s Tree typing is defined badly.
         set_fonts = []
-        # print(&#34;Starting to iterate on children&#34;)
-        # print(&#34;PREP-B4: &#34;+repr(children))
+        log_text_extraction(&#34;Starting to iterate on text extraction children...&#34;)
+        log_text_extraction(&#34;PREP-BEFORE: &#34;+repr(children))
         children = self.prep_unicode(children)
-        # print(&#34;PREP-AFTER: &#34;+repr(children))
-
+        log_text_extraction(&#34;PREP-AFTER: &#34;+repr(children))
 
         for item in children:
             if is_font_number(item): # Font Definitions
@@ -675,7 +724,7 @@ class TextDecoder:
             elif is_unicode_char_byte_count(item):
                 bc = get_unicode_char_byte_count(item)
             elif is_unicode_encoded(item): # Unicode Chars
-                decoded = unicode_escape_to_chr(item.value)
+                decoded = unicode_escape_to_chr(item.value).encode()
                 # Convert into STRING token
                 decoded_tok = Token(&#39;STRING&#39;,
                                     decoded,
@@ -685,7 +734,7 @@ class TextDecoder:
                                     end_line=item.end_line,
                                     column=item.column,
                                     end_column=item.end_column)
-                # print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
+                print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
                 yield decoded_tok
             # Decode a hex array
             elif is_hexarray(item):
@@ -698,7 +747,6 @@ class TextDecoder:
                         base_bytes += get_bytes_from_hex_encoded(hexchild.value)
                 current_fontdef = self.font_table[self.font_stack[-1]]
                 current_codec = current_fontdef.codec
-                # print(current_fontdef)
                 decoded_hex = decode_hex_char(base_bytes, current_codec)
                 # We are replacing a Tree. So, need item.data to access it&#39;s info token
                 decoded_hex_tok = Token(&#39;STRING&#39;,
@@ -790,48 +838,62 @@ codec (str): The name of the codec to use to decode the bytes</p></div>
     item (bytes): A bytes object.
     codec (str): The name of the codec to use to decode the bytes
     &#34;&#34;&#34;
-    # print(&#34;decoding char {0} with font {1}&#34;.format(item, codec))
+    log_text_extraction(&#34;decoding char {0} with font {1}&#34;.format(item, codec))
     if codec is None:
         # Default to U.S. Windows default codepage
         codec = &#39;CP1252&#39;
     decoded = item.decode(codec)
-    # print(&#34;char {0} decoded into {1} using codec {2}&#34;.format(item, decoded, codec))
+    decoded = decoded.encode()
+    log_text_extraction(&#34;char {0} decoded into {1} using codec {2}&#34;.format(item, decoded, codec))
     return decoded</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.decode_surrogate_pair"><code class="name flex">
-<span>def <span class="ident">decode_surrogate_pair</span></span>(<span>high, low, encoding='utf-16-le')</span>
+<span>def <span class="ident">decode_surrogate_pair</span></span>(<span>high: bytes, low: bytes, encoding: str = 'utf-16-le') ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.</p>
-<p>high (chr): the high-surrogate code point
-low (chr): the low-surrogate code point
-encoding (str): The encoding to apply to the final value. Defaults to 'utf-16-le' because:
-Microsoft uses UTF-16, little endian byte order. ( <a href="https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks">https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks</a> ) The Msg format is a Microsoft standard. Therefore, man is mortal.</p></div>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>high</code></strong> :&ensp;<code>bytes</code></dt>
+<dd>the high-surrogate code point</dd>
+<dt><strong><code>low</code></strong> :&ensp;<code>bytes</code></dt>
+<dd>the low-surrogate code point</dd>
+<dt><strong><code>encoding</code></strong> :&ensp;<code>str</code></dt>
+<dd>The encoding to apply to the final value. Defaults to 'utf-16-le' because:
+Microsoft uses UTF-16, little endian byte order. ( <a href="https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks">https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks</a> ) The Msg format is a Microsoft standard. Therefore, man is mortal.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def decode_surrogate_pair(high, low, encoding=&#39;utf-16-le&#39;):
+<pre><code class="python">def decode_surrogate_pair(high: bytes, low: bytes, encoding: str =&#39;utf-16-le&#39;) -&gt; bytes:
     &#34;&#34;&#34; Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.
 
-        high (chr): the high-surrogate code point
-        low (chr): the low-surrogate code point
+Args:
+        high (bytes): the high-surrogate code point
+        low (bytes): the low-surrogate code point
         encoding (str): The encoding to apply to the final value. Defaults to &#39;utf-16-le&#39; because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
     &#34;&#34;&#34;
     # Equation for turning surrogate pairs into a unicode scalar value which be used with utl-16 can ONLY found in Unicode 3.0.0 standard.
     # Unicode scalar value means the same thing as &#34;code position&#34; or &#34;code point&#34;
      # https://www.unicode.org/versions/Unicode3.0.0/
      # section 3.7 https://www.unicode.org/versions/Unicode3.0.0/ch03.pdf#page=9
-    if high.startswith(&#34;\\u&#34;):
+    if high.startswith(b&#34;\\u&#34;):
         high = high[2:]
-    if low.startswith(&#34;\\u&#34;):
+    if low.startswith(b&#34;\\u&#34;):
         low = low[2:]
-    high = chr(65536+int(high))
-    low = chr(65536+int(low))
-    unicode_scalar_value = ((ord(high) - 0xD800) * 0x400) + (ord(low) - 0xDC00) + 0x10000
+    if is_surrogate_16bit(high, &#34;high&#34;):
+        char_high = chr(65536+int(high))
+    else:
+        char_high = chr(int(high))
+    if is_surrogate_16bit(low, &#34;low&#34;):
+        char_low = chr(65536+int(low))
+    else:
+        char_low = chr(int(low))
+    unicode_scalar_value = ((ord(char_high) - 0xD800) * 0x400) + (ord(char_low) - 0xDC00) + 0x10000
     unicode_bytes = chr(unicode_scalar_value).encode(encoding)
-    return unicode_bytes.decode(encoding)</code></pre>
+    return unicode_bytes.decode(encoding).encode()</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.get_bytes_from_hex_encoded"><code class="name flex">
@@ -849,8 +911,8 @@ Microsoft uses UTF-16, little endian byte order. ( <a href="https://learn.micros
 
     item (str): a hex encoded string in format \\&#39;XX
     &#34;&#34;&#34;
-    hexstring = item.replace(&#34;\\&#39;&#34;, &#34;&#34;)
-    hex_bytes = bytes.fromhex(hexstring)
+    hexstring = item.replace(b&#34;\\&#39;&#34;, b&#34;&#34;)
+    hex_bytes = bytes.fromhex(hexstring.decode())
     return hex_bytes</code></pre>
 </details>
 </dd>
@@ -901,7 +963,7 @@ Returns:
         238:{&#34;name&#34;:&#34;EE_CHARSET&#34;,&#34;hex&#34;:&#34;0xEE&#34;,&#34;decimal&#34;:238,&#34;id&#34;:1250},
         255:{&#34;name&#34;:&#34;OEM_CHARSET&#34;,&#34;hex&#34;:&#34;0xFF&#34;,&#34;decimal&#34;:255,&#34;id&#34;:None},
 }
-    # print(f&#34;Getting charset for {fcharsetN}&#34;)
+    log_text_extraction(f&#34;Getting charset for {fcharsetN}&#34;)
     charset = charsets.get(fcharsetN, None)
     if charset is not None:
         charset_id = charset.get(&#39;id&#39;, None)
@@ -938,14 +1000,14 @@ Returns:
     The default font control number if it exists from the first `\\deffN`. None if not found.
 &#34;&#34;&#34;
     deff_gen = tree.scan_values(
-        lambda v: is_codeword_with_numeric_arg(v, &#39;\\deff&#39;)
+        lambda v: is_codeword_with_numeric_arg(v, b&#39;\\deff&#39;)
     )
     deff_options = list(deff_gen)
     try:
         # We just want the first \\deffN. It shouldn&#39;t be set multiple times.
         deff = deff_options[0]
         deff_num = deff.value[5:]
-        return &#39;\\f&#39; + deff_num
+        return b&#39;\\f&#39; + deff_num
     except IndexError:
         return None</code></pre>
 </details>
@@ -1003,7 +1065,7 @@ Returns:
                 continue
             if isinstance(ctrl_value, Token):
                 table_type = ctrl_value.value.strip()
-                if table_type == &#34;\\fonttbl&#34;:
+                if table_type == b&#34;\\fonttbl&#34;:
                     return item
     raise ValueError(&#34;No font table found in tree&#34;)</code></pre>
 </details>
@@ -1039,7 +1101,7 @@ Returns:
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.get_unicode_char_byte_count"><code class="name flex">
-<span>def <span class="ident">get_unicode_char_byte_count</span></span>(<span>item)</span>
+<span>def <span class="ident">get_unicode_char_byte_count</span></span>(<span>item: lark.lexer.Token) ‑> int</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -1047,13 +1109,14 @@ Returns:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_unicode_char_byte_count(item):
+<pre><code class="python">def get_unicode_char_byte_count(item: Token) -&gt; int:
+    item = item.value.decode()
     cur_uc = int(item[3:])
     return cur_uc</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.has_hexarray"><code class="name flex">
-<span>def <span class="ident">has_hexarray</span></span>(<span>children)</span>
+<span>def <span class="ident">has_hexarray</span></span>(<span>children: List[Union[lark.lexer.Token, lark.tree.Tree]]) ‑> bool</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Checks if an tree's children includes a hexarray tree.</p>
@@ -1062,7 +1125,7 @@ Returns:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def has_hexarray(children):
+<pre><code class="python">def has_hexarray(children: List[Union[Token, Tree]]) -&gt; bool:
     &#34;&#34;&#34;Checks if an tree&#39;s children includes a hexarray tree.
 
     children (array): the children object from a tree.
@@ -1123,7 +1186,7 @@ Returns:
 
 &#34;&#34;&#34;
     try:
-        if is_codeword_with_numeric_arg(token, &#39;\\f&#39;):
+        if is_codeword_with_numeric_arg(token, b&#39;\\f&#39;):
             return True
     except AttributeError: # pragma: no cover
         return False
@@ -1181,62 +1244,113 @@ Return:
     return False</code></pre>
 </details>
 </dd>
-<dt id="RTFDE.text_extraction.is_surrogate_high_char"><code class="name flex">
-<span>def <span class="ident">is_surrogate_high_char</span></span>(<span>item)</span>
+<dt id="RTFDE.text_extraction.is_surrogate_16bit"><code class="name flex">
+<span>def <span class="ident">is_surrogate_16bit</span></span>(<span>item: bytes, cp_range) ‑> bool</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Check's if chr is a is in the high-surrogate code point rage. "High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF." High-surrogate also sometimes known as the leading surrogate.</p>
-<p>item (str): A string representing a unicode character. "\u-10179"</p></div>
+<div class="desc"><p>Checks if a unicode char is 16 bit signed integer or the raw unicode char. This should first check if it is a surrogate code using the is_surrogate_XXXX_char functions.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item</code></strong> :&ensp;<code>bytes</code></dt>
+<dd>A bytes representation of a string representing a unicode character.</dd>
+<dt><strong><code>cp_range</code></strong> :&ensp;<code>str</code></dt>
+<dd>['low' OR 'high'] The code point range (low-surrogate or high-surrogate).</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def is_surrogate_high_char(item):
+<pre><code class="python">def is_surrogate_16bit(item: bytes, cp_range) -&gt; bool:
+    &#34;&#34;&#34;Checks if a unicode char is 16 bit signed integer or the raw unicode char. This should first check if it is a surrogate code using the is_surrogate_XXXX_char functions.
+
+Args:
+    item (bytes): A bytes representation of a string representing a unicode character.
+    cp_range (str): [&#39;low&#39; OR &#39;high&#39;] The code point range (low-surrogate or high-surrogate).
+    &#34;&#34;&#34;
+    if cp_range == &#39;low&#39;:
+        if 0xDC00 &lt;= ord(chr(65536+int(item))) &lt;= 0xDFFF:
+            return True
+    elif cp_range == &#39;high&#39;:
+        if 0xD800 &lt;= ord(chr(65536+int(item))) &lt;= 0xDBFF:
+            return True
+    else:
+        raise ValueError(&#34;cp_range must be either &#39;low&#39; or &#39;high&#39;&#34;)
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.text_extraction.is_surrogate_high_char"><code class="name flex">
+<span>def <span class="ident">is_surrogate_high_char</span></span>(<span>item: bytes) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check's if chr is a is in the high-surrogate code point rage. "High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF." High-surrogate also sometimes known as the leading surrogate.</p>
+<p>item (bytes): A bytes representation of a string representing a unicode character. "\u-10179"</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_surrogate_high_char(item: bytes) -&gt; bool:
     &#34;&#34;&#34;Check&#39;s if chr is a is in the high-surrogate code point rage. &#34;High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF.&#34; High-surrogate also sometimes known as the leading surrogate.
 
-        item (str): A string representing a unicode character. &#34;\\u-10179&#34;
+        item (bytes): A bytes representation of a string representing a unicode character. &#34;\\u-10179&#34;
     &#34;&#34;&#34;
-    if item.startswith(&#34;\\u&#34;):
+    if item.startswith(b&#34;\\u&#34;):
         item = item[2:]
     if 0xD800 &lt;= ord(chr(65536+int(item))) &lt;= 0xDBFF:
+        return True
+    # In case unicode is NOT using the 16 bit signed integer
+    elif 0xD800 &lt;= int(item) &lt;= 0xDBFF:
         return True
     return False</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.is_surrogate_low_char"><code class="name flex">
-<span>def <span class="ident">is_surrogate_low_char</span></span>(<span>item)</span>
+<span>def <span class="ident">is_surrogate_low_char</span></span>(<span>item: bytes) ‑> bool</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Check's if chr is a is in the low-surrogate code point rage. "Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF."
 Low-surrogate also sometimes known as following surrogates.</p>
-<p>item (str): A string representing a unicode character.</p></div>
+<p>item (bytes): A bytes representation of a string representing a unicode character.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def is_surrogate_low_char(item):
+<pre><code class="python">def is_surrogate_low_char(item: bytes) -&gt; bool:
     &#34;&#34;&#34;Check&#39;s if chr is a is in the low-surrogate code point rage. &#34;Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF.&#34;  Low-surrogate also sometimes known as following surrogates.
 
-        item (str): A string representing a unicode character.
+        item (bytes): A bytes representation of a string representing a unicode character.
     &#34;&#34;&#34;
-    if item.startswith(&#34;\\u&#34;):
+    if item.startswith(b&#34;\\u&#34;):
         item = item[2:]
     if 0xDC00 &lt;= ord(chr(65536+int(item))) &lt;= 0xDFFF:
+        return True
+    # In case unicode is NOT using the 16 bit signed integer
+    elif 0xDC00 &lt;= int(item) &lt;= 0xDFFF:
         return True
     return False</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.is_surrogate_pair"><code class="name flex">
-<span>def <span class="ident">is_surrogate_pair</span></span>(<span>first, second)</span>
+<span>def <span class="ident">is_surrogate_pair</span></span>(<span>first: bytes, second: bytes) ‑> bool</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.</p></div>
+<div class="desc"><p>Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>first</code></strong> :&ensp;<code>bytes</code></dt>
+<dd>A bytes representation of a string representing the high-order byte in a surrogate char.</dd>
+<dt><strong><code>second</code></strong> :&ensp;<code>bytes</code></dt>
+<dd>A bytes representation of a string representing the low-order byte in a surrogate char.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def is_surrogate_pair(first, second):
+<pre><code class="python">def is_surrogate_pair(first: bytes, second: bytes) -&gt; bool:
     &#34;&#34;&#34;Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.
+
+Args:
+    first (bytes): A bytes representation of a string representing the high-order byte in a surrogate char.
+    second (bytes): A bytes representation of a string representing the low-order byte in a surrogate char.
     &#34;&#34;&#34;
     if is_surrogate_high_char(first):
         if is_surrogate_low_char(second):
@@ -1258,7 +1372,7 @@ Low-surrogate also sometimes known as following surrogates.</p>
 <pre><code class="python">def is_unicode_char_byte_count(item: Token) -&gt; bool:
     if isinstance(item, Token):
         if item.type == &#34;CONTROLWORD&#34;:
-            if item.value.startswith(&#39;\\uc&#39;):
+            if item.value.startswith(b&#39;\\uc&#39;):
                 return True
     return False</code></pre>
 </details>
@@ -1348,7 +1462,8 @@ Return:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def merge_surrogate_chars(children, ascii_map,
+<pre><code class="python">def merge_surrogate_chars(children,
+                          ascii_map,
                           use_ASCII_alternatives_on_unicode_decode_failure = False):
     &#34;&#34;&#34;
 
@@ -1381,19 +1496,27 @@ Raises:
                                               column=surrogate_high.column,
                                               end_column=surrogate_low.end_column)
                         children[surrogate_start] = surrogate_tok
-                        children[i] = &#34;&#34;
+                        blank_tok = Token(&#39;STRING&#39;,
+                                          b&#34;&#34;,
+                                          start_pos=surrogate_high.start_pos+1,
+                                          end_pos=surrogate_low.end_pos+1,
+                                          line=surrogate_high.line,
+                                          end_line=surrogate_low.end_line,
+                                          column=surrogate_high.column,
+                                          end_column=surrogate_low.end_column)
+                        children[i] = blank_tok
                         surrogate_start = None
                         surrogate_high = None
                     except UnicodeDecodeError as _e:
                         if use_ASCII_alternatives_on_unicode_decode_failure is True:
-                            children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
-                            children[i] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_low]])
+                            children[surrogate_start] = b&#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                            children[i] = b&#34;&#34;.join([i.value for i in ascii_map[surrogate_low]])
                         else:
                             raise _e
                 else:
                     log.info(&#34;RTFDE encountered a standalone high-surrogate point without a corresponding low-surrogate. Standalone surrogate code points have either a high surrogate without an adjacent low surrogate, or vice versa. These code points are invalid and are not supported. Their behavior is undefined. Codepoints encountered: {0}, {1}&#34;.format(surrogate_high, surrogate_low))
                     if use_ASCII_alternatives_on_unicode_decode_failure is True:
-                        children[surrogate_start] = &#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
+                        children[surrogate_start] = b&#34;&#34;.join([i.value for i in ascii_map[surrogate_high]])
                     else:
                         raise ValueError(&#34;Standalone high-surrogate found. High surrogate followed by a illegal low-surrogate character.&#34;)
     return children</code></pre>
@@ -1431,12 +1554,12 @@ Returns:
             fcharset = None
             cpg_num = None
             for tok in tree.children:
-                if is_codeword_with_numeric_arg(tok, &#39;\\f&#39;):
+                if is_codeword_with_numeric_arg(tok, b&#39;\\f&#39;):
                     fnum = tok.value
-                elif is_codeword_with_numeric_arg(tok, &#39;\\fcharset&#39;):
+                elif is_codeword_with_numeric_arg(tok, b&#39;\\fcharset&#39;):
                     fchar_num = int(tok.value[9:])
                     fcharset = get_codepage_num_from_fcharset(fchar_num)
-                elif is_codeword_with_numeric_arg(tok, &#39;\\cpg&#39;):
+                elif is_codeword_with_numeric_arg(tok, b&#39;\\cpg&#39;):
                     cpg_num = int(tok.value[4:])
             if fnum is not None:
                 # get the codepage
@@ -1459,7 +1582,7 @@ Returns:
                 else:
                     codec = None
                 # Only add if there is a font definition
-                tree_str =  &#34;&#34;.join(list(flatten_tree_to_string_array(tree)))
+                tree_str =  b&#34;&#34;.join(list(flatten_tree_to_string_array(tree)))
                 parsed_font_tree[fnum] = fontdef(fnum, codepage_num, codec, tree_str)
     return parsed_font_tree</code></pre>
 </details>
@@ -1507,7 +1630,7 @@ Returns:
     ascii_map: Dict[Token,List[Token]]  = {}
     new_children = []
     removal_map: List[Token] = []
-    # print(f&#34;Removing unicode replacements on {repr(children)}&#34;)
+    log_text_extraction(f&#34;Removing unicode replacements on {repr(children)}&#34;)
     for child in children:
         if len(removal_map) &gt; 0:
             if isinstance(child, Token):
@@ -1540,7 +1663,14 @@ Returns:
                     else:
                         # print(f&#34;AC CHILD NOT VALID {repr(ac)}&#34;)
                         new_ansi_children.append(ac)
-                child.children = new_ansi_children
+                # print(f&#34;NEW Children = {new_ansi_children}&#34;)
+                if new_ansi_children == []:
+                    from RTFDE.utils import make_token_replacement
+                    # from RTFDE.utils import embed
+                    # embed()
+                    child = make_token_replacement(&#34;STRING&#34;, b&#34;&#34;, child)
+                else:
+                    child.children = new_ansi_children
                 # print(f&#34;NEW Tree = {child}&#34;)
             # else:
                 # print(f&#34;FOUND ASCII STRING {child} with RM: {removal_map}&#34;)
@@ -1562,7 +1692,7 @@ Returns:
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.unicode_escape_to_chr"><code class="name flex">
-<span>def <span class="ident">unicode_escape_to_chr</span></span>(<span>item: str) ‑> str</span>
+<span>def <span class="ident">unicode_escape_to_chr</span></span>(<span>item: bytes) ‑> str</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert unicode char from it's decimal to its unicode character representation. From "\u[-]NNNNN" to the string representing the character whose Unicode code point that decimal represents.</p>
@@ -1582,7 +1712,7 @@ Returns:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def unicode_escape_to_chr(item: str) -&gt; str:
+<pre><code class="python">def unicode_escape_to_chr(item: bytes) -&gt; str:
     &#34;&#34;&#34;Convert unicode char from it&#39;s decimal to its unicode character representation. From &#34;\\u[-]NNNNN&#34; to the string representing the character whose Unicode code point that decimal represents.
 
 Args:
@@ -1595,7 +1725,7 @@ Raises:
     ValueError: The escaped unicode character is not valid.
 &#34;&#34;&#34;
     try:
-        nnnn = int(item.removeprefix(&#39;\\u&#39;)) # raises ValueError if not int.
+        nnnn = int(item.removeprefix(b&#39;\\u&#39;)) # raises ValueError if not int.
     except ValueError as _e:
         raise ValueError(f&#34;`{item}` is not a valid escaped unicode character.&#34;) from _e
     if nnnn &lt; 0: # § -NNNNN is a negative integer expressed in decimal digits
@@ -1679,7 +1809,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
         self.font_table = {}
 
 
-    def set_font_info(self, obj):
+    def set_font_info(self, obj: Tree):
         &#34;&#34;&#34;
 
         obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
@@ -1688,10 +1818,10 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
         self.font_stack = [self.default_font]
         raw_fonttbl = get_font_table(obj.children[1])
         self.font_table = parse_font_tree(raw_fonttbl)
-        # print(raw_fonttbl)
+        log_text_extraction(f&#34;FONT TABLE FOUND: {raw_fonttbl}&#34;)
 
 
-    def update_children(self, obj):
+    def update_children(self, obj: Tree):
         &#34;&#34;&#34;
 
         obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
@@ -1701,10 +1831,10 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
         children = obj.children
         obj.children = [i for i in self.iterate_on_children(children)]
 
-    def prep_unicode(self, children):
+    def prep_unicode(self, children: List[Token]):
         if includes_unicode_chars(children):
             # Clean out all replacement chars
-            # print(&#34;\n===\nORIGINAL:&#34; + repr(children))
+            # log_text_extraction(&#34;Prepping Unicode Chars:&#34; + repr(children))
             children, ascii_map = remove_unicode_replacements(children,
                                                               byte_count=self.ucbc)
             # print(&#34;===\nCHILD:&#34; + repr(children))
@@ -1714,17 +1844,15 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
                                              ascii_map,
                                              self.use_ASCII_alternatives_on_unicode_decode_failure)
             # print(&#34;FINAL CHILDREN&#34;)
-            # print(repr(children))
+            # log_text_extraction(&#34;Replaced Unicode Chars With: &#34; + repr(children))
         return children
 
-
-    def iterate_on_children(self, children):
+    def iterate_on_children(self, children): # Children should be &#39;List[Union[Token,Tree]]&#39; but lark&#39;s Tree typing is defined badly.
         set_fonts = []
-        # print(&#34;Starting to iterate on children&#34;)
-        # print(&#34;PREP-B4: &#34;+repr(children))
+        log_text_extraction(&#34;Starting to iterate on text extraction children...&#34;)
+        log_text_extraction(&#34;PREP-BEFORE: &#34;+repr(children))
         children = self.prep_unicode(children)
-        # print(&#34;PREP-AFTER: &#34;+repr(children))
-
+        log_text_extraction(&#34;PREP-AFTER: &#34;+repr(children))
 
         for item in children:
             if is_font_number(item): # Font Definitions
@@ -1735,7 +1863,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
             elif is_unicode_char_byte_count(item):
                 bc = get_unicode_char_byte_count(item)
             elif is_unicode_encoded(item): # Unicode Chars
-                decoded = unicode_escape_to_chr(item.value)
+                decoded = unicode_escape_to_chr(item.value).encode()
                 # Convert into STRING token
                 decoded_tok = Token(&#39;STRING&#39;,
                                     decoded,
@@ -1745,7 +1873,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
                                     end_line=item.end_line,
                                     column=item.column,
                                     end_column=item.end_column)
-                # print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
+                print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
                 yield decoded_tok
             # Decode a hex array
             elif is_hexarray(item):
@@ -1758,7 +1886,6 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
                         base_bytes += get_bytes_from_hex_encoded(hexchild.value)
                 current_fontdef = self.font_table[self.font_stack[-1]]
                 current_codec = current_fontdef.codec
-                # print(current_fontdef)
                 decoded_hex = decode_hex_char(base_bytes, current_codec)
                 # We are replacing a Tree. So, need item.data to access it&#39;s info token
                 decoded_hex_tok = Token(&#39;STRING&#39;,
@@ -1791,13 +1918,12 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def iterate_on_children(self, children):
+<pre><code class="python">def iterate_on_children(self, children): # Children should be &#39;List[Union[Token,Tree]]&#39; but lark&#39;s Tree typing is defined badly.
     set_fonts = []
-    # print(&#34;Starting to iterate on children&#34;)
-    # print(&#34;PREP-B4: &#34;+repr(children))
+    log_text_extraction(&#34;Starting to iterate on text extraction children...&#34;)
+    log_text_extraction(&#34;PREP-BEFORE: &#34;+repr(children))
     children = self.prep_unicode(children)
-    # print(&#34;PREP-AFTER: &#34;+repr(children))
-
+    log_text_extraction(&#34;PREP-AFTER: &#34;+repr(children))
 
     for item in children:
         if is_font_number(item): # Font Definitions
@@ -1808,7 +1934,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
         elif is_unicode_char_byte_count(item):
             bc = get_unicode_char_byte_count(item)
         elif is_unicode_encoded(item): # Unicode Chars
-            decoded = unicode_escape_to_chr(item.value)
+            decoded = unicode_escape_to_chr(item.value).encode()
             # Convert into STRING token
             decoded_tok = Token(&#39;STRING&#39;,
                                 decoded,
@@ -1818,7 +1944,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
                                 end_line=item.end_line,
                                 column=item.column,
                                 end_column=item.end_column)
-            # print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
+            print(f&#34;UNICODE TOKEN {item}: {decoded_tok}&#34;)
             yield decoded_tok
         # Decode a hex array
         elif is_hexarray(item):
@@ -1831,7 +1957,6 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
                     base_bytes += get_bytes_from_hex_encoded(hexchild.value)
             current_fontdef = self.font_table[self.font_stack[-1]]
             current_codec = current_fontdef.codec
-            # print(current_fontdef)
             decoded_hex = decode_hex_char(base_bytes, current_codec)
             # We are replacing a Tree. So, need item.data to access it&#39;s info token
             decoded_hex_tok = Token(&#39;STRING&#39;,
@@ -1855,7 +1980,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.TextDecoder.prep_unicode"><code class="name flex">
-<span>def <span class="ident">prep_unicode</span></span>(<span>self, children)</span>
+<span>def <span class="ident">prep_unicode</span></span>(<span>self, children: List[lark.lexer.Token])</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -1863,10 +1988,10 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def prep_unicode(self, children):
+<pre><code class="python">def prep_unicode(self, children: List[Token]):
     if includes_unicode_chars(children):
         # Clean out all replacement chars
-        # print(&#34;\n===\nORIGINAL:&#34; + repr(children))
+        # log_text_extraction(&#34;Prepping Unicode Chars:&#34; + repr(children))
         children, ascii_map = remove_unicode_replacements(children,
                                                           byte_count=self.ucbc)
         # print(&#34;===\nCHILD:&#34; + repr(children))
@@ -1876,12 +2001,12 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
                                          ascii_map,
                                          self.use_ASCII_alternatives_on_unicode_decode_failure)
         # print(&#34;FINAL CHILDREN&#34;)
-        # print(repr(children))
+        # log_text_extraction(&#34;Replaced Unicode Chars With: &#34; + repr(children))
     return children</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.TextDecoder.set_font_info"><code class="name flex">
-<span>def <span class="ident">set_font_info</span></span>(<span>self, obj)</span>
+<span>def <span class="ident">set_font_info</span></span>(<span>self, obj: lark.tree.Tree)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.</p></div>
@@ -1889,7 +2014,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def set_font_info(self, obj):
+<pre><code class="python">def set_font_info(self, obj: Tree):
     &#34;&#34;&#34;
 
     obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
@@ -1898,11 +2023,11 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
     self.font_stack = [self.default_font]
     raw_fonttbl = get_font_table(obj.children[1])
     self.font_table = parse_font_tree(raw_fonttbl)
-    # print(raw_fonttbl)</code></pre>
+    log_text_extraction(f&#34;FONT TABLE FOUND: {raw_fonttbl}&#34;)</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.text_extraction.TextDecoder.update_children"><code class="name flex">
-<span>def <span class="ident">update_children</span></span>(<span>self, obj)</span>
+<span>def <span class="ident">update_children</span></span>(<span>self, obj: lark.tree.Tree)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.</p></div>
@@ -1910,7 +2035,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def update_children(self, obj):
+<pre><code class="python">def update_children(self, obj: Tree):
     &#34;&#34;&#34;
 
     obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
@@ -1983,6 +2108,7 @@ use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors 
 <li><code><a title="RTFDE.text_extraction.is_font_number" href="#RTFDE.text_extraction.is_font_number">is_font_number</a></code></li>
 <li><code><a title="RTFDE.text_extraction.is_hex_encoded" href="#RTFDE.text_extraction.is_hex_encoded">is_hex_encoded</a></code></li>
 <li><code><a title="RTFDE.text_extraction.is_hexarray" href="#RTFDE.text_extraction.is_hexarray">is_hexarray</a></code></li>
+<li><code><a title="RTFDE.text_extraction.is_surrogate_16bit" href="#RTFDE.text_extraction.is_surrogate_16bit">is_surrogate_16bit</a></code></li>
 <li><code><a title="RTFDE.text_extraction.is_surrogate_high_char" href="#RTFDE.text_extraction.is_surrogate_high_char">is_surrogate_high_char</a></code></li>
 <li><code><a title="RTFDE.text_extraction.is_surrogate_low_char" href="#RTFDE.text_extraction.is_surrogate_low_char">is_surrogate_low_char</a></code></li>
 <li><code><a title="RTFDE.text_extraction.is_surrogate_pair" href="#RTFDE.text_extraction.is_surrogate_pair">is_surrogate_pair</a></code></li>

--- a/docs/RTFDE/text_extraction.md
+++ b/docs/RTFDE/text_extraction.md
@@ -25,12 +25,13 @@ Functions
     codec (str): The name of the codec to use to decode the bytes
 
     
-`decode_surrogate_pair(high, low, encoding='utf-16-le')`
+`decode_surrogate_pair(high: bytes, low: bytes, encoding: str = 'utf-16-le') ‑> bytes`
 :   Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.
     
-    high (chr): the high-surrogate code point
-    low (chr): the low-surrogate code point
-    encoding (str): The encoding to apply to the final value. Defaults to 'utf-16-le' because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
+    Args:
+            high (bytes): the high-surrogate code point
+            low (bytes): the low-surrogate code point
+            encoding (str): The encoding to apply to the final value. Defaults to 'utf-16-le' because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
 
     
 `get_bytes_from_hex_encoded(item)`
@@ -90,11 +91,11 @@ Functions
         The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
 
     
-`get_unicode_char_byte_count(item)`
+`get_unicode_char_byte_count(item: lark.lexer.Token) ‑> int`
 :   
 
     
-`has_hexarray(children)`
+`has_hexarray(children: List[Union[lark.lexer.Token, lark.tree.Tree]]) ‑> bool`
 :   Checks if an tree's children includes a hexarray tree.
     
     children (array): the children object from a tree.
@@ -132,20 +133,32 @@ Functions
     item (Tree or Token): an item to check to see if its a hex array
 
     
-`is_surrogate_high_char(item)`
+`is_surrogate_16bit(item: bytes, cp_range) ‑> bool`
+:   Checks if a unicode char is 16 bit signed integer or the raw unicode char. This should first check if it is a surrogate code using the is_surrogate_XXXX_char functions.
+    
+    Args:
+        item (bytes): A bytes representation of a string representing a unicode character.
+        cp_range (str): ['low' OR 'high'] The code point range (low-surrogate or high-surrogate).
+
+    
+`is_surrogate_high_char(item: bytes) ‑> bool`
 :   Check's if chr is a is in the high-surrogate code point rage. "High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF." High-surrogate also sometimes known as the leading surrogate.
     
-    item (str): A string representing a unicode character. "\u-10179"
+    item (bytes): A bytes representation of a string representing a unicode character. "\u-10179"
 
     
-`is_surrogate_low_char(item)`
+`is_surrogate_low_char(item: bytes) ‑> bool`
 :   Check's if chr is a is in the low-surrogate code point rage. "Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF."  Low-surrogate also sometimes known as following surrogates.
     
-    item (str): A string representing a unicode character.
+    item (bytes): A bytes representation of a string representing a unicode character.
 
     
-`is_surrogate_pair(first, second)`
+`is_surrogate_pair(first: bytes, second: bytes) ‑> bool`
 :   Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.
+    
+    Args:
+        first (bytes): A bytes representation of a string representing the high-order byte in a surrogate char.
+        second (bytes): A bytes representation of a string representing the low-order byte in a surrogate char.
 
     
 `is_unicode_char_byte_count(item: lark.lexer.Token) ‑> bool`
@@ -200,7 +213,7 @@ Functions
         ascii_map (dict): All the Tokens which were removed from the provided children list keyed by
 
     
-`unicode_escape_to_chr(item: str) ‑> str`
+`unicode_escape_to_chr(item: bytes) ‑> str`
 :   Convert unicode char from it's decimal to its unicode character representation. From "\u[-]NNNNN" to the string representing the character whose Unicode code point that decimal represents.
     
     Args:
@@ -235,13 +248,13 @@ Classes
     `iterate_on_children(self, children)`
     :
 
-    `prep_unicode(self, children)`
+    `prep_unicode(self, children: List[lark.lexer.Token])`
     :
 
-    `set_font_info(self, obj)`
+    `set_font_info(self, obj: lark.tree.Tree)`
     :   obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
 
-    `update_children(self, obj)`
+    `update_children(self, obj: lark.tree.Tree)`
     :   obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
 
 `fontdef(fnum, codepage, codec, fontdef_tree)`

--- a/docs/RTFDE/text_extraction.md
+++ b/docs/RTFDE/text_extraction.md
@@ -1,0 +1,266 @@
+Module RTFDE.text_extraction
+============================
+
+Functions
+---------
+
+    
+`check_codepage_num(codepage_num: int) ‑> int`
+:   Provide the codepage number back to you if it is valid.
+    
+    Args:
+        codepage_num (int): A possible codepage number.
+    
+    Returns:
+        The codepage number IF it is a valid codepage number
+    
+    Raises:
+        ValueError: The codepage_num provided isn't a valid codepage number.
+
+    
+`decode_hex_char(item, codec)`
+:   Decode a bytes object using a specified codec.
+    
+    item (bytes): A bytes object.
+    codec (str): The name of the codec to use to decode the bytes
+
+    
+`decode_surrogate_pair(high, low, encoding='utf-16-le')`
+:   Convert a pair of surrogate chars into the corresponding utf-16 encoded text string they should represent.
+    
+    high (chr): the high-surrogate code point
+    low (chr): the low-surrogate code point
+    encoding (str): The encoding to apply to the final value. Defaults to 'utf-16-le' because:  Microsoft uses UTF-16, little endian byte order. ( https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks ) The Msg format is a Microsoft standard. Therefore, man is mortal.
+
+    
+`get_bytes_from_hex_encoded(item)`
+:   Convert hex encoded string to bytes.
+    
+    item (str): a hex encoded string in format \'XX
+
+    
+`get_codepage_num_from_fcharset(fcharsetN: int) ‑> Optional[int]`
+:   Return the codepage to use with a specific fcharsetN.
+    
+    Args:
+        fcharsetN (int): The numeric argument N for a charsetN control word.
+    
+    Returns:
+        (int OR None) Returns the int for a codepage if known. Returns None for unknown charsets or charsets with no corresponding codepage (such as OEM or DEFAULT.)
+
+    
+`get_default_font(tree: lark.tree.Tree) ‑> Optional[str]`
+:   Extract the font number controlword default font if it exists.
+    
+    If an RTF file uses a default font, the default font number is specified with the \deffN control word, which must precede the font-table group.
+    
+    Args:
+        tree (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree object.
+    
+    Returns:
+        The default font control number if it exists from the first `\deffN`. None if not found.
+
+    
+`get_font_table(tree: lark.tree.Tree) ‑> lark.tree.Tree`
+:   Extract the font table group from the first 20 tokens of a .rtf document.
+    
+    Args:
+        tree (Tree): A .rtf document object parsed into a Tree object
+    
+    Raises:
+        ValueError: If no group with a `\fonttbl` token as its first controlword is found.
+    
+    Returns:
+        {'\f0': fontdef(fnum='\f0', codepage=932, codec='cp932', fontdef_tree='{\f0\fswiss\fcharset128 MS PGothic;}'),
+        '\f1': fontdef(fnum='\f1', codepage=None, codec=None, fontdef_tree='{\f1\fmodern MS Gothic;}'),
+        '\f2': fontdef(fnum='\f2', codepage=None, codec=None, fontdef_tree='{\f2\fnil\fcharset2 Symbol;}'),
+        '\f3': fontdef(fnum='\f3', codepage=1252, codec='cp1252', fontdef_tree='{\f3\fmodern\fcharset0 Courier New;}'),
+        '\f4': fontdef(fnum='\f4', codepage=932, codec='cp932', fontdef_tree='{\f4\fswiss\fcharset128 "PMingLiU";}'),
+        '\f5': fontdef(fnum='\f5', codepage=None, codec=None, fontdef_tree='{\f5\fswiss "Amnesty Trade Gothic";}'),
+        '\f6': fontdef(fnum='\f6', codepage=None, codec=None, fontdef_tree='{\f6\fswiss "Arial";}')}
+
+    
+`get_python_codec(codepage_num: int) ‑> str`
+:   Returns the python codec needed to decode bytes to unicode.
+    
+    Args:
+        codepage_num (int): A codepage number.
+    
+    Returns:
+        The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
+
+    
+`get_unicode_char_byte_count(item)`
+:   
+
+    
+`has_hexarray(children)`
+:   Checks if an tree's children includes a hexarray tree.
+    
+    children (array): the children object from a tree.
+
+    
+`includes_unicode_chars(children: List[lark.lexer.Token]) ‑> bool`
+:   Does a list include Tokens which contain unicode characters. Not recursive.
+    
+    Args:
+        children (list): A Tree.children list to check to see if it includes unicode characters.
+    
+    Returns:
+        True if list includes tokens which contain unicode chars. False if not.
+
+    
+`is_font_number(token: lark.lexer.Token) ‑> bool`
+:   Checks if an object is a "font number".
+    
+    Returns:
+        True if an object is a "font number" controlword `\fN`. False if not.
+
+    
+`is_hex_encoded(item: lark.lexer.Token) ‑> bool`
+:   Identify if a token contains a HEXENCODED token.
+    Args:
+        item (token): A token to check if it is HEXENCODED.
+    
+    Return:
+        True if HEXENCODED. False if not.
+
+    
+`is_hexarray(item)`
+:   Checks if an item is a hexarray tree.
+    
+    item (Tree or Token): an item to check to see if its a hex array
+
+    
+`is_surrogate_high_char(item)`
+:   Check's if chr is a is in the high-surrogate code point rage. "High-surrogate code point: A Unicode code point in the range U+D800 to U+DBFF." High-surrogate also sometimes known as the leading surrogate.
+    
+    item (str): A string representing a unicode character. "\u-10179"
+
+    
+`is_surrogate_low_char(item)`
+:   Check's if chr is a is in the low-surrogate code point rage. "Low-surrogate code point: A Unicode code point in the range U+DC00 to U+DFFF."  Low-surrogate also sometimes known as following surrogates.
+    
+    item (str): A string representing a unicode character.
+
+    
+`is_surrogate_pair(first, second)`
+:   Check if a pair of unicode characters are a surrogate pair. Must be passed in the correct order.
+
+    
+`is_unicode_char_byte_count(item: lark.lexer.Token) ‑> bool`
+:   
+
+    
+`is_unicode_encoded(item: lark.lexer.Token) ‑> bool`
+:   Is token contain a unicode char.
+    
+    Args:
+        item (token): A token to check if contains a unicode char.
+    
+    Return:
+        True if token contains a unicode char. False if not.
+
+    
+`is_valid_ANSI_representation_char(item: lark.lexer.Token) ‑> bool`
+:   Is token contain a valid ANSI representation string for a Unicode char.
+    
+    Args:
+        item (token): A token to check if it is a valid ANSI representation.
+    
+    Return:
+        True if token is an ansi representation of a unicode char. False if not.
+
+    
+`merge_surrogate_chars(children, ascii_map, use_ASCII_alternatives_on_unicode_decode_failure=False)`
+:   Raises:
+        ValueError:  A Standalone high-surrogate was found. High surrogate followed by a illegal low-surrogate character.
+
+    
+`parse_font_tree(font_tree: lark.tree.Tree) ‑> dict`
+:   Create a font tree dictionary with appropriate codeces to decode text.
+    
+    Args:
+        font_tree (Tree): The .rtf font table object decoded as a tree.
+    
+    Returns:
+        A dictionary which maps font numbers to appropriate python codeces needed to decode text.
+
+    
+`remove_unicode_replacements(children: List[lark.lexer.Token], return_ascii_map: bool = True, byte_count: int = 1) ‑> Union[Tuple[List[lark.lexer.Token], Dict[lark.lexer.Token, List[lark.lexer.Token]]], List[lark.lexer.Token]]`
+:   Remove all unicode replacement characters from a list of Tokens.
+    
+    Args:
+        children (list): A Tree.children list to remove unicode replacement characters from.
+        return_ascii_map (bool): On True, have this function return a map of the ASCII token that were removed.
+        byte_count (int): The number of bytes corresponding to a given \uN Unicode character.  A default of 1 should be assumed if no \uc keyword has been seen in the current or outer scopes.
+    
+    Returns:
+        new_children (list): The list of Tokens with all unicode replacement characters removed.
+        ascii_map (dict): All the Tokens which were removed from the provided children list keyed by
+
+    
+`unicode_escape_to_chr(item: str) ‑> str`
+:   Convert unicode char from it's decimal to its unicode character representation. From "\u[-]NNNNN" to the string representing the character whose Unicode code point that decimal represents.
+    
+    Args:
+        item (str): A RTF Escape in the format \u[-]NNNNN.
+    
+    Returns:
+        The unicode character representation of the identified character
+    
+    Raises:
+        ValueError: The escaped unicode character is not valid.
+
+    
+`validate_ansi_cpg(header: str) ‑> None`
+:   Check an '\ansicpgNNNN' string to see if the number NNNN is an actual codepage.
+    
+    Args:
+        header (str): The value from the lark `\ansicpg` CONTROLWORD Token.
+    
+    Raises:
+        MalformedRtf: If the value passed is not a valid ansi codepage.
+
+Classes
+-------
+
+`TextDecoder(keep_fontdef=False, initial_byte_count=None, use_ASCII_alternatives_on_unicode_decode_failure=False)`
+:   keep_fontdef: (bool) If False (default), will remove fontdef's from object tree once they are processed.
+    initial_byte_count: (int) The initial Unicode Character Byte Count. Does not need to be set unless you are only providing a RTF snippet which does not contain the RTF header which sets the  information.
+    use_ASCII_alternatives_on_unicode_decode_failure: (bool) If we encounter errors when decoding unicode chars we will use the ASCII alternative since that's what they are included for.
+
+    ### Methods
+
+    `iterate_on_children(self, children)`
+    :
+
+    `prep_unicode(self, children)`
+    :
+
+    `set_font_info(self, obj)`
+    :   obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+
+    `update_children(self, obj)`
+    :   obj (Tree): A lark Tree object. Should be the DeEncapsulator.full_tree.
+
+`fontdef(fnum, codepage, codec, fontdef_tree)`
+:   fontdef(fnum, codepage, codec, fontdef_tree)
+
+    ### Ancestors (in MRO)
+
+    * builtins.tuple
+
+    ### Instance variables
+
+    `codec`
+    :   Alias for field number 2
+
+    `codepage`
+    :   Alias for field number 1
+
+    `fnum`
+    :   Alias for field number 0
+
+    `fontdef_tree`
+    :   Alias for field number 3

--- a/docs/RTFDE/transformers.html
+++ b/docs/RTFDE/transformers.html
@@ -42,7 +42,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
 
 
-from typing import Union, List
+from typing import Union, List, Tuple
+from typing import TypedDict
 #  from Python 3.9 typing.Generator is deprecated in favour of collections.abc.Generator
 from collections.abc import Generator
 
@@ -50,12 +51,12 @@ from lark.visitors import Transformer
 from lark.visitors import v_args, Discard
 from lark.tree import Tree
 from lark.lexer import Token
+import re
 
 from RTFDE.utils import log_htmlrtf_stripping
 
 import logging
 log = logging.getLogger(&#34;RTFDE&#34;)
-
 
 class StripNonVisibleRTFGroups(Transformer):
     &#34;&#34;&#34;Visits each Token in provided RTF Trees and strips out any RTF groups which are non-visible when de-encapsulated into HTML.
@@ -72,7 +73,7 @@ Args:
 &#34;&#34;&#34;
         children = tree.children
         if len(children) == 0:
-            return &#34;&#34;
+            return b&#34;&#34;
         first_child = children[0]
 
         known_control_groups = [&#34;htmltag_group&#34;]
@@ -82,13 +83,15 @@ Args:
         known_non_visible_control_groups = [&#34;mhtmltag_group&#34;]
         if isinstance(first_child, Tree):
             if first_child.data in known_non_visible_control_groups:
-                return &#34;&#34;
+                # print(f&#34;DELETING: {first_child} : because mhtmltag&#34;)
+                return b&#34;&#34;
 
         # process known non-visible groups
-        non_visible_control_words = [&#34;\\context&#34;, &#34;\\colortbl&#34;, &#34;\\fonttbl&#34;]
+        non_visible_control_words = [b&#34;\\context&#34;, b&#34;\\colortbl&#34;, b&#34;\\fonttbl&#34;]
         first_control = self.get_first_controlword(children)
+        # print(f&#34;FIRST: {first_control}&#34;)
         if first_control in non_visible_control_words:
-            return &#34;&#34;
+            return b&#34;&#34;
 
         # Process star escaped groups
         # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
@@ -103,13 +106,14 @@ Args:
                     is_star_escaped = True
         control_word = None
         if is_star_escaped is True:
+            # print(f&#34;STAR: {children}&#34;)
             first_token = children[1]
             if isinstance(first_token, Token):
                 if first_token.type == &#34;CONTROLWORD&#34;:
                     control_word = first_token
                     if control_word.value in understood_commands:
                         return tree
-                    return &#34;&#34;
+                    return b&#34;&#34;
         return tree
 
     @staticmethod
@@ -134,23 +138,27 @@ class RTFCleaner(Transformer):
     &#34;&#34;&#34;Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn&#39;t be visible. And, joins all strings that are left into one final string.
     &#34;&#34;&#34;
 
-    def start(self, args: List) -&gt; str:
+    def start(self, args: List) -&gt; bytes:
         &#34;&#34;&#34;Joins the .rtf object&#39;s string representations together at highest level object `start`.
 
 This is the final string combination. &#34;&#34;&#34;
-        return &#34;&#34;.join(args)
+        return b&#34;&#34;.join(args)
 
-    def STRING(self, string: Token) -&gt; str:
+    def STRING(self, string: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert a string object into a raw string.&#34;&#34;&#34;
         if string.value is not None:
             return string.value
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def string(self, strings: List) -&gt; str:
+    def SPACE_SAVE(self, string: Token) -&gt; bytes:
+        return string.value
+
+    def string(self, strings: List) -&gt; bytes:
         &#34;&#34;&#34;Convert all string objects withing a string group into a single string.&#34;&#34;&#34;
-        return &#34;&#34;.join(strings)
+        # print(strings)
+        return b&#34;&#34;.join(strings)
 
-    def group(self, grp: List) -&gt; str:
+    def group(self, grp: List) -&gt; bytes:
         &#34;&#34;&#34;Join the strings in all group objects.&#34;&#34;&#34;
         _new_children = []
         for i in grp:
@@ -158,19 +166,20 @@ This is the final string combination. &#34;&#34;&#34;
                 pass
             else:
                 _new_children.append(i)
-        return &#34;&#34;.join(_new_children)
+        return b&#34;&#34;.join(_new_children)
 
-    def document(self, args: List) -&gt; str:
+    def document(self, args: List) -&gt; bytes:
         &#34;&#34;&#34;Join the all the strings in an .rtf object into a single string representation of the document.&#34;&#34;&#34;
-        return &#34;&#34;.join(args)
+        args = [i for i in args if i is not None]
+        return b&#34;&#34;.join(args)
 
-    def OPENPAREN(self, args: Token) -&gt; str:
+    def OPENPAREN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all open parens.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def CLOSEPAREN(self, args: Token) -&gt; str:
+    def CLOSEPAREN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all closed parens.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
     def mhtmltag_group(self, args: List):
         &#34;&#34;&#34;Process MHTMLTAG groups
@@ -181,86 +190,86 @@ Returns:
         Always returns a discard object.&#34;&#34;&#34;
         return Discard
 
-    def htmltag_group(self, strings: List) -&gt; str:
+    def htmltag_group(self, strings: List) -&gt; bytes:
         &#34;&#34;&#34;HTMLTAG processing.
 
 Takes any string values within an HTMLTAG and returns them.
         &#34;&#34;&#34;
-        return &#34;&#34;.join(strings)
+        return b&#34;&#34;.join(strings)
 
-    def HTMLTAG(self, htmltag: Token) -&gt; str:
+    def HTMLTAG(self, htmltag: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all HTMLTAG objects&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def STAR_ESCAPE(self, char: Token) -&gt; str:
+    def STAR_ESCAPE(self, char: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all star escape objects&#34;&#34;&#34;
         # &#39;\\*&#39;: &#39;&#39;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def control_symbol(self, symbols: List) -&gt; str:
+    def control_symbol(self, symbols: List) -&gt; bytes:
         &#34;&#34;&#34;Join all visible symbols from in control symbol groups.&#34;&#34;&#34;
-        return &#34;&#34;.join(symbols)
+        return b&#34;&#34;.join(symbols)
 
-    def NONBREAKING_SPACE(self, args: Token) -&gt; str:
+    def NONBREAKING_SPACE(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert non-breaking spaces into visible representation.&#34;&#34;&#34;
         # &#39;\\~&#39;: &#39;\u00A0&#39;,
-        return u&#39;\u00A0&#39;
+        return u&#39;\u00A0&#39;.encode()
 
-    def NONBREAKING_HYPHEN(self, args: Token) -&gt; str:
+    def NONBREAKING_HYPHEN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert non-breaking hyphens into visible representation.&#34;&#34;&#34;
         # &#39;\\_&#39;: &#39;\u00AD&#39;
-        return u&#39;\u00AD&#39;
+        return u&#39;\u00AD&#39;.encode()
 
-    def OPTIONAL_HYPHEN(self, args: Token) -&gt; str:
+    def OPTIONAL_HYPHEN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert hyphen control char into visible representation.&#34;&#34;&#34;
         # &#39;\\-&#39;: &#39;\u2027&#39;
-        return u&#39;\u2027&#39;
+        return u&#39;\u2027&#39;.encode()
 
-    def FORMULA_CHARACTER(self, args: Token) -&gt; str:
+    def FORMULA_CHARACTER(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert a formula character into an empty string.
 
 If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def INDEX_SUBENTRY(self, args: Token) -&gt; str:
+    def INDEX_SUBENTRY(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Process index subentry items
 
 Discard index sub-entries. Because, we don&#39;t care about indexes when de-encapsulating at this time.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def CONTROLSYMBOL(self, args: Token) -&gt; str:
+    def CONTROLSYMBOL(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.&#34;&#34;&#34;
         symbols = {
-            &#39;\\{&#39;: &#39;\x7B&#39;,
-            &#39;\\}&#39;: &#39;\x7D&#39;,
-            &#39;\\\\&#39;: &#39;\x5C&#39;,
+            b&#39;\\{&#39;: b&#39;\x7B&#39;,
+            b&#39;\\}&#39;: b&#39;\x7D&#39;,
+            b&#39;\\\\&#39;: b&#39;\x5C&#39;,
         }
         replacement = symbols.get(args.value, None)
         # If this is simply a character to replace then return the value
         if replacement is not None:
             return replacement
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def CONTROLWORD(self, args: Token) -&gt; str:
+    def CONTROLWORD(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
         &#34;&#34;&#34;
         words = {
-            &#39;\\par&#39;: &#39;\n&#39;,
-            &#39;\\tab&#39;: &#39;\t&#39;,
-            &#39;\\line&#39;: &#39;\n&#39;,
-            &#39;\\lquote&#39;: &#39;\u2018&#39;,
-            &#39;\\rquote&#39;: &#39;\u2019&#39;,
-            &#39;\\ldblquote&#39;: &#39;\u201C&#39;,
-            &#39;\\rdblquote&#39;: &#39;\u201D&#39;,
-            &#39;\\bullet&#39;: &#39;\u2022&#39;,
-            &#39;\\endash&#39;: &#39;\u2013&#39;,
-            &#39;\\emdash&#39;: &#39;\u2014&#39;
+            b&#39;\\par&#39;: b&#39;\n&#39;,
+            b&#39;\\tab&#39;: b&#39;\t&#39;,
+            b&#39;\\line&#39;: b&#39;\n&#39;,
+            b&#39;\\lquote&#39;: b&#39;\u2018&#39;,
+            b&#39;\\rquote&#39;: b&#39;\u2019&#39;,
+            b&#39;\\ldblquote&#39;: b&#39;\u201C&#39;,
+            b&#39;\\rdblquote&#39;: b&#39;\u201D&#39;,
+            b&#39;\\bullet&#39;: b&#39;\u2022&#39;,
+            b&#39;\\endash&#39;: b&#39;\u2013&#39;,
+            b&#39;\\emdash&#39;: b&#39;\u2014&#39;
         }
         replacement = words.get(args.value, None)
         # If this is simply a character to replace then return the value as a string
         if replacement is not None:
             return replacement
-        return &#34;&#34;
+        return b&#34;&#34;
 
 def get_stripped_HTMLRTF_values(tree: Tree, current_state: Union[bool,None] = None) -&gt; Generator:
     &#34;&#34;&#34;Get a list of Tokens which should be suppressed by HTMLRTF control words.
@@ -297,7 +306,7 @@ Returns:
 &#34;&#34;&#34;
     if isinstance(child, Token):
         if child.type == &#34;HTMLRTF&#34;:
-            htmlrtfstr = str(child).strip()
+            htmlrtfstr = child.value.decode().strip()
             if (len(htmlrtfstr) &gt; 0 and htmlrtfstr[-1] == &#34;0&#34;):
                 return False
             return True
@@ -341,6 +350,7 @@ Returns:
                         i.end_pos == token.end_pos and
                         i.value == token.value):
                         log_htmlrtf_stripping(i)
+                        # print(f&#34;DELETING: {i}&#34;)
                         return Discard
         return token
 
@@ -388,7 +398,57 @@ Args:
         token: A CONTROLWORD token to strip whitespace from.
         &#34;&#34;&#34;
         tok = token.update(value=token.value.strip())
-        return tok</code></pre>
+        return tok
+
+
+def strip_binary_objects(raw_rtf: bytes) -&gt; tuple:
+    &#34;&#34;&#34;Extracts binary objects from a rtf file.
+
+Parameters:
+    raw_rtf: (bytes): It&#39;s the raw RTF file as bytes.
+
+Returns:
+    A tuple containing (new_raw, found_bytes)
+        new_raw: (bytes) A bytes object where any binary data has been removed.
+        found_bytes: (list) List of dictionaries containing binary data extracted from the rtf file. Each dictionary includes the data extracted, where it was extracted from in the original rtf file and where it can be inserted back into the stripped output.
+
+    Description of found_bytes dictionaries:
+
+        &#34;bytes&#34;: (bytes) The binary data contained which was extracted.
+        &#34;ctrl_char&#34;: (tuple) Tuple containing the binary control word and its numeric parameter
+        &#34;start_pos&#34;: (int) The position (in the original raw rtf data) where the binary control word started.
+        &#34;bin_start_pos&#34;: (int) The position (in the original raw rtf data) where the binary data starts.
+        &#34;end_pos&#34;: (int) The position (in the original raw rtf data) where the binary data ends.
+
+    Here is an example of what this looks like (by displaying the printable representation so you can see the bytes and then splitting the dict keys on new lines to make it readable.)
+        &gt;&gt; print(repr(found_bytes))
+
+        &#34;{&#39;bytes&#39;: b&#39;\\xf4UP\\x13\\xdb\\xe4\\xe6CO\\xa8\\x16\\x10\\x8b\\n\\xfbA\\x9d\\xc5\\xd1C&#39;,
+          &#39;ctrl_char&#39;: (b&#39;\\\\bin&#39;, b&#39;20&#39;),
+          &#39;start_pos&#39;: 56,
+          &#39;end_pos&#39;: 83,
+          &#39;bin_start_pos&#39;: 63}&#34;
+    &#34;&#34;&#34;
+    found_bytes = []
+    byte_finder = rb&#39;(\\bin)([0-9]+)[ ]?&#39;
+    for matchitem in re.finditer(byte_finder, raw_rtf):
+        param = int(matchitem[2])
+        bin_start_pos = matchitem.span()[-1]
+        byte_obj = {&#34;bytes&#34;: raw_rtf[bin_start_pos:bin_start_pos+param],
+                    &#34;ctrl_char&#34;: matchitem.groups(),
+                    &#34;start_pos&#34;: matchitem.span()[0],
+                    &#34;end_pos&#34;: bin_start_pos+param,
+                    &#34;bin_start_pos&#34;: bin_start_pos
+                    }
+        # byte_obj : dict[str, Union[bytes, int, Tuple[bytes, bytes]]]
+        found_bytes.append(byte_obj)
+    new_raw = b&#39;&#39;
+    start_buffer = 0
+    for new_bytes in found_bytes:
+        new_raw += raw_rtf[start_buffer:new_bytes[&#34;start_pos&#34;]]
+        start_buffer = new_bytes[&#34;end_pos&#34;]
+    new_raw += raw_rtf[start_buffer:]
+    return (new_raw, found_bytes)</code></pre>
 </details>
 </section>
 <section>
@@ -439,6 +499,90 @@ Returns:
                 yield child</code></pre>
 </details>
 </dd>
+<dt id="RTFDE.transformers.strip_binary_objects"><code class="name flex">
+<span>def <span class="ident">strip_binary_objects</span></span>(<span>raw_rtf: bytes) ‑> tuple</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extracts binary objects from a rtf file.</p>
+<h2 id="parameters">Parameters</h2>
+<p>raw_rtf: (bytes): It's the raw RTF file as bytes.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt>A tuple containing (new_raw, found_bytes)</dt>
+<dt><code>
+new_raw</code></dt>
+<dd>(bytes) A bytes object where any binary data has been removed.
+found_bytes: (list) List of dictionaries containing binary data extracted from the rtf file. Each dictionary includes the data extracted, where it was extracted from in the original rtf file and where it can be inserted back into the stripped output.</dd>
+</dl>
+<p>Description of found_bytes dictionaries:</p>
+<pre><code>"bytes": (bytes) The binary data contained which was extracted.
+"ctrl_char": (tuple) Tuple containing the binary control word and its numeric parameter
+"start_pos": (int) The position (in the original raw rtf data) where the binary control word started.
+"bin_start_pos": (int) The position (in the original raw rtf data) where the binary data starts.
+"end_pos": (int) The position (in the original raw rtf data) where the binary data ends.
+</code></pre>
+<p>Here is an example of what this looks like (by displaying the printable representation so you can see the bytes and then splitting the dict keys on new lines to make it readable.)
+&gt;&gt; print(repr(found_bytes))</p>
+<pre><code>"{'bytes': b'\xf4UP\x13\xdb\xe4\xe6CO\xa8\x16\x10\x8b\n\xfbA\x9d\xc5\xd1C',
+  'ctrl_char': (b'\\bin', b'20'),
+  'start_pos': 56,
+  'end_pos': 83,
+  'bin_start_pos': 63}"
+</code></pre></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def strip_binary_objects(raw_rtf: bytes) -&gt; tuple:
+    &#34;&#34;&#34;Extracts binary objects from a rtf file.
+
+Parameters:
+    raw_rtf: (bytes): It&#39;s the raw RTF file as bytes.
+
+Returns:
+    A tuple containing (new_raw, found_bytes)
+        new_raw: (bytes) A bytes object where any binary data has been removed.
+        found_bytes: (list) List of dictionaries containing binary data extracted from the rtf file. Each dictionary includes the data extracted, where it was extracted from in the original rtf file and where it can be inserted back into the stripped output.
+
+    Description of found_bytes dictionaries:
+
+        &#34;bytes&#34;: (bytes) The binary data contained which was extracted.
+        &#34;ctrl_char&#34;: (tuple) Tuple containing the binary control word and its numeric parameter
+        &#34;start_pos&#34;: (int) The position (in the original raw rtf data) where the binary control word started.
+        &#34;bin_start_pos&#34;: (int) The position (in the original raw rtf data) where the binary data starts.
+        &#34;end_pos&#34;: (int) The position (in the original raw rtf data) where the binary data ends.
+
+    Here is an example of what this looks like (by displaying the printable representation so you can see the bytes and then splitting the dict keys on new lines to make it readable.)
+        &gt;&gt; print(repr(found_bytes))
+
+        &#34;{&#39;bytes&#39;: b&#39;\\xf4UP\\x13\\xdb\\xe4\\xe6CO\\xa8\\x16\\x10\\x8b\\n\\xfbA\\x9d\\xc5\\xd1C&#39;,
+          &#39;ctrl_char&#39;: (b&#39;\\\\bin&#39;, b&#39;20&#39;),
+          &#39;start_pos&#39;: 56,
+          &#39;end_pos&#39;: 83,
+          &#39;bin_start_pos&#39;: 63}&#34;
+    &#34;&#34;&#34;
+    found_bytes = []
+    byte_finder = rb&#39;(\\bin)([0-9]+)[ ]?&#39;
+    for matchitem in re.finditer(byte_finder, raw_rtf):
+        param = int(matchitem[2])
+        bin_start_pos = matchitem.span()[-1]
+        byte_obj = {&#34;bytes&#34;: raw_rtf[bin_start_pos:bin_start_pos+param],
+                    &#34;ctrl_char&#34;: matchitem.groups(),
+                    &#34;start_pos&#34;: matchitem.span()[0],
+                    &#34;end_pos&#34;: bin_start_pos+param,
+                    &#34;bin_start_pos&#34;: bin_start_pos
+                    }
+        # byte_obj : dict[str, Union[bytes, int, Tuple[bytes, bytes]]]
+        found_bytes.append(byte_obj)
+    new_raw = b&#39;&#39;
+    start_buffer = 0
+    for new_bytes in found_bytes:
+        new_raw += raw_rtf[start_buffer:new_bytes[&#34;start_pos&#34;]]
+        start_buffer = new_bytes[&#34;end_pos&#34;]
+    new_raw += raw_rtf[start_buffer:]
+    return (new_raw, found_bytes)</code></pre>
+</details>
+</dd>
 <dt id="RTFDE.transformers.toggle_htmlrtf"><code class="name flex">
 <span>def <span class="ident">toggle_htmlrtf</span></span>(<span>child: Union[lark.lexer.Token, str]) ‑> Optional[bool]</span>
 </code></dt>
@@ -458,7 +602,7 @@ Returns:
 &#34;&#34;&#34;
     if isinstance(child, Token):
         if child.type == &#34;HTMLRTF&#34;:
-            htmlrtfstr = str(child).strip()
+            htmlrtfstr = child.value.decode().strip()
             if (len(htmlrtfstr) &gt; 0 and htmlrtfstr[-1] == &#34;0&#34;):
                 return False
             return True
@@ -533,6 +677,7 @@ Returns:
                         i.end_pos == token.end_pos and
                         i.value == token.value):
                         log_htmlrtf_stripping(i)
+                        # print(f&#34;DELETING: {i}&#34;)
                         return Discard
         return token</code></pre>
 </details>
@@ -558,23 +703,27 @@ Returns:
     &#34;&#34;&#34;Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn&#39;t be visible. And, joins all strings that are left into one final string.
     &#34;&#34;&#34;
 
-    def start(self, args: List) -&gt; str:
+    def start(self, args: List) -&gt; bytes:
         &#34;&#34;&#34;Joins the .rtf object&#39;s string representations together at highest level object `start`.
 
 This is the final string combination. &#34;&#34;&#34;
-        return &#34;&#34;.join(args)
+        return b&#34;&#34;.join(args)
 
-    def STRING(self, string: Token) -&gt; str:
+    def STRING(self, string: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert a string object into a raw string.&#34;&#34;&#34;
         if string.value is not None:
             return string.value
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def string(self, strings: List) -&gt; str:
+    def SPACE_SAVE(self, string: Token) -&gt; bytes:
+        return string.value
+
+    def string(self, strings: List) -&gt; bytes:
         &#34;&#34;&#34;Convert all string objects withing a string group into a single string.&#34;&#34;&#34;
-        return &#34;&#34;.join(strings)
+        # print(strings)
+        return b&#34;&#34;.join(strings)
 
-    def group(self, grp: List) -&gt; str:
+    def group(self, grp: List) -&gt; bytes:
         &#34;&#34;&#34;Join the strings in all group objects.&#34;&#34;&#34;
         _new_children = []
         for i in grp:
@@ -582,19 +731,20 @@ This is the final string combination. &#34;&#34;&#34;
                 pass
             else:
                 _new_children.append(i)
-        return &#34;&#34;.join(_new_children)
+        return b&#34;&#34;.join(_new_children)
 
-    def document(self, args: List) -&gt; str:
+    def document(self, args: List) -&gt; bytes:
         &#34;&#34;&#34;Join the all the strings in an .rtf object into a single string representation of the document.&#34;&#34;&#34;
-        return &#34;&#34;.join(args)
+        args = [i for i in args if i is not None]
+        return b&#34;&#34;.join(args)
 
-    def OPENPAREN(self, args: Token) -&gt; str:
+    def OPENPAREN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all open parens.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def CLOSEPAREN(self, args: Token) -&gt; str:
+    def CLOSEPAREN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all closed parens.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
     def mhtmltag_group(self, args: List):
         &#34;&#34;&#34;Process MHTMLTAG groups
@@ -605,86 +755,86 @@ Returns:
         Always returns a discard object.&#34;&#34;&#34;
         return Discard
 
-    def htmltag_group(self, strings: List) -&gt; str:
+    def htmltag_group(self, strings: List) -&gt; bytes:
         &#34;&#34;&#34;HTMLTAG processing.
 
 Takes any string values within an HTMLTAG and returns them.
         &#34;&#34;&#34;
-        return &#34;&#34;.join(strings)
+        return b&#34;&#34;.join(strings)
 
-    def HTMLTAG(self, htmltag: Token) -&gt; str:
+    def HTMLTAG(self, htmltag: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all HTMLTAG objects&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def STAR_ESCAPE(self, char: Token) -&gt; str:
+    def STAR_ESCAPE(self, char: Token) -&gt; bytes:
         &#34;&#34;&#34;Delete all star escape objects&#34;&#34;&#34;
         # &#39;\\*&#39;: &#39;&#39;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def control_symbol(self, symbols: List) -&gt; str:
+    def control_symbol(self, symbols: List) -&gt; bytes:
         &#34;&#34;&#34;Join all visible symbols from in control symbol groups.&#34;&#34;&#34;
-        return &#34;&#34;.join(symbols)
+        return b&#34;&#34;.join(symbols)
 
-    def NONBREAKING_SPACE(self, args: Token) -&gt; str:
+    def NONBREAKING_SPACE(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert non-breaking spaces into visible representation.&#34;&#34;&#34;
         # &#39;\\~&#39;: &#39;\u00A0&#39;,
-        return u&#39;\u00A0&#39;
+        return u&#39;\u00A0&#39;.encode()
 
-    def NONBREAKING_HYPHEN(self, args: Token) -&gt; str:
+    def NONBREAKING_HYPHEN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert non-breaking hyphens into visible representation.&#34;&#34;&#34;
         # &#39;\\_&#39;: &#39;\u00AD&#39;
-        return u&#39;\u00AD&#39;
+        return u&#39;\u00AD&#39;.encode()
 
-    def OPTIONAL_HYPHEN(self, args: Token) -&gt; str:
+    def OPTIONAL_HYPHEN(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert hyphen control char into visible representation.&#34;&#34;&#34;
         # &#39;\\-&#39;: &#39;\u2027&#39;
-        return u&#39;\u2027&#39;
+        return u&#39;\u2027&#39;.encode()
 
-    def FORMULA_CHARACTER(self, args: Token) -&gt; str:
+    def FORMULA_CHARACTER(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert a formula character into an empty string.
 
 If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def INDEX_SUBENTRY(self, args: Token) -&gt; str:
+    def INDEX_SUBENTRY(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Process index subentry items
 
 Discard index sub-entries. Because, we don&#39;t care about indexes when de-encapsulating at this time.&#34;&#34;&#34;
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def CONTROLSYMBOL(self, args: Token) -&gt; str:
+    def CONTROLSYMBOL(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.&#34;&#34;&#34;
         symbols = {
-            &#39;\\{&#39;: &#39;\x7B&#39;,
-            &#39;\\}&#39;: &#39;\x7D&#39;,
-            &#39;\\\\&#39;: &#39;\x5C&#39;,
+            b&#39;\\{&#39;: b&#39;\x7B&#39;,
+            b&#39;\\}&#39;: b&#39;\x7D&#39;,
+            b&#39;\\\\&#39;: b&#39;\x5C&#39;,
         }
         replacement = symbols.get(args.value, None)
         # If this is simply a character to replace then return the value
         if replacement is not None:
             return replacement
-        return &#34;&#34;
+        return b&#34;&#34;
 
-    def CONTROLWORD(self, args: Token) -&gt; str:
+    def CONTROLWORD(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
         &#34;&#34;&#34;
         words = {
-            &#39;\\par&#39;: &#39;\n&#39;,
-            &#39;\\tab&#39;: &#39;\t&#39;,
-            &#39;\\line&#39;: &#39;\n&#39;,
-            &#39;\\lquote&#39;: &#39;\u2018&#39;,
-            &#39;\\rquote&#39;: &#39;\u2019&#39;,
-            &#39;\\ldblquote&#39;: &#39;\u201C&#39;,
-            &#39;\\rdblquote&#39;: &#39;\u201D&#39;,
-            &#39;\\bullet&#39;: &#39;\u2022&#39;,
-            &#39;\\endash&#39;: &#39;\u2013&#39;,
-            &#39;\\emdash&#39;: &#39;\u2014&#39;
+            b&#39;\\par&#39;: b&#39;\n&#39;,
+            b&#39;\\tab&#39;: b&#39;\t&#39;,
+            b&#39;\\line&#39;: b&#39;\n&#39;,
+            b&#39;\\lquote&#39;: b&#39;\u2018&#39;,
+            b&#39;\\rquote&#39;: b&#39;\u2019&#39;,
+            b&#39;\\ldblquote&#39;: b&#39;\u201C&#39;,
+            b&#39;\\rdblquote&#39;: b&#39;\u201D&#39;,
+            b&#39;\\bullet&#39;: b&#39;\u2022&#39;,
+            b&#39;\\endash&#39;: b&#39;\u2013&#39;,
+            b&#39;\\emdash&#39;: b&#39;\u2014&#39;
         }
         replacement = words.get(args.value, None)
         # If this is simply a character to replace then return the value as a string
         if replacement is not None:
             return replacement
-        return &#34;&#34;</code></pre>
+        return b&#34;&#34;</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -696,7 +846,7 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <h3>Methods</h3>
 <dl>
 <dt id="RTFDE.transformers.RTFCleaner.CLOSEPAREN"><code class="name flex">
-<span>def <span class="ident">CLOSEPAREN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">CLOSEPAREN</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Delete all closed parens.</p></div>
@@ -704,13 +854,13 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def CLOSEPAREN(self, args: Token) -&gt; str:
+<pre><code class="python">def CLOSEPAREN(self, args: Token) -&gt; bytes:
     &#34;&#34;&#34;Delete all closed parens.&#34;&#34;&#34;
-    return &#34;&#34;</code></pre>
+    return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.CONTROLSYMBOL"><code class="name flex">
-<span>def <span class="ident">CONTROLSYMBOL</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">CONTROLSYMBOL</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.</p></div>
@@ -718,22 +868,22 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def CONTROLSYMBOL(self, args: Token) -&gt; str:
+<pre><code class="python">def CONTROLSYMBOL(self, args: Token) -&gt; bytes:
     &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.&#34;&#34;&#34;
     symbols = {
-        &#39;\\{&#39;: &#39;\x7B&#39;,
-        &#39;\\}&#39;: &#39;\x7D&#39;,
-        &#39;\\\\&#39;: &#39;\x5C&#39;,
+        b&#39;\\{&#39;: b&#39;\x7B&#39;,
+        b&#39;\\}&#39;: b&#39;\x7D&#39;,
+        b&#39;\\\\&#39;: b&#39;\x5C&#39;,
     }
     replacement = symbols.get(args.value, None)
     # If this is simply a character to replace then return the value
     if replacement is not None:
         return replacement
-    return &#34;&#34;</code></pre>
+    return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.CONTROLWORD"><code class="name flex">
-<span>def <span class="ident">CONTROLWORD</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">CONTROLWORD</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.</p></div>
@@ -741,30 +891,30 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def CONTROLWORD(self, args: Token) -&gt; str:
+<pre><code class="python">def CONTROLWORD(self, args: Token) -&gt; bytes:
     &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
     &#34;&#34;&#34;
     words = {
-        &#39;\\par&#39;: &#39;\n&#39;,
-        &#39;\\tab&#39;: &#39;\t&#39;,
-        &#39;\\line&#39;: &#39;\n&#39;,
-        &#39;\\lquote&#39;: &#39;\u2018&#39;,
-        &#39;\\rquote&#39;: &#39;\u2019&#39;,
-        &#39;\\ldblquote&#39;: &#39;\u201C&#39;,
-        &#39;\\rdblquote&#39;: &#39;\u201D&#39;,
-        &#39;\\bullet&#39;: &#39;\u2022&#39;,
-        &#39;\\endash&#39;: &#39;\u2013&#39;,
-        &#39;\\emdash&#39;: &#39;\u2014&#39;
+        b&#39;\\par&#39;: b&#39;\n&#39;,
+        b&#39;\\tab&#39;: b&#39;\t&#39;,
+        b&#39;\\line&#39;: b&#39;\n&#39;,
+        b&#39;\\lquote&#39;: b&#39;\u2018&#39;,
+        b&#39;\\rquote&#39;: b&#39;\u2019&#39;,
+        b&#39;\\ldblquote&#39;: b&#39;\u201C&#39;,
+        b&#39;\\rdblquote&#39;: b&#39;\u201D&#39;,
+        b&#39;\\bullet&#39;: b&#39;\u2022&#39;,
+        b&#39;\\endash&#39;: b&#39;\u2013&#39;,
+        b&#39;\\emdash&#39;: b&#39;\u2014&#39;
     }
     replacement = words.get(args.value, None)
     # If this is simply a character to replace then return the value as a string
     if replacement is not None:
         return replacement
-    return &#34;&#34;</code></pre>
+    return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.FORMULA_CHARACTER"><code class="name flex">
-<span>def <span class="ident">FORMULA_CHARACTER</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">FORMULA_CHARACTER</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert a formula character into an empty string.</p>
@@ -773,15 +923,15 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">    def FORMULA_CHARACTER(self, args: Token) -&gt; str:
+<pre><code class="python">    def FORMULA_CHARACTER(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Convert a formula character into an empty string.
 
 If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.&#34;&#34;&#34;
-        return &#34;&#34;</code></pre>
+        return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.HTMLTAG"><code class="name flex">
-<span>def <span class="ident">HTMLTAG</span></span>(<span>self, htmltag: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">HTMLTAG</span></span>(<span>self, htmltag: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Delete all HTMLTAG objects</p></div>
@@ -789,13 +939,13 @@ If we are attempting to represent formula characters the scope for this library 
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def HTMLTAG(self, htmltag: Token) -&gt; str:
+<pre><code class="python">def HTMLTAG(self, htmltag: Token) -&gt; bytes:
     &#34;&#34;&#34;Delete all HTMLTAG objects&#34;&#34;&#34;
-    return &#34;&#34;</code></pre>
+    return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.INDEX_SUBENTRY"><code class="name flex">
-<span>def <span class="ident">INDEX_SUBENTRY</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">INDEX_SUBENTRY</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Process index subentry items</p>
@@ -804,15 +954,15 @@ If we are attempting to represent formula characters the scope for this library 
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">    def INDEX_SUBENTRY(self, args: Token) -&gt; str:
+<pre><code class="python">    def INDEX_SUBENTRY(self, args: Token) -&gt; bytes:
         &#34;&#34;&#34;Process index subentry items
 
 Discard index sub-entries. Because, we don&#39;t care about indexes when de-encapsulating at this time.&#34;&#34;&#34;
-        return &#34;&#34;</code></pre>
+        return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.NONBREAKING_HYPHEN"><code class="name flex">
-<span>def <span class="ident">NONBREAKING_HYPHEN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">NONBREAKING_HYPHEN</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert non-breaking hyphens into visible representation.</p></div>
@@ -820,14 +970,14 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def NONBREAKING_HYPHEN(self, args: Token) -&gt; str:
+<pre><code class="python">def NONBREAKING_HYPHEN(self, args: Token) -&gt; bytes:
     &#34;&#34;&#34;Convert non-breaking hyphens into visible representation.&#34;&#34;&#34;
     # &#39;\\_&#39;: &#39;\u00AD&#39;
-    return u&#39;\u00AD&#39;</code></pre>
+    return u&#39;\u00AD&#39;.encode()</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.NONBREAKING_SPACE"><code class="name flex">
-<span>def <span class="ident">NONBREAKING_SPACE</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">NONBREAKING_SPACE</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert non-breaking spaces into visible representation.</p></div>
@@ -835,14 +985,14 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def NONBREAKING_SPACE(self, args: Token) -&gt; str:
+<pre><code class="python">def NONBREAKING_SPACE(self, args: Token) -&gt; bytes:
     &#34;&#34;&#34;Convert non-breaking spaces into visible representation.&#34;&#34;&#34;
     # &#39;\\~&#39;: &#39;\u00A0&#39;,
-    return u&#39;\u00A0&#39;</code></pre>
+    return u&#39;\u00A0&#39;.encode()</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.OPENPAREN"><code class="name flex">
-<span>def <span class="ident">OPENPAREN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">OPENPAREN</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Delete all open parens.</p></div>
@@ -850,13 +1000,13 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def OPENPAREN(self, args: Token) -&gt; str:
+<pre><code class="python">def OPENPAREN(self, args: Token) -&gt; bytes:
     &#34;&#34;&#34;Delete all open parens.&#34;&#34;&#34;
-    return &#34;&#34;</code></pre>
+    return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.OPTIONAL_HYPHEN"><code class="name flex">
-<span>def <span class="ident">OPTIONAL_HYPHEN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">OPTIONAL_HYPHEN</span></span>(<span>self, args: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert hyphen control char into visible representation.</p></div>
@@ -864,14 +1014,27 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def OPTIONAL_HYPHEN(self, args: Token) -&gt; str:
+<pre><code class="python">def OPTIONAL_HYPHEN(self, args: Token) -&gt; bytes:
     &#34;&#34;&#34;Convert hyphen control char into visible representation.&#34;&#34;&#34;
     # &#39;\\-&#39;: &#39;\u2027&#39;
-    return u&#39;\u2027&#39;</code></pre>
+    return u&#39;\u2027&#39;.encode()</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.SPACE_SAVE"><code class="name flex">
+<span>def <span class="ident">SPACE_SAVE</span></span>(<span>self, string: lark.lexer.Token) ‑> bytes</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def SPACE_SAVE(self, string: Token) -&gt; bytes:
+    return string.value</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.STAR_ESCAPE"><code class="name flex">
-<span>def <span class="ident">STAR_ESCAPE</span></span>(<span>self, char: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">STAR_ESCAPE</span></span>(<span>self, char: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Delete all star escape objects</p></div>
@@ -879,14 +1042,14 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def STAR_ESCAPE(self, char: Token) -&gt; str:
+<pre><code class="python">def STAR_ESCAPE(self, char: Token) -&gt; bytes:
     &#34;&#34;&#34;Delete all star escape objects&#34;&#34;&#34;
     # &#39;\\*&#39;: &#39;&#39;
-    return &#34;&#34;</code></pre>
+    return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.STRING"><code class="name flex">
-<span>def <span class="ident">STRING</span></span>(<span>self, string: lark.lexer.Token) ‑> str</span>
+<span>def <span class="ident">STRING</span></span>(<span>self, string: lark.lexer.Token) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert a string object into a raw string.</p></div>
@@ -894,15 +1057,15 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def STRING(self, string: Token) -&gt; str:
+<pre><code class="python">def STRING(self, string: Token) -&gt; bytes:
     &#34;&#34;&#34;Convert a string object into a raw string.&#34;&#34;&#34;
     if string.value is not None:
         return string.value
-    return &#34;&#34;</code></pre>
+    return b&#34;&#34;</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.control_symbol"><code class="name flex">
-<span>def <span class="ident">control_symbol</span></span>(<span>self, symbols: List) ‑> str</span>
+<span>def <span class="ident">control_symbol</span></span>(<span>self, symbols: List) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Join all visible symbols from in control symbol groups.</p></div>
@@ -910,13 +1073,13 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def control_symbol(self, symbols: List) -&gt; str:
+<pre><code class="python">def control_symbol(self, symbols: List) -&gt; bytes:
     &#34;&#34;&#34;Join all visible symbols from in control symbol groups.&#34;&#34;&#34;
-    return &#34;&#34;.join(symbols)</code></pre>
+    return b&#34;&#34;.join(symbols)</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.document"><code class="name flex">
-<span>def <span class="ident">document</span></span>(<span>self, args: List) ‑> str</span>
+<span>def <span class="ident">document</span></span>(<span>self, args: List) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Join the all the strings in an .rtf object into a single string representation of the document.</p></div>
@@ -924,13 +1087,14 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def document(self, args: List) -&gt; str:
+<pre><code class="python">def document(self, args: List) -&gt; bytes:
     &#34;&#34;&#34;Join the all the strings in an .rtf object into a single string representation of the document.&#34;&#34;&#34;
-    return &#34;&#34;.join(args)</code></pre>
+    args = [i for i in args if i is not None]
+    return b&#34;&#34;.join(args)</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.group"><code class="name flex">
-<span>def <span class="ident">group</span></span>(<span>self, grp: List) ‑> str</span>
+<span>def <span class="ident">group</span></span>(<span>self, grp: List) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Join the strings in all group objects.</p></div>
@@ -938,7 +1102,7 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def group(self, grp: List) -&gt; str:
+<pre><code class="python">def group(self, grp: List) -&gt; bytes:
     &#34;&#34;&#34;Join the strings in all group objects.&#34;&#34;&#34;
     _new_children = []
     for i in grp:
@@ -946,11 +1110,11 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
             pass
         else:
             _new_children.append(i)
-    return &#34;&#34;.join(_new_children)</code></pre>
+    return b&#34;&#34;.join(_new_children)</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.htmltag_group"><code class="name flex">
-<span>def <span class="ident">htmltag_group</span></span>(<span>self, strings: List) ‑> str</span>
+<span>def <span class="ident">htmltag_group</span></span>(<span>self, strings: List) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>HTMLTAG processing.</p>
@@ -959,12 +1123,12 @@ Discard index sub-entries. Because, we don&#39;t care about indexes when de-enca
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">    def htmltag_group(self, strings: List) -&gt; str:
+<pre><code class="python">    def htmltag_group(self, strings: List) -&gt; bytes:
         &#34;&#34;&#34;HTMLTAG processing.
 
 Takes any string values within an HTMLTAG and returns them.
         &#34;&#34;&#34;
-        return &#34;&#34;.join(strings)</code></pre>
+        return b&#34;&#34;.join(strings)</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.mhtmltag_group"><code class="name flex">
@@ -991,7 +1155,7 @@ Returns:
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.start"><code class="name flex">
-<span>def <span class="ident">start</span></span>(<span>self, args: List) ‑> str</span>
+<span>def <span class="ident">start</span></span>(<span>self, args: List) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Joins the .rtf object's string representations together at highest level object <code>start</code>.</p>
@@ -1000,15 +1164,15 @@ Returns:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">    def start(self, args: List) -&gt; str:
+<pre><code class="python">    def start(self, args: List) -&gt; bytes:
         &#34;&#34;&#34;Joins the .rtf object&#39;s string representations together at highest level object `start`.
 
 This is the final string combination. &#34;&#34;&#34;
-        return &#34;&#34;.join(args)</code></pre>
+        return b&#34;&#34;.join(args)</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.transformers.RTFCleaner.string"><code class="name flex">
-<span>def <span class="ident">string</span></span>(<span>self, strings: List) ‑> str</span>
+<span>def <span class="ident">string</span></span>(<span>self, strings: List) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Convert all string objects withing a string group into a single string.</p></div>
@@ -1016,9 +1180,10 @@ This is the final string combination. &#34;&#34;&#34;
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def string(self, strings: List) -&gt; str:
+<pre><code class="python">def string(self, strings: List) -&gt; bytes:
     &#34;&#34;&#34;Convert all string objects withing a string group into a single string.&#34;&#34;&#34;
-    return &#34;&#34;.join(strings)</code></pre>
+    # print(strings)
+    return b&#34;&#34;.join(strings)</code></pre>
 </details>
 </dd>
 </dl>
@@ -1106,7 +1271,7 @@ Args:
 &#34;&#34;&#34;
         children = tree.children
         if len(children) == 0:
-            return &#34;&#34;
+            return b&#34;&#34;
         first_child = children[0]
 
         known_control_groups = [&#34;htmltag_group&#34;]
@@ -1116,13 +1281,15 @@ Args:
         known_non_visible_control_groups = [&#34;mhtmltag_group&#34;]
         if isinstance(first_child, Tree):
             if first_child.data in known_non_visible_control_groups:
-                return &#34;&#34;
+                # print(f&#34;DELETING: {first_child} : because mhtmltag&#34;)
+                return b&#34;&#34;
 
         # process known non-visible groups
-        non_visible_control_words = [&#34;\\context&#34;, &#34;\\colortbl&#34;, &#34;\\fonttbl&#34;]
+        non_visible_control_words = [b&#34;\\context&#34;, b&#34;\\colortbl&#34;, b&#34;\\fonttbl&#34;]
         first_control = self.get_first_controlword(children)
+        # print(f&#34;FIRST: {first_control}&#34;)
         if first_control in non_visible_control_words:
-            return &#34;&#34;
+            return b&#34;&#34;
 
         # Process star escaped groups
         # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
@@ -1137,13 +1304,14 @@ Args:
                     is_star_escaped = True
         control_word = None
         if is_star_escaped is True:
+            # print(f&#34;STAR: {children}&#34;)
             first_token = children[1]
             if isinstance(first_token, Token):
                 if first_token.type == &#34;CONTROLWORD&#34;:
                     control_word = first_token
                     if control_word.value in understood_commands:
                         return tree
-                    return &#34;&#34;
+                    return b&#34;&#34;
         return tree
 
     @staticmethod
@@ -1237,7 +1405,7 @@ Args:
 &#34;&#34;&#34;
         children = tree.children
         if len(children) == 0:
-            return &#34;&#34;
+            return b&#34;&#34;
         first_child = children[0]
 
         known_control_groups = [&#34;htmltag_group&#34;]
@@ -1247,13 +1415,15 @@ Args:
         known_non_visible_control_groups = [&#34;mhtmltag_group&#34;]
         if isinstance(first_child, Tree):
             if first_child.data in known_non_visible_control_groups:
-                return &#34;&#34;
+                # print(f&#34;DELETING: {first_child} : because mhtmltag&#34;)
+                return b&#34;&#34;
 
         # process known non-visible groups
-        non_visible_control_words = [&#34;\\context&#34;, &#34;\\colortbl&#34;, &#34;\\fonttbl&#34;]
+        non_visible_control_words = [b&#34;\\context&#34;, b&#34;\\colortbl&#34;, b&#34;\\fonttbl&#34;]
         first_control = self.get_first_controlword(children)
+        # print(f&#34;FIRST: {first_control}&#34;)
         if first_control in non_visible_control_words:
-            return &#34;&#34;
+            return b&#34;&#34;
 
         # Process star escaped groups
         # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
@@ -1268,13 +1438,14 @@ Args:
                     is_star_escaped = True
         control_word = None
         if is_star_escaped is True:
+            # print(f&#34;STAR: {children}&#34;)
             first_token = children[1]
             if isinstance(first_token, Token):
                 if first_token.type == &#34;CONTROLWORD&#34;:
                     control_word = first_token
                     if control_word.value in understood_commands:
                         return tree
-                    return &#34;&#34;
+                    return b&#34;&#34;
         return tree</code></pre>
 </details>
 </dd>
@@ -1349,6 +1520,7 @@ Returns:
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
 <li><code><a title="RTFDE.transformers.get_stripped_HTMLRTF_values" href="#RTFDE.transformers.get_stripped_HTMLRTF_values">get_stripped_HTMLRTF_values</a></code></li>
+<li><code><a title="RTFDE.transformers.strip_binary_objects" href="#RTFDE.transformers.strip_binary_objects">strip_binary_objects</a></code></li>
 <li><code><a title="RTFDE.transformers.toggle_htmlrtf" href="#RTFDE.transformers.toggle_htmlrtf">toggle_htmlrtf</a></code></li>
 </ul>
 </li>
@@ -1370,6 +1542,7 @@ Returns:
 <li><code><a title="RTFDE.transformers.RTFCleaner.NONBREAKING_SPACE" href="#RTFDE.transformers.RTFCleaner.NONBREAKING_SPACE">NONBREAKING_SPACE</a></code></li>
 <li><code><a title="RTFDE.transformers.RTFCleaner.OPENPAREN" href="#RTFDE.transformers.RTFCleaner.OPENPAREN">OPENPAREN</a></code></li>
 <li><code><a title="RTFDE.transformers.RTFCleaner.OPTIONAL_HYPHEN" href="#RTFDE.transformers.RTFCleaner.OPTIONAL_HYPHEN">OPTIONAL_HYPHEN</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.SPACE_SAVE" href="#RTFDE.transformers.RTFCleaner.SPACE_SAVE">SPACE_SAVE</a></code></li>
 <li><code><a title="RTFDE.transformers.RTFCleaner.STAR_ESCAPE" href="#RTFDE.transformers.RTFCleaner.STAR_ESCAPE">STAR_ESCAPE</a></code></li>
 <li><code><a title="RTFDE.transformers.RTFCleaner.STRING" href="#RTFDE.transformers.RTFCleaner.STRING">STRING</a></code></li>
 <li><code><a title="RTFDE.transformers.RTFCleaner.control_symbol" href="#RTFDE.transformers.RTFCleaner.control_symbol">control_symbol</a></code></li>

--- a/docs/RTFDE/transformers.html
+++ b/docs/RTFDE/transformers.html
@@ -1,0 +1,1409 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>RTFDE.transformers API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>RTFDE.transformers</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of RTFDE, a RTF De-Encapsulator.
+# Copyright © 2020 seamus tuohy, &lt;code@seamustuohy.com&gt;
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+
+from typing import Union, List
+#  from Python 3.9 typing.Generator is deprecated in favour of collections.abc.Generator
+from collections.abc import Generator
+
+from lark.visitors import Transformer
+from lark.visitors import v_args, Discard
+from lark.tree import Tree
+from lark.lexer import Token
+
+from RTFDE.utils import log_htmlrtf_stripping
+
+import logging
+log = logging.getLogger(&#34;RTFDE&#34;)
+
+
+class StripNonVisibleRTFGroups(Transformer):
+    &#34;&#34;&#34;Visits each Token in provided RTF Trees and strips out any RTF groups which are non-visible when de-encapsulated into HTML.
+    &#34;&#34;&#34;
+
+    @v_args(tree=True)
+    def group(self, tree: Tree):
+        &#34;&#34;&#34;Transformer which aggressively seeks out possible non-visible RTF groups and replaces them with empty strings.
+
+NOTE: Currently deleting all groups that don&#39;t have an htmltag. Please file an issue if you find one that should be included in de-encapsulated HTML. I will refine what gets deleted and what is converted based on identified needs for greater functionality or specific issues which need to be addressed.
+
+Args:
+        tree: A .rtf group (Tree object) which needs its contents decoded.
+&#34;&#34;&#34;
+        children = tree.children
+        if len(children) == 0:
+            return &#34;&#34;
+        first_child = children[0]
+
+        known_control_groups = [&#34;htmltag_group&#34;]
+        if isinstance(first_child, Tree):
+            if first_child.data in known_control_groups:
+                return tree
+        known_non_visible_control_groups = [&#34;mhtmltag_group&#34;]
+        if isinstance(first_child, Tree):
+            if first_child.data in known_non_visible_control_groups:
+                return &#34;&#34;
+
+        # process known non-visible groups
+        non_visible_control_words = [&#34;\\context&#34;, &#34;\\colortbl&#34;, &#34;\\fonttbl&#34;]
+        first_control = self.get_first_controlword(children)
+        if first_control in non_visible_control_words:
+            return &#34;&#34;
+
+        # Process star escaped groups
+        # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
+        # For example, if we added support for `destination text` we would need to add &#39;\\bkmkstart&#39; and &#39;\\ud&#39; so our processor doesn&#39;t delete those groups
+        understood_commands: List[str] = []
+        is_star_escaped = None
+        if (isinstance(first_child, Tree) and
+             len(first_child.children) != 0 ):
+            first_item = first_child.children[0]
+            if isinstance(first_item, Token):
+                if first_item.type == &#34;STAR_ESCAPE&#34;:
+                    is_star_escaped = True
+        control_word = None
+        if is_star_escaped is True:
+            first_token = children[1]
+            if isinstance(first_token, Token):
+                if first_token.type == &#34;CONTROLWORD&#34;:
+                    control_word = first_token
+                    if control_word.value in understood_commands:
+                        return tree
+                    return &#34;&#34;
+        return tree
+
+    @staticmethod
+    def get_first_controlword(children: List) -&gt; Union[str,None]:
+        &#34;&#34;&#34;Extracts the first control word from a .rtf group.
+
+Args:
+        children: A list of child objects within a .rtf group
+
+Returns:
+        The first controlword found in a group. Returns None if no controls words are found.
+        &#34;&#34;&#34;
+        for i in children:
+            try:
+                if i.type == &#34;CONTROLWORD&#34;:
+                    return i.value
+            except AttributeError:
+                continue
+        return None
+
+class RTFCleaner(Transformer):
+    &#34;&#34;&#34;Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn&#39;t be visible. And, joins all strings that are left into one final string.
+    &#34;&#34;&#34;
+
+    def start(self, args: List) -&gt; str:
+        &#34;&#34;&#34;Joins the .rtf object&#39;s string representations together at highest level object `start`.
+
+This is the final string combination. &#34;&#34;&#34;
+        return &#34;&#34;.join(args)
+
+    def STRING(self, string: Token) -&gt; str:
+        &#34;&#34;&#34;Convert a string object into a raw string.&#34;&#34;&#34;
+        if string.value is not None:
+            return string.value
+        return &#34;&#34;
+
+    def string(self, strings: List) -&gt; str:
+        &#34;&#34;&#34;Convert all string objects withing a string group into a single string.&#34;&#34;&#34;
+        return &#34;&#34;.join(strings)
+
+    def group(self, grp: List) -&gt; str:
+        &#34;&#34;&#34;Join the strings in all group objects.&#34;&#34;&#34;
+        _new_children = []
+        for i in grp:
+            if isinstance(i, type(Discard)):
+                pass
+            else:
+                _new_children.append(i)
+        return &#34;&#34;.join(_new_children)
+
+    def document(self, args: List) -&gt; str:
+        &#34;&#34;&#34;Join the all the strings in an .rtf object into a single string representation of the document.&#34;&#34;&#34;
+        return &#34;&#34;.join(args)
+
+    def OPENPAREN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all open parens.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def CLOSEPAREN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all closed parens.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def mhtmltag_group(self, args: List):
+        &#34;&#34;&#34;Process MHTMLTAG groups
+
+        Currently discarding because they don&#39;t need to be processed.
+
+Returns:
+        Always returns a discard object.&#34;&#34;&#34;
+        return Discard
+
+    def htmltag_group(self, strings: List) -&gt; str:
+        &#34;&#34;&#34;HTMLTAG processing.
+
+Takes any string values within an HTMLTAG and returns them.
+        &#34;&#34;&#34;
+        return &#34;&#34;.join(strings)
+
+    def HTMLTAG(self, htmltag: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all HTMLTAG objects&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def STAR_ESCAPE(self, char: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all star escape objects&#34;&#34;&#34;
+        # &#39;\\*&#39;: &#39;&#39;
+        return &#34;&#34;
+
+    def control_symbol(self, symbols: List) -&gt; str:
+        &#34;&#34;&#34;Join all visible symbols from in control symbol groups.&#34;&#34;&#34;
+        return &#34;&#34;.join(symbols)
+
+    def NONBREAKING_SPACE(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert non-breaking spaces into visible representation.&#34;&#34;&#34;
+        # &#39;\\~&#39;: &#39;\u00A0&#39;,
+        return u&#39;\u00A0&#39;
+
+    def NONBREAKING_HYPHEN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert non-breaking hyphens into visible representation.&#34;&#34;&#34;
+        # &#39;\\_&#39;: &#39;\u00AD&#39;
+        return u&#39;\u00AD&#39;
+
+    def OPTIONAL_HYPHEN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert hyphen control char into visible representation.&#34;&#34;&#34;
+        # &#39;\\-&#39;: &#39;\u2027&#39;
+        return u&#39;\u2027&#39;
+
+    def FORMULA_CHARACTER(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert a formula character into an empty string.
+
+If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def INDEX_SUBENTRY(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Process index subentry items
+
+Discard index sub-entries. Because, we don&#39;t care about indexes when de-encapsulating at this time.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def CONTROLSYMBOL(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.&#34;&#34;&#34;
+        symbols = {
+            &#39;\\{&#39;: &#39;\x7B&#39;,
+            &#39;\\}&#39;: &#39;\x7D&#39;,
+            &#39;\\\\&#39;: &#39;\x5C&#39;,
+        }
+        replacement = symbols.get(args.value, None)
+        # If this is simply a character to replace then return the value
+        if replacement is not None:
+            return replacement
+        return &#34;&#34;
+
+    def CONTROLWORD(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
+        &#34;&#34;&#34;
+        words = {
+            &#39;\\par&#39;: &#39;\n&#39;,
+            &#39;\\tab&#39;: &#39;\t&#39;,
+            &#39;\\line&#39;: &#39;\n&#39;,
+            &#39;\\lquote&#39;: &#39;\u2018&#39;,
+            &#39;\\rquote&#39;: &#39;\u2019&#39;,
+            &#39;\\ldblquote&#39;: &#39;\u201C&#39;,
+            &#39;\\rdblquote&#39;: &#39;\u201D&#39;,
+            &#39;\\bullet&#39;: &#39;\u2022&#39;,
+            &#39;\\endash&#39;: &#39;\u2013&#39;,
+            &#39;\\emdash&#39;: &#39;\u2014&#39;
+        }
+        replacement = words.get(args.value, None)
+        # If this is simply a character to replace then return the value as a string
+        if replacement is not None:
+            return replacement
+        return &#34;&#34;
+
+def get_stripped_HTMLRTF_values(tree: Tree, current_state: Union[bool,None] = None) -&gt; Generator:
+    &#34;&#34;&#34;Get a list of Tokens which should be suppressed by HTMLRTF control words.
+
+
+    NOTE: This de-encapsulation supports the HTMLRTF control word within nested groups. The state of the HTMLRTF control word transfers when entering groups and is restored when exiting groups, as specified in [MSFT-RTF].
+
+Returns:
+    A list of Tokens which should be suppressed by HTMLRTF control words.
+    &#34;&#34;&#34;
+    if current_state is None:
+        htmlrtf_stack = [False]
+    else:
+        htmlrtf_stack = [current_state]
+    for child in tree.children:
+        is_htmlrtf = None
+        if isinstance(child, Tree):
+            # A de-encapsulating RTF reader MUST support the HTMLRTF control word within nested groups. The state of the HTMLRTF control word MUST transfer when entering groups and be restored when exiting groups, as specified in [MSFT-RTF].
+            for toggle in get_stripped_HTMLRTF_values(child, htmlrtf_stack[-1]):
+                yield toggle
+        else:
+            is_htmlrtf = toggle_htmlrtf(child)
+            if is_htmlrtf is not None:
+                htmlrtf_stack.append(is_htmlrtf)
+                yield child
+            elif htmlrtf_stack[-1] is True:
+                yield child
+
+def toggle_htmlrtf(child: Union[Token,str]) -&gt; Union[bool,None]:
+    &#34;&#34;&#34;Identify if htmlrtf is being turned on or off.
+
+Returns:
+    Bool representing if htmlrtf is being enabled or disabled. None if object is not an HTMLRTF token.
+&#34;&#34;&#34;
+    if isinstance(child, Token):
+        if child.type == &#34;HTMLRTF&#34;:
+            htmlrtfstr = str(child).strip()
+            if (len(htmlrtfstr) &gt; 0 and htmlrtfstr[-1] == &#34;0&#34;):
+                return False
+            return True
+    return None
+
+class DeleteTokensFromTree(Transformer):
+    &#34;&#34;&#34;Removes a series of tokens from a Tree.
+
+Parameters:
+    tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+
+Attributes:
+    to_delete: A list of tokens to delete from the Tree object.
+    delete_start_pos: The starting position for all the identified tokens. Used to identify which tokens to delete.
+&#34;&#34;&#34;
+
+    def __init__(self, tokens_to_delete: List[Token]):
+        &#34;&#34;&#34;Setup attributes including token start_pos tracking.
+
+Args:
+    tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+&#34;&#34;&#34;
+        super().__init__()
+        self.to_delete = tokens_to_delete
+        self.delete_start_pos = {i.start_pos for i in self.to_delete}
+
+    def __default_token__(self, token: Token):
+        &#34;&#34;&#34;Discard any identified tokens.
+
+Args:
+        token: All tokens within the transformed tree.
+
+Returns:
+        Returns all non-identified tokens. Returns Discard objects for any identified tokens.
+&#34;&#34;&#34;
+        # print&#34;(Evaluating token {0} at {1} to consider deleting&#34;.format(child.value, child.end_pos))
+        if isinstance(token, Token):
+            if token.start_pos in self.delete_start_pos:
+                for i in self.to_delete:
+                    if (i.start_pos == token.start_pos and
+                        i.end_pos == token.end_pos and
+                        i.value == token.value):
+                        log_htmlrtf_stripping(i)
+                        return Discard
+        return token
+
+class StripUnusedSpecialCharacters(Transformer):
+    &#34;&#34;&#34;Strip all unused tokens which lark has extracted from the RTF.
+
+These tokens are largely artifacts of the RTF format.
+
+We have to do this because we use the &#34;keep_all_tokens&#34; option in our lark parser. It&#39;s better to be explicit then to allow for ambiguity because of the grammar.
+    &#34;&#34;&#34;
+
+    def _LBRACE(self, token: Token):
+        &#34;&#34;&#34;Remove RTF braces.
+
+Returns:
+        Always returns a discard object.&#34;&#34;&#34;
+        return Discard
+
+    def _RBRACE(self, token: Token):
+        &#34;&#34;&#34;Remove RTF braces.
+
+Returns:
+        Always returns a discard object.&#34;&#34;&#34;
+        return Discard
+
+    def _SPACE_DELETE(self, token: Token):
+        &#34;&#34;&#34;Remove spaces which are not a part of the content
+
+These are mostly spaces used to separate control words from the content they precede.
+
+Returns:
+        Always returns a discard object.
+        &#34;&#34;&#34;
+        return Discard
+
+
+class StripControlWords(Transformer):
+    &#34;&#34;&#34;Visits each control word and strips the whitespace from around it.
+    &#34;&#34;&#34;
+
+    def CONTROLWORD(self, token: Token):
+        &#34;&#34;&#34;Strips the whitespace from around a provided control word.
+
+Args:
+        token: A CONTROLWORD token to strip whitespace from.
+        &#34;&#34;&#34;
+        tok = token.update(value=token.value.strip())
+        return tok</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="RTFDE.transformers.get_stripped_HTMLRTF_values"><code class="name flex">
+<span>def <span class="ident">get_stripped_HTMLRTF_values</span></span>(<span>tree: lark.tree.Tree, current_state: Optional[bool] = None) ‑> collections.abc.Generator</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get a list of Tokens which should be suppressed by HTMLRTF control words.</p>
+<pre><code>NOTE: This de-encapsulation supports the HTMLRTF control word within nested groups. The state of the HTMLRTF control word transfers when entering groups and is restored when exiting groups, as specified in [MSFT-RTF].
+</code></pre>
+<h2 id="returns">Returns</h2>
+<p>A list of Tokens which should be suppressed by HTMLRTF control words.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_stripped_HTMLRTF_values(tree: Tree, current_state: Union[bool,None] = None) -&gt; Generator:
+    &#34;&#34;&#34;Get a list of Tokens which should be suppressed by HTMLRTF control words.
+
+
+    NOTE: This de-encapsulation supports the HTMLRTF control word within nested groups. The state of the HTMLRTF control word transfers when entering groups and is restored when exiting groups, as specified in [MSFT-RTF].
+
+Returns:
+    A list of Tokens which should be suppressed by HTMLRTF control words.
+    &#34;&#34;&#34;
+    if current_state is None:
+        htmlrtf_stack = [False]
+    else:
+        htmlrtf_stack = [current_state]
+    for child in tree.children:
+        is_htmlrtf = None
+        if isinstance(child, Tree):
+            # A de-encapsulating RTF reader MUST support the HTMLRTF control word within nested groups. The state of the HTMLRTF control word MUST transfer when entering groups and be restored when exiting groups, as specified in [MSFT-RTF].
+            for toggle in get_stripped_HTMLRTF_values(child, htmlrtf_stack[-1]):
+                yield toggle
+        else:
+            is_htmlrtf = toggle_htmlrtf(child)
+            if is_htmlrtf is not None:
+                htmlrtf_stack.append(is_htmlrtf)
+                yield child
+            elif htmlrtf_stack[-1] is True:
+                yield child</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.toggle_htmlrtf"><code class="name flex">
+<span>def <span class="ident">toggle_htmlrtf</span></span>(<span>child: Union[lark.lexer.Token, str]) ‑> Optional[bool]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Identify if htmlrtf is being turned on or off.</p>
+<h2 id="returns">Returns</h2>
+<p>Bool representing if htmlrtf is being enabled or disabled. None if object is not an HTMLRTF token.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def toggle_htmlrtf(child: Union[Token,str]) -&gt; Union[bool,None]:
+    &#34;&#34;&#34;Identify if htmlrtf is being turned on or off.
+
+Returns:
+    Bool representing if htmlrtf is being enabled or disabled. None if object is not an HTMLRTF token.
+&#34;&#34;&#34;
+    if isinstance(child, Token):
+        if child.type == &#34;HTMLRTF&#34;:
+            htmlrtfstr = str(child).strip()
+            if (len(htmlrtfstr) &gt; 0 and htmlrtfstr[-1] == &#34;0&#34;):
+                return False
+            return True
+    return None</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="RTFDE.transformers.DeleteTokensFromTree"><code class="flex name class">
+<span>class <span class="ident">DeleteTokensFromTree</span></span>
+<span>(</span><span>tokens_to_delete: List[lark.lexer.Token])</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Removes a series of tokens from a Tree.</p>
+<h2 id="parameters">Parameters</h2>
+<p>tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>to_delete</code></strong></dt>
+<dd>A list of tokens to delete from the Tree object.</dd>
+<dt><strong><code>delete_start_pos</code></strong></dt>
+<dd>The starting position for all the identified tokens. Used to identify which tokens to delete.</dd>
+</dl>
+<p>Setup attributes including token start_pos tracking.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>tokens_to_delete</code></strong></dt>
+<dd>A list of tokens to delete from the Tree object. (sets self.to_delete)</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class DeleteTokensFromTree(Transformer):
+    &#34;&#34;&#34;Removes a series of tokens from a Tree.
+
+Parameters:
+    tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+
+Attributes:
+    to_delete: A list of tokens to delete from the Tree object.
+    delete_start_pos: The starting position for all the identified tokens. Used to identify which tokens to delete.
+&#34;&#34;&#34;
+
+    def __init__(self, tokens_to_delete: List[Token]):
+        &#34;&#34;&#34;Setup attributes including token start_pos tracking.
+
+Args:
+    tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+&#34;&#34;&#34;
+        super().__init__()
+        self.to_delete = tokens_to_delete
+        self.delete_start_pos = {i.start_pos for i in self.to_delete}
+
+    def __default_token__(self, token: Token):
+        &#34;&#34;&#34;Discard any identified tokens.
+
+Args:
+        token: All tokens within the transformed tree.
+
+Returns:
+        Returns all non-identified tokens. Returns Discard objects for any identified tokens.
+&#34;&#34;&#34;
+        # print&#34;(Evaluating token {0} at {1} to consider deleting&#34;.format(child.value, child.end_pos))
+        if isinstance(token, Token):
+            if token.start_pos in self.delete_start_pos:
+                for i in self.to_delete:
+                    if (i.start_pos == token.start_pos and
+                        i.end_pos == token.end_pos and
+                        i.value == token.value):
+                        log_htmlrtf_stripping(i)
+                        return Discard
+        return token</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>lark.visitors.Transformer</li>
+<li>lark.visitors._Decoratable</li>
+<li>abc.ABC</li>
+<li>typing.Generic</li>
+</ul>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner"><code class="flex name class">
+<span>class <span class="ident">RTFCleaner</span></span>
+<span>(</span><span>visit_tokens: bool = True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn't be visible. And, joins all strings that are left into one final string.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class RTFCleaner(Transformer):
+    &#34;&#34;&#34;Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn&#39;t be visible. And, joins all strings that are left into one final string.
+    &#34;&#34;&#34;
+
+    def start(self, args: List) -&gt; str:
+        &#34;&#34;&#34;Joins the .rtf object&#39;s string representations together at highest level object `start`.
+
+This is the final string combination. &#34;&#34;&#34;
+        return &#34;&#34;.join(args)
+
+    def STRING(self, string: Token) -&gt; str:
+        &#34;&#34;&#34;Convert a string object into a raw string.&#34;&#34;&#34;
+        if string.value is not None:
+            return string.value
+        return &#34;&#34;
+
+    def string(self, strings: List) -&gt; str:
+        &#34;&#34;&#34;Convert all string objects withing a string group into a single string.&#34;&#34;&#34;
+        return &#34;&#34;.join(strings)
+
+    def group(self, grp: List) -&gt; str:
+        &#34;&#34;&#34;Join the strings in all group objects.&#34;&#34;&#34;
+        _new_children = []
+        for i in grp:
+            if isinstance(i, type(Discard)):
+                pass
+            else:
+                _new_children.append(i)
+        return &#34;&#34;.join(_new_children)
+
+    def document(self, args: List) -&gt; str:
+        &#34;&#34;&#34;Join the all the strings in an .rtf object into a single string representation of the document.&#34;&#34;&#34;
+        return &#34;&#34;.join(args)
+
+    def OPENPAREN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all open parens.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def CLOSEPAREN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all closed parens.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def mhtmltag_group(self, args: List):
+        &#34;&#34;&#34;Process MHTMLTAG groups
+
+        Currently discarding because they don&#39;t need to be processed.
+
+Returns:
+        Always returns a discard object.&#34;&#34;&#34;
+        return Discard
+
+    def htmltag_group(self, strings: List) -&gt; str:
+        &#34;&#34;&#34;HTMLTAG processing.
+
+Takes any string values within an HTMLTAG and returns them.
+        &#34;&#34;&#34;
+        return &#34;&#34;.join(strings)
+
+    def HTMLTAG(self, htmltag: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all HTMLTAG objects&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def STAR_ESCAPE(self, char: Token) -&gt; str:
+        &#34;&#34;&#34;Delete all star escape objects&#34;&#34;&#34;
+        # &#39;\\*&#39;: &#39;&#39;
+        return &#34;&#34;
+
+    def control_symbol(self, symbols: List) -&gt; str:
+        &#34;&#34;&#34;Join all visible symbols from in control symbol groups.&#34;&#34;&#34;
+        return &#34;&#34;.join(symbols)
+
+    def NONBREAKING_SPACE(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert non-breaking spaces into visible representation.&#34;&#34;&#34;
+        # &#39;\\~&#39;: &#39;\u00A0&#39;,
+        return u&#39;\u00A0&#39;
+
+    def NONBREAKING_HYPHEN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert non-breaking hyphens into visible representation.&#34;&#34;&#34;
+        # &#39;\\_&#39;: &#39;\u00AD&#39;
+        return u&#39;\u00AD&#39;
+
+    def OPTIONAL_HYPHEN(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert hyphen control char into visible representation.&#34;&#34;&#34;
+        # &#39;\\-&#39;: &#39;\u2027&#39;
+        return u&#39;\u2027&#39;
+
+    def FORMULA_CHARACTER(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert a formula character into an empty string.
+
+If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def INDEX_SUBENTRY(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Process index subentry items
+
+Discard index sub-entries. Because, we don&#39;t care about indexes when de-encapsulating at this time.&#34;&#34;&#34;
+        return &#34;&#34;
+
+    def CONTROLSYMBOL(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.&#34;&#34;&#34;
+        symbols = {
+            &#39;\\{&#39;: &#39;\x7B&#39;,
+            &#39;\\}&#39;: &#39;\x7D&#39;,
+            &#39;\\\\&#39;: &#39;\x5C&#39;,
+        }
+        replacement = symbols.get(args.value, None)
+        # If this is simply a character to replace then return the value
+        if replacement is not None:
+            return replacement
+        return &#34;&#34;
+
+    def CONTROLWORD(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
+        &#34;&#34;&#34;
+        words = {
+            &#39;\\par&#39;: &#39;\n&#39;,
+            &#39;\\tab&#39;: &#39;\t&#39;,
+            &#39;\\line&#39;: &#39;\n&#39;,
+            &#39;\\lquote&#39;: &#39;\u2018&#39;,
+            &#39;\\rquote&#39;: &#39;\u2019&#39;,
+            &#39;\\ldblquote&#39;: &#39;\u201C&#39;,
+            &#39;\\rdblquote&#39;: &#39;\u201D&#39;,
+            &#39;\\bullet&#39;: &#39;\u2022&#39;,
+            &#39;\\endash&#39;: &#39;\u2013&#39;,
+            &#39;\\emdash&#39;: &#39;\u2014&#39;
+        }
+        replacement = words.get(args.value, None)
+        # If this is simply a character to replace then return the value as a string
+        if replacement is not None:
+            return replacement
+        return &#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>lark.visitors.Transformer</li>
+<li>lark.visitors._Decoratable</li>
+<li>abc.ABC</li>
+<li>typing.Generic</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="RTFDE.transformers.RTFCleaner.CLOSEPAREN"><code class="name flex">
+<span>def <span class="ident">CLOSEPAREN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Delete all closed parens.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def CLOSEPAREN(self, args: Token) -&gt; str:
+    &#34;&#34;&#34;Delete all closed parens.&#34;&#34;&#34;
+    return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.CONTROLSYMBOL"><code class="name flex">
+<span>def <span class="ident">CONTROLSYMBOL</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def CONTROLSYMBOL(self, args: Token) -&gt; str:
+    &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.&#34;&#34;&#34;
+    symbols = {
+        &#39;\\{&#39;: &#39;\x7B&#39;,
+        &#39;\\}&#39;: &#39;\x7D&#39;,
+        &#39;\\\\&#39;: &#39;\x5C&#39;,
+    }
+    replacement = symbols.get(args.value, None)
+    # If this is simply a character to replace then return the value
+    if replacement is not None:
+        return replacement
+    return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.CONTROLWORD"><code class="name flex">
+<span>def <span class="ident">CONTROLWORD</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def CONTROLWORD(self, args: Token) -&gt; str:
+    &#34;&#34;&#34;Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
+    &#34;&#34;&#34;
+    words = {
+        &#39;\\par&#39;: &#39;\n&#39;,
+        &#39;\\tab&#39;: &#39;\t&#39;,
+        &#39;\\line&#39;: &#39;\n&#39;,
+        &#39;\\lquote&#39;: &#39;\u2018&#39;,
+        &#39;\\rquote&#39;: &#39;\u2019&#39;,
+        &#39;\\ldblquote&#39;: &#39;\u201C&#39;,
+        &#39;\\rdblquote&#39;: &#39;\u201D&#39;,
+        &#39;\\bullet&#39;: &#39;\u2022&#39;,
+        &#39;\\endash&#39;: &#39;\u2013&#39;,
+        &#39;\\emdash&#39;: &#39;\u2014&#39;
+    }
+    replacement = words.get(args.value, None)
+    # If this is simply a character to replace then return the value as a string
+    if replacement is not None:
+        return replacement
+    return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.FORMULA_CHARACTER"><code class="name flex">
+<span>def <span class="ident">FORMULA_CHARACTER</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert a formula character into an empty string.</p>
+<p>If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def FORMULA_CHARACTER(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Convert a formula character into an empty string.
+
+If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.&#34;&#34;&#34;
+        return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.HTMLTAG"><code class="name flex">
+<span>def <span class="ident">HTMLTAG</span></span>(<span>self, htmltag: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Delete all HTMLTAG objects</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def HTMLTAG(self, htmltag: Token) -&gt; str:
+    &#34;&#34;&#34;Delete all HTMLTAG objects&#34;&#34;&#34;
+    return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.INDEX_SUBENTRY"><code class="name flex">
+<span>def <span class="ident">INDEX_SUBENTRY</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Process index subentry items</p>
+<p>Discard index sub-entries. Because, we don't care about indexes when de-encapsulating at this time.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def INDEX_SUBENTRY(self, args: Token) -&gt; str:
+        &#34;&#34;&#34;Process index subentry items
+
+Discard index sub-entries. Because, we don&#39;t care about indexes when de-encapsulating at this time.&#34;&#34;&#34;
+        return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.NONBREAKING_HYPHEN"><code class="name flex">
+<span>def <span class="ident">NONBREAKING_HYPHEN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert non-breaking hyphens into visible representation.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def NONBREAKING_HYPHEN(self, args: Token) -&gt; str:
+    &#34;&#34;&#34;Convert non-breaking hyphens into visible representation.&#34;&#34;&#34;
+    # &#39;\\_&#39;: &#39;\u00AD&#39;
+    return u&#39;\u00AD&#39;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.NONBREAKING_SPACE"><code class="name flex">
+<span>def <span class="ident">NONBREAKING_SPACE</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert non-breaking spaces into visible representation.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def NONBREAKING_SPACE(self, args: Token) -&gt; str:
+    &#34;&#34;&#34;Convert non-breaking spaces into visible representation.&#34;&#34;&#34;
+    # &#39;\\~&#39;: &#39;\u00A0&#39;,
+    return u&#39;\u00A0&#39;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.OPENPAREN"><code class="name flex">
+<span>def <span class="ident">OPENPAREN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Delete all open parens.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def OPENPAREN(self, args: Token) -&gt; str:
+    &#34;&#34;&#34;Delete all open parens.&#34;&#34;&#34;
+    return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.OPTIONAL_HYPHEN"><code class="name flex">
+<span>def <span class="ident">OPTIONAL_HYPHEN</span></span>(<span>self, args: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert hyphen control char into visible representation.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def OPTIONAL_HYPHEN(self, args: Token) -&gt; str:
+    &#34;&#34;&#34;Convert hyphen control char into visible representation.&#34;&#34;&#34;
+    # &#39;\\-&#39;: &#39;\u2027&#39;
+    return u&#39;\u2027&#39;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.STAR_ESCAPE"><code class="name flex">
+<span>def <span class="ident">STAR_ESCAPE</span></span>(<span>self, char: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Delete all star escape objects</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def STAR_ESCAPE(self, char: Token) -&gt; str:
+    &#34;&#34;&#34;Delete all star escape objects&#34;&#34;&#34;
+    # &#39;\\*&#39;: &#39;&#39;
+    return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.STRING"><code class="name flex">
+<span>def <span class="ident">STRING</span></span>(<span>self, string: lark.lexer.Token) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert a string object into a raw string.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def STRING(self, string: Token) -&gt; str:
+    &#34;&#34;&#34;Convert a string object into a raw string.&#34;&#34;&#34;
+    if string.value is not None:
+        return string.value
+    return &#34;&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.control_symbol"><code class="name flex">
+<span>def <span class="ident">control_symbol</span></span>(<span>self, symbols: List) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Join all visible symbols from in control symbol groups.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def control_symbol(self, symbols: List) -&gt; str:
+    &#34;&#34;&#34;Join all visible symbols from in control symbol groups.&#34;&#34;&#34;
+    return &#34;&#34;.join(symbols)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.document"><code class="name flex">
+<span>def <span class="ident">document</span></span>(<span>self, args: List) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Join the all the strings in an .rtf object into a single string representation of the document.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def document(self, args: List) -&gt; str:
+    &#34;&#34;&#34;Join the all the strings in an .rtf object into a single string representation of the document.&#34;&#34;&#34;
+    return &#34;&#34;.join(args)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.group"><code class="name flex">
+<span>def <span class="ident">group</span></span>(<span>self, grp: List) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Join the strings in all group objects.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def group(self, grp: List) -&gt; str:
+    &#34;&#34;&#34;Join the strings in all group objects.&#34;&#34;&#34;
+    _new_children = []
+    for i in grp:
+        if isinstance(i, type(Discard)):
+            pass
+        else:
+            _new_children.append(i)
+    return &#34;&#34;.join(_new_children)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.htmltag_group"><code class="name flex">
+<span>def <span class="ident">htmltag_group</span></span>(<span>self, strings: List) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>HTMLTAG processing.</p>
+<p>Takes any string values within an HTMLTAG and returns them.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def htmltag_group(self, strings: List) -&gt; str:
+        &#34;&#34;&#34;HTMLTAG processing.
+
+Takes any string values within an HTMLTAG and returns them.
+        &#34;&#34;&#34;
+        return &#34;&#34;.join(strings)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.mhtmltag_group"><code class="name flex">
+<span>def <span class="ident">mhtmltag_group</span></span>(<span>self, args: List)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Process MHTMLTAG groups</p>
+<pre><code>    Currently discarding because they don't need to be processed.
+</code></pre>
+<h2 id="returns">Returns</h2>
+<p>Always returns a discard object.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def mhtmltag_group(self, args: List):
+        &#34;&#34;&#34;Process MHTMLTAG groups
+
+        Currently discarding because they don&#39;t need to be processed.
+
+Returns:
+        Always returns a discard object.&#34;&#34;&#34;
+        return Discard</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.start"><code class="name flex">
+<span>def <span class="ident">start</span></span>(<span>self, args: List) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Joins the .rtf object's string representations together at highest level object <code>start</code>.</p>
+<p>This is the final string combination.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def start(self, args: List) -&gt; str:
+        &#34;&#34;&#34;Joins the .rtf object&#39;s string representations together at highest level object `start`.
+
+This is the final string combination. &#34;&#34;&#34;
+        return &#34;&#34;.join(args)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.transformers.RTFCleaner.string"><code class="name flex">
+<span>def <span class="ident">string</span></span>(<span>self, strings: List) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert all string objects withing a string group into a single string.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def string(self, strings: List) -&gt; str:
+    &#34;&#34;&#34;Convert all string objects withing a string group into a single string.&#34;&#34;&#34;
+    return &#34;&#34;.join(strings)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="RTFDE.transformers.StripControlWords"><code class="flex name class">
+<span>class <span class="ident">StripControlWords</span></span>
+<span>(</span><span>visit_tokens: bool = True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Visits each control word and strips the whitespace from around it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class StripControlWords(Transformer):
+    &#34;&#34;&#34;Visits each control word and strips the whitespace from around it.
+    &#34;&#34;&#34;
+
+    def CONTROLWORD(self, token: Token):
+        &#34;&#34;&#34;Strips the whitespace from around a provided control word.
+
+Args:
+        token: A CONTROLWORD token to strip whitespace from.
+        &#34;&#34;&#34;
+        tok = token.update(value=token.value.strip())
+        return tok</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>lark.visitors.Transformer</li>
+<li>lark.visitors._Decoratable</li>
+<li>abc.ABC</li>
+<li>typing.Generic</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="RTFDE.transformers.StripControlWords.CONTROLWORD"><code class="name flex">
+<span>def <span class="ident">CONTROLWORD</span></span>(<span>self, token: lark.lexer.Token)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Strips the whitespace from around a provided control word.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>token</code></strong></dt>
+<dd>A CONTROLWORD token to strip whitespace from.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    def CONTROLWORD(self, token: Token):
+        &#34;&#34;&#34;Strips the whitespace from around a provided control word.
+
+Args:
+        token: A CONTROLWORD token to strip whitespace from.
+        &#34;&#34;&#34;
+        tok = token.update(value=token.value.strip())
+        return tok</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="RTFDE.transformers.StripNonVisibleRTFGroups"><code class="flex name class">
+<span>class <span class="ident">StripNonVisibleRTFGroups</span></span>
+<span>(</span><span>visit_tokens: bool = True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Visits each Token in provided RTF Trees and strips out any RTF groups which are non-visible when de-encapsulated into HTML.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class StripNonVisibleRTFGroups(Transformer):
+    &#34;&#34;&#34;Visits each Token in provided RTF Trees and strips out any RTF groups which are non-visible when de-encapsulated into HTML.
+    &#34;&#34;&#34;
+
+    @v_args(tree=True)
+    def group(self, tree: Tree):
+        &#34;&#34;&#34;Transformer which aggressively seeks out possible non-visible RTF groups and replaces them with empty strings.
+
+NOTE: Currently deleting all groups that don&#39;t have an htmltag. Please file an issue if you find one that should be included in de-encapsulated HTML. I will refine what gets deleted and what is converted based on identified needs for greater functionality or specific issues which need to be addressed.
+
+Args:
+        tree: A .rtf group (Tree object) which needs its contents decoded.
+&#34;&#34;&#34;
+        children = tree.children
+        if len(children) == 0:
+            return &#34;&#34;
+        first_child = children[0]
+
+        known_control_groups = [&#34;htmltag_group&#34;]
+        if isinstance(first_child, Tree):
+            if first_child.data in known_control_groups:
+                return tree
+        known_non_visible_control_groups = [&#34;mhtmltag_group&#34;]
+        if isinstance(first_child, Tree):
+            if first_child.data in known_non_visible_control_groups:
+                return &#34;&#34;
+
+        # process known non-visible groups
+        non_visible_control_words = [&#34;\\context&#34;, &#34;\\colortbl&#34;, &#34;\\fonttbl&#34;]
+        first_control = self.get_first_controlword(children)
+        if first_control in non_visible_control_words:
+            return &#34;&#34;
+
+        # Process star escaped groups
+        # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
+        # For example, if we added support for `destination text` we would need to add &#39;\\bkmkstart&#39; and &#39;\\ud&#39; so our processor doesn&#39;t delete those groups
+        understood_commands: List[str] = []
+        is_star_escaped = None
+        if (isinstance(first_child, Tree) and
+             len(first_child.children) != 0 ):
+            first_item = first_child.children[0]
+            if isinstance(first_item, Token):
+                if first_item.type == &#34;STAR_ESCAPE&#34;:
+                    is_star_escaped = True
+        control_word = None
+        if is_star_escaped is True:
+            first_token = children[1]
+            if isinstance(first_token, Token):
+                if first_token.type == &#34;CONTROLWORD&#34;:
+                    control_word = first_token
+                    if control_word.value in understood_commands:
+                        return tree
+                    return &#34;&#34;
+        return tree
+
+    @staticmethod
+    def get_first_controlword(children: List) -&gt; Union[str,None]:
+        &#34;&#34;&#34;Extracts the first control word from a .rtf group.
+
+Args:
+        children: A list of child objects within a .rtf group
+
+Returns:
+        The first controlword found in a group. Returns None if no controls words are found.
+        &#34;&#34;&#34;
+        for i in children:
+            try:
+                if i.type == &#34;CONTROLWORD&#34;:
+                    return i.value
+            except AttributeError:
+                continue
+        return None</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>lark.visitors.Transformer</li>
+<li>lark.visitors._Decoratable</li>
+<li>abc.ABC</li>
+<li>typing.Generic</li>
+</ul>
+<h3>Static methods</h3>
+<dl>
+<dt id="RTFDE.transformers.StripNonVisibleRTFGroups.get_first_controlword"><code class="name flex">
+<span>def <span class="ident">get_first_controlword</span></span>(<span>children: List) ‑> Optional[str]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extracts the first control word from a .rtf group.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>children</code></strong></dt>
+<dd>A list of child objects within a .rtf group</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The first controlword found in a group. Returns None if no controls words are found.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    @staticmethod
+    def get_first_controlword(children: List) -&gt; Union[str,None]:
+        &#34;&#34;&#34;Extracts the first control word from a .rtf group.
+
+Args:
+        children: A list of child objects within a .rtf group
+
+Returns:
+        The first controlword found in a group. Returns None if no controls words are found.
+        &#34;&#34;&#34;
+        for i in children:
+            try:
+                if i.type == &#34;CONTROLWORD&#34;:
+                    return i.value
+            except AttributeError:
+                continue
+        return None</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="RTFDE.transformers.StripNonVisibleRTFGroups.group"><code class="name flex">
+<span>def <span class="ident">group</span></span>(<span>self, tree: lark.tree.Tree)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transformer which aggressively seeks out possible non-visible RTF groups and replaces them with empty strings.</p>
+<p>NOTE: Currently deleting all groups that don't have an htmltag. Please file an issue if you find one that should be included in de-encapsulated HTML. I will refine what gets deleted and what is converted based on identified needs for greater functionality or specific issues which need to be addressed.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>tree</code></strong></dt>
+<dd>A .rtf group (Tree object) which needs its contents decoded.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">    @v_args(tree=True)
+    def group(self, tree: Tree):
+        &#34;&#34;&#34;Transformer which aggressively seeks out possible non-visible RTF groups and replaces them with empty strings.
+
+NOTE: Currently deleting all groups that don&#39;t have an htmltag. Please file an issue if you find one that should be included in de-encapsulated HTML. I will refine what gets deleted and what is converted based on identified needs for greater functionality or specific issues which need to be addressed.
+
+Args:
+        tree: A .rtf group (Tree object) which needs its contents decoded.
+&#34;&#34;&#34;
+        children = tree.children
+        if len(children) == 0:
+            return &#34;&#34;
+        first_child = children[0]
+
+        known_control_groups = [&#34;htmltag_group&#34;]
+        if isinstance(first_child, Tree):
+            if first_child.data in known_control_groups:
+                return tree
+        known_non_visible_control_groups = [&#34;mhtmltag_group&#34;]
+        if isinstance(first_child, Tree):
+            if first_child.data in known_non_visible_control_groups:
+                return &#34;&#34;
+
+        # process known non-visible groups
+        non_visible_control_words = [&#34;\\context&#34;, &#34;\\colortbl&#34;, &#34;\\fonttbl&#34;]
+        first_control = self.get_first_controlword(children)
+        if first_control in non_visible_control_words:
+            return &#34;&#34;
+
+        # Process star escaped groups
+        # NOTE: `understood_commands` is where we can include commands we decide to actively process during deencapsulation in the future.
+        # For example, if we added support for `destination text` we would need to add &#39;\\bkmkstart&#39; and &#39;\\ud&#39; so our processor doesn&#39;t delete those groups
+        understood_commands: List[str] = []
+        is_star_escaped = None
+        if (isinstance(first_child, Tree) and
+             len(first_child.children) != 0 ):
+            first_item = first_child.children[0]
+            if isinstance(first_item, Token):
+                if first_item.type == &#34;STAR_ESCAPE&#34;:
+                    is_star_escaped = True
+        control_word = None
+        if is_star_escaped is True:
+            first_token = children[1]
+            if isinstance(first_token, Token):
+                if first_token.type == &#34;CONTROLWORD&#34;:
+                    control_word = first_token
+                    if control_word.value in understood_commands:
+                        return tree
+                    return &#34;&#34;
+        return tree</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="RTFDE.transformers.StripUnusedSpecialCharacters"><code class="flex name class">
+<span>class <span class="ident">StripUnusedSpecialCharacters</span></span>
+<span>(</span><span>visit_tokens: bool = True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Strip all unused tokens which lark has extracted from the RTF.</p>
+<p>These tokens are largely artifacts of the RTF format.</p>
+<p>We have to do this because we use the "keep_all_tokens" option in our lark parser. It's better to be explicit then to allow for ambiguity because of the grammar.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class StripUnusedSpecialCharacters(Transformer):
+    &#34;&#34;&#34;Strip all unused tokens which lark has extracted from the RTF.
+
+These tokens are largely artifacts of the RTF format.
+
+We have to do this because we use the &#34;keep_all_tokens&#34; option in our lark parser. It&#39;s better to be explicit then to allow for ambiguity because of the grammar.
+    &#34;&#34;&#34;
+
+    def _LBRACE(self, token: Token):
+        &#34;&#34;&#34;Remove RTF braces.
+
+Returns:
+        Always returns a discard object.&#34;&#34;&#34;
+        return Discard
+
+    def _RBRACE(self, token: Token):
+        &#34;&#34;&#34;Remove RTF braces.
+
+Returns:
+        Always returns a discard object.&#34;&#34;&#34;
+        return Discard
+
+    def _SPACE_DELETE(self, token: Token):
+        &#34;&#34;&#34;Remove spaces which are not a part of the content
+
+These are mostly spaces used to separate control words from the content they precede.
+
+Returns:
+        Always returns a discard object.
+        &#34;&#34;&#34;
+        return Discard</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>lark.visitors.Transformer</li>
+<li>lark.visitors._Decoratable</li>
+<li>abc.ABC</li>
+<li>typing.Generic</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="RTFDE" href="index.html">RTFDE</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="RTFDE.transformers.get_stripped_HTMLRTF_values" href="#RTFDE.transformers.get_stripped_HTMLRTF_values">get_stripped_HTMLRTF_values</a></code></li>
+<li><code><a title="RTFDE.transformers.toggle_htmlrtf" href="#RTFDE.transformers.toggle_htmlrtf">toggle_htmlrtf</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="RTFDE.transformers.DeleteTokensFromTree" href="#RTFDE.transformers.DeleteTokensFromTree">DeleteTokensFromTree</a></code></h4>
+</li>
+<li>
+<h4><code><a title="RTFDE.transformers.RTFCleaner" href="#RTFDE.transformers.RTFCleaner">RTFCleaner</a></code></h4>
+<ul class="two-column">
+<li><code><a title="RTFDE.transformers.RTFCleaner.CLOSEPAREN" href="#RTFDE.transformers.RTFCleaner.CLOSEPAREN">CLOSEPAREN</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.CONTROLSYMBOL" href="#RTFDE.transformers.RTFCleaner.CONTROLSYMBOL">CONTROLSYMBOL</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.CONTROLWORD" href="#RTFDE.transformers.RTFCleaner.CONTROLWORD">CONTROLWORD</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.FORMULA_CHARACTER" href="#RTFDE.transformers.RTFCleaner.FORMULA_CHARACTER">FORMULA_CHARACTER</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.HTMLTAG" href="#RTFDE.transformers.RTFCleaner.HTMLTAG">HTMLTAG</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.INDEX_SUBENTRY" href="#RTFDE.transformers.RTFCleaner.INDEX_SUBENTRY">INDEX_SUBENTRY</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.NONBREAKING_HYPHEN" href="#RTFDE.transformers.RTFCleaner.NONBREAKING_HYPHEN">NONBREAKING_HYPHEN</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.NONBREAKING_SPACE" href="#RTFDE.transformers.RTFCleaner.NONBREAKING_SPACE">NONBREAKING_SPACE</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.OPENPAREN" href="#RTFDE.transformers.RTFCleaner.OPENPAREN">OPENPAREN</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.OPTIONAL_HYPHEN" href="#RTFDE.transformers.RTFCleaner.OPTIONAL_HYPHEN">OPTIONAL_HYPHEN</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.STAR_ESCAPE" href="#RTFDE.transformers.RTFCleaner.STAR_ESCAPE">STAR_ESCAPE</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.STRING" href="#RTFDE.transformers.RTFCleaner.STRING">STRING</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.control_symbol" href="#RTFDE.transformers.RTFCleaner.control_symbol">control_symbol</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.document" href="#RTFDE.transformers.RTFCleaner.document">document</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.group" href="#RTFDE.transformers.RTFCleaner.group">group</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.htmltag_group" href="#RTFDE.transformers.RTFCleaner.htmltag_group">htmltag_group</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.mhtmltag_group" href="#RTFDE.transformers.RTFCleaner.mhtmltag_group">mhtmltag_group</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.start" href="#RTFDE.transformers.RTFCleaner.start">start</a></code></li>
+<li><code><a title="RTFDE.transformers.RTFCleaner.string" href="#RTFDE.transformers.RTFCleaner.string">string</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="RTFDE.transformers.StripControlWords" href="#RTFDE.transformers.StripControlWords">StripControlWords</a></code></h4>
+<ul class="">
+<li><code><a title="RTFDE.transformers.StripControlWords.CONTROLWORD" href="#RTFDE.transformers.StripControlWords.CONTROLWORD">CONTROLWORD</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="RTFDE.transformers.StripNonVisibleRTFGroups" href="#RTFDE.transformers.StripNonVisibleRTFGroups">StripNonVisibleRTFGroups</a></code></h4>
+<ul class="">
+<li><code><a title="RTFDE.transformers.StripNonVisibleRTFGroups.get_first_controlword" href="#RTFDE.transformers.StripNonVisibleRTFGroups.get_first_controlword">get_first_controlword</a></code></li>
+<li><code><a title="RTFDE.transformers.StripNonVisibleRTFGroups.group" href="#RTFDE.transformers.StripNonVisibleRTFGroups.group">group</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="RTFDE.transformers.StripUnusedSpecialCharacters" href="#RTFDE.transformers.StripUnusedSpecialCharacters">StripUnusedSpecialCharacters</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/RTFDE/transformers.md
+++ b/docs/RTFDE/transformers.md
@@ -1,0 +1,192 @@
+Module RTFDE.transformers
+=========================
+
+Functions
+---------
+
+    
+`get_stripped_HTMLRTF_values(tree: lark.tree.Tree, current_state: Optional[bool] = None) ‑> collections.abc.Generator`
+:   Get a list of Tokens which should be suppressed by HTMLRTF control words.
+    
+    
+        NOTE: This de-encapsulation supports the HTMLRTF control word within nested groups. The state of the HTMLRTF control word transfers when entering groups and is restored when exiting groups, as specified in [MSFT-RTF].
+    
+    Returns:
+        A list of Tokens which should be suppressed by HTMLRTF control words.
+
+    
+`toggle_htmlrtf(child: Union[lark.lexer.Token, str]) ‑> Optional[bool]`
+:   Identify if htmlrtf is being turned on or off.
+    
+    Returns:
+        Bool representing if htmlrtf is being enabled or disabled. None if object is not an HTMLRTF token.
+
+Classes
+-------
+
+`DeleteTokensFromTree(tokens_to_delete: List[lark.lexer.Token])`
+:   Removes a series of tokens from a Tree.
+    
+    Parameters:
+        tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+    
+    Attributes:
+        to_delete: A list of tokens to delete from the Tree object.
+        delete_start_pos: The starting position for all the identified tokens. Used to identify which tokens to delete.
+    
+    Setup attributes including token start_pos tracking.
+    
+    Args:
+        tokens_to_delete: A list of tokens to delete from the Tree object. (sets self.to_delete)
+
+    ### Ancestors (in MRO)
+
+    * lark.visitors.Transformer
+    * lark.visitors._Decoratable
+    * abc.ABC
+    * typing.Generic
+
+`RTFCleaner(visit_tokens: bool = True)`
+:   Visits each Token in provided RTF Trees. Converts all tokens that need converting. Deletes all tokens that shouldn't be visible. And, joins all strings that are left into one final string.
+
+    ### Ancestors (in MRO)
+
+    * lark.visitors.Transformer
+    * lark.visitors._Decoratable
+    * abc.ABC
+    * typing.Generic
+
+    ### Methods
+
+    `CLOSEPAREN(self, args: lark.lexer.Token) ‑> str`
+    :   Delete all closed parens.
+
+    `CONTROLSYMBOL(self, args: lark.lexer.Token) ‑> str`
+    :   Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.
+
+    `CONTROLWORD(self, args: lark.lexer.Token) ‑> str`
+    :   Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
+
+    `FORMULA_CHARACTER(self, args: lark.lexer.Token) ‑> str`
+    :   Convert a formula character into an empty string.
+        
+        If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.
+
+    `HTMLTAG(self, htmltag: lark.lexer.Token) ‑> str`
+    :   Delete all HTMLTAG objects
+
+    `INDEX_SUBENTRY(self, args: lark.lexer.Token) ‑> str`
+    :   Process index subentry items
+        
+        Discard index sub-entries. Because, we don't care about indexes when de-encapsulating at this time.
+
+    `NONBREAKING_HYPHEN(self, args: lark.lexer.Token) ‑> str`
+    :   Convert non-breaking hyphens into visible representation.
+
+    `NONBREAKING_SPACE(self, args: lark.lexer.Token) ‑> str`
+    :   Convert non-breaking spaces into visible representation.
+
+    `OPENPAREN(self, args: lark.lexer.Token) ‑> str`
+    :   Delete all open parens.
+
+    `OPTIONAL_HYPHEN(self, args: lark.lexer.Token) ‑> str`
+    :   Convert hyphen control char into visible representation.
+
+    `STAR_ESCAPE(self, char: lark.lexer.Token) ‑> str`
+    :   Delete all star escape objects
+
+    `STRING(self, string: lark.lexer.Token) ‑> str`
+    :   Convert a string object into a raw string.
+
+    `control_symbol(self, symbols: List) ‑> str`
+    :   Join all visible symbols from in control symbol groups.
+
+    `document(self, args: List) ‑> str`
+    :   Join the all the strings in an .rtf object into a single string representation of the document.
+
+    `group(self, grp: List) ‑> str`
+    :   Join the strings in all group objects.
+
+    `htmltag_group(self, strings: List) ‑> str`
+    :   HTMLTAG processing.
+        
+        Takes any string values within an HTMLTAG and returns them.
+
+    `mhtmltag_group(self, args: List)`
+    :   Process MHTMLTAG groups
+        
+                Currently discarding because they don't need to be processed.
+        
+        Returns:
+                Always returns a discard object.
+
+    `start(self, args: List) ‑> str`
+    :   Joins the .rtf object's string representations together at highest level object `start`.
+        
+        This is the final string combination.
+
+    `string(self, strings: List) ‑> str`
+    :   Convert all string objects withing a string group into a single string.
+
+`StripControlWords(visit_tokens: bool = True)`
+:   Visits each control word and strips the whitespace from around it.
+
+    ### Ancestors (in MRO)
+
+    * lark.visitors.Transformer
+    * lark.visitors._Decoratable
+    * abc.ABC
+    * typing.Generic
+
+    ### Methods
+
+    `CONTROLWORD(self, token: lark.lexer.Token)`
+    :   Strips the whitespace from around a provided control word.
+        
+        Args:
+                token: A CONTROLWORD token to strip whitespace from.
+
+`StripNonVisibleRTFGroups(visit_tokens: bool = True)`
+:   Visits each Token in provided RTF Trees and strips out any RTF groups which are non-visible when de-encapsulated into HTML.
+
+    ### Ancestors (in MRO)
+
+    * lark.visitors.Transformer
+    * lark.visitors._Decoratable
+    * abc.ABC
+    * typing.Generic
+
+    ### Static methods
+
+    `get_first_controlword(children: List) ‑> Optional[str]`
+    :   Extracts the first control word from a .rtf group.
+        
+        Args:
+                children: A list of child objects within a .rtf group
+        
+        Returns:
+                The first controlword found in a group. Returns None if no controls words are found.
+
+    ### Methods
+
+    `group(self, tree: lark.tree.Tree)`
+    :   Transformer which aggressively seeks out possible non-visible RTF groups and replaces them with empty strings.
+        
+        NOTE: Currently deleting all groups that don't have an htmltag. Please file an issue if you find one that should be included in de-encapsulated HTML. I will refine what gets deleted and what is converted based on identified needs for greater functionality or specific issues which need to be addressed.
+        
+        Args:
+                tree: A .rtf group (Tree object) which needs its contents decoded.
+
+`StripUnusedSpecialCharacters(visit_tokens: bool = True)`
+:   Strip all unused tokens which lark has extracted from the RTF.
+    
+    These tokens are largely artifacts of the RTF format.
+    
+    We have to do this because we use the "keep_all_tokens" option in our lark parser. It's better to be explicit then to allow for ambiguity because of the grammar.
+
+    ### Ancestors (in MRO)
+
+    * lark.visitors.Transformer
+    * lark.visitors._Decoratable
+    * abc.ABC
+    * typing.Generic

--- a/docs/RTFDE/transformers.md
+++ b/docs/RTFDE/transformers.md
@@ -15,6 +15,35 @@ Functions
         A list of Tokens which should be suppressed by HTMLRTF control words.
 
     
+`strip_binary_objects(raw_rtf: bytes) ‑> tuple`
+:   Extracts binary objects from a rtf file.
+    
+    Parameters:
+        raw_rtf: (bytes): It's the raw RTF file as bytes.
+    
+    Returns:
+        A tuple containing (new_raw, found_bytes)
+            new_raw: (bytes) A bytes object where any binary data has been removed.
+            found_bytes: (list) List of dictionaries containing binary data extracted from the rtf file. Each dictionary includes the data extracted, where it was extracted from in the original rtf file and where it can be inserted back into the stripped output.
+    
+        Description of found_bytes dictionaries:
+    
+            "bytes": (bytes) The binary data contained which was extracted.
+            "ctrl_char": (tuple) Tuple containing the binary control word and its numeric parameter
+            "start_pos": (int) The position (in the original raw rtf data) where the binary control word started.
+            "bin_start_pos": (int) The position (in the original raw rtf data) where the binary data starts.
+            "end_pos": (int) The position (in the original raw rtf data) where the binary data ends.
+    
+        Here is an example of what this looks like (by displaying the printable representation so you can see the bytes and then splitting the dict keys on new lines to make it readable.)
+            >> print(repr(found_bytes))
+    
+            "{'bytes': b'\xf4UP\x13\xdb\xe4\xe6CO\xa8\x16\x10\x8b\n\xfbA\x9d\xc5\xd1C',
+              'ctrl_char': (b'\\bin', b'20'),
+              'start_pos': 56,
+              'end_pos': 83,
+              'bin_start_pos': 63}"
+
+    
 `toggle_htmlrtf(child: Union[lark.lexer.Token, str]) ‑> Optional[bool]`
 :   Identify if htmlrtf is being turned on or off.
     
@@ -58,56 +87,59 @@ Classes
 
     ### Methods
 
-    `CLOSEPAREN(self, args: lark.lexer.Token) ‑> str`
+    `CLOSEPAREN(self, args: lark.lexer.Token) ‑> bytes`
     :   Delete all closed parens.
 
-    `CONTROLSYMBOL(self, args: lark.lexer.Token) ‑> str`
+    `CONTROLSYMBOL(self, args: lark.lexer.Token) ‑> bytes`
     :   Convert encoded chars which are mis-categorized as control symbols into their respective chars. Delete all the other ones.
 
-    `CONTROLWORD(self, args: lark.lexer.Token) ‑> str`
+    `CONTROLWORD(self, args: lark.lexer.Token) ‑> bytes`
     :   Convert encoded chars which are mis-categorized as control words into their respective chars. Delete all the other ones.
 
-    `FORMULA_CHARACTER(self, args: lark.lexer.Token) ‑> str`
+    `FORMULA_CHARACTER(self, args: lark.lexer.Token) ‑> bytes`
     :   Convert a formula character into an empty string.
         
         If we are attempting to represent formula characters the scope for this library has grown too inclusive. This was only used by Word 5.1 for the Macintosh as the beginning delimiter for a string of formula typesetting commands.
 
-    `HTMLTAG(self, htmltag: lark.lexer.Token) ‑> str`
+    `HTMLTAG(self, htmltag: lark.lexer.Token) ‑> bytes`
     :   Delete all HTMLTAG objects
 
-    `INDEX_SUBENTRY(self, args: lark.lexer.Token) ‑> str`
+    `INDEX_SUBENTRY(self, args: lark.lexer.Token) ‑> bytes`
     :   Process index subentry items
         
         Discard index sub-entries. Because, we don't care about indexes when de-encapsulating at this time.
 
-    `NONBREAKING_HYPHEN(self, args: lark.lexer.Token) ‑> str`
+    `NONBREAKING_HYPHEN(self, args: lark.lexer.Token) ‑> bytes`
     :   Convert non-breaking hyphens into visible representation.
 
-    `NONBREAKING_SPACE(self, args: lark.lexer.Token) ‑> str`
+    `NONBREAKING_SPACE(self, args: lark.lexer.Token) ‑> bytes`
     :   Convert non-breaking spaces into visible representation.
 
-    `OPENPAREN(self, args: lark.lexer.Token) ‑> str`
+    `OPENPAREN(self, args: lark.lexer.Token) ‑> bytes`
     :   Delete all open parens.
 
-    `OPTIONAL_HYPHEN(self, args: lark.lexer.Token) ‑> str`
+    `OPTIONAL_HYPHEN(self, args: lark.lexer.Token) ‑> bytes`
     :   Convert hyphen control char into visible representation.
 
-    `STAR_ESCAPE(self, char: lark.lexer.Token) ‑> str`
+    `SPACE_SAVE(self, string: lark.lexer.Token) ‑> bytes`
+    :
+
+    `STAR_ESCAPE(self, char: lark.lexer.Token) ‑> bytes`
     :   Delete all star escape objects
 
-    `STRING(self, string: lark.lexer.Token) ‑> str`
+    `STRING(self, string: lark.lexer.Token) ‑> bytes`
     :   Convert a string object into a raw string.
 
-    `control_symbol(self, symbols: List) ‑> str`
+    `control_symbol(self, symbols: List) ‑> bytes`
     :   Join all visible symbols from in control symbol groups.
 
-    `document(self, args: List) ‑> str`
+    `document(self, args: List) ‑> bytes`
     :   Join the all the strings in an .rtf object into a single string representation of the document.
 
-    `group(self, grp: List) ‑> str`
+    `group(self, grp: List) ‑> bytes`
     :   Join the strings in all group objects.
 
-    `htmltag_group(self, strings: List) ‑> str`
+    `htmltag_group(self, strings: List) ‑> bytes`
     :   HTMLTAG processing.
         
         Takes any string values within an HTMLTAG and returns them.
@@ -120,12 +152,12 @@ Classes
         Returns:
                 Always returns a discard object.
 
-    `start(self, args: List) ‑> str`
+    `start(self, args: List) ‑> bytes`
     :   Joins the .rtf object's string representations together at highest level object `start`.
         
         This is the final string combination.
 
-    `string(self, strings: List) ‑> str`
+    `string(self, strings: List) ‑> bytes`
     :   Convert all string objects withing a string group into a single string.
 
 `StripControlWords(visit_tokens: bool = True)`

--- a/docs/RTFDE/utils.html
+++ b/docs/RTFDE/utils.html
@@ -91,7 +91,7 @@ Args:
         print(data)
         sys.stdout = original_stdout
 
-def encode_escaped_control_chars(raw_text: str) -&gt; str:
+def encode_escaped_control_chars(raw_text: bytes) -&gt; bytes:
     &#34;&#34;&#34;Replaces escaped control chars within the text with their RTF encoded versions \\&#39;HH.
 
 Args:
@@ -100,12 +100,12 @@ Args:
 Returns:
     A string with escaped control chars
     &#34;&#34;&#34;
-    cleaned = raw_text.replace(&#39;\\\\&#39;, &#34;\\&#39;5c&#34;)
-    cleaned = cleaned.replace(&#39;\\{&#39;, &#34;\\&#39;7b&#34;)
-    cleaned = cleaned.replace(&#39;\\}&#39;, &#34;\\&#39;7d&#34;)
+    cleaned = raw_text.replace(b&#39;\\\\&#39;, b&#34;\\&#39;5c&#34;)
+    cleaned = cleaned.replace(b&#39;\\{&#39;, b&#34;\\&#39;7b&#34;)
+    cleaned = cleaned.replace(b&#39;\\}&#39;, b&#34;\\&#39;7d&#34;)
     return cleaned
 
-def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword) -&gt; bool:
+def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword: bytes) -&gt; bool:
     &#34;&#34;&#34;Checks if a Token is a codeword with a numeric argument.
 
 Returns:
@@ -113,6 +113,7 @@ Returns:
 &#34;&#34;&#34;
     try:
         val = token.value.strip()
+        # print(val, codeword)
         if (val.startswith(codeword) and
             val[len(codeword):].isdigit()):
             return True
@@ -156,6 +157,13 @@ def log_transformations(data):
     if logger.level == logging.DEBUG:
         logger.debug(data)
 
+def log_text_extraction(data):
+    &#34;&#34;&#34;Log additional text decoding/encoding logging only if RTFDE.text_extraction set to debug.
+    &#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.text_extraction&#34;)
+    if logger.level == logging.DEBUG:
+        logger.debug(data)
+
 def log_htmlrtf_stripping(data: Token):
     &#34;&#34;&#34;Log HTMLRTF Stripping logging only if RTFDE.HTMLRTF_Stripping_logger set to debug.
 
@@ -174,7 +182,7 @@ Raises:
                                   end_pos = data.end_pos)
         logger.debug(log_msg)
 
-def log_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+def log_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
     &#34;&#34;&#34;Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
 
 Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
@@ -186,7 +194,7 @@ Args:
 &#34;&#34;&#34;
     log.debug(get_string_diff(original, revised, sep))
 
-def get_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+def get_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
     &#34;&#34;&#34;Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
 
 Args:
@@ -198,13 +206,13 @@ Returns:
     A string object representing the diff of the two strings provided.
 &#34;&#34;&#34;
     if sep is None:
-        orig_split = original.splitlines(keepends=True)
-        revised_split = revised.splitlines(keepends=True)
+        orig_split = original.decode().splitlines(keepends=True)
+        revised_split = revised.decode().splitlines(keepends=True)
     else:
-        original = original.replace(&#39;\n&#39;,&#39;&#39;)
-        revised = revised.replace(&#39;\n&#39;,&#39;&#39;)
-        orig_split = [i for i in re.split(sep, original) if i != &#39;&#39;]
-        revised_split = [i for i in re.split(sep, revised) if i != &#39;&#39;]
+        original = original.replace(b&#39;\n&#39;,b&#39;&#39;)
+        revised = revised.replace(b&#39;\n&#39;,b&#39;&#39;)
+        orig_split = [i.decode() for i in re.split(sep, original) if i != b&#39;&#39;]
+        revised_split = [i.decode() for i in re.split(sep, revised) if i != b&#39;&#39;]
     return &#34;\n&#34;.join(list(difflib.context_diff(orig_split,
                                                revised_split)))
 
@@ -259,7 +267,62 @@ Args:
         elif isinstance(child, Token):
             yield child.value
         else:
-            yield child</code></pre>
+            yield child
+
+def make_token_replacement(ttype, value, example):
+    if isinstance(example, Token):
+        fake_tok = Token(ttype,
+                        value,
+                        start_pos=example.start_pos,
+                        end_pos=example.end_pos,
+                        line=example.line,
+                        end_line=example.end_line,
+                        column=example.column,
+                        end_column=example.end_column)
+    elif isinstance(example, Tree):
+        fake_tok = Token(ttype,
+                         value,
+                         start_pos=example.meta.start_pos,
+                         end_pos=example.meta.end_pos,
+                         line=example.meta.line,
+                         end_line=example.meta.end_line,
+                         column=example.meta.column,
+                         end_column=example.meta.end_column)
+
+    return fake_tok
+
+
+def embed():
+    import os
+    import readline
+    import rlcompleter
+    import code
+    import inspect
+    import traceback
+
+    history = os.path.join(os.path.expanduser(&#39;~&#39;), &#39;.python_history&#39;)
+    if os.path.isfile(history):
+        readline.read_history_file(history)
+
+    frame = inspect.currentframe().f_back
+    namespace = frame.f_locals.copy()
+    namespace.update(frame.f_globals)
+
+    readline.set_completer(rlcompleter.Completer(namespace).complete)
+    readline.parse_and_bind(&#34;tab: complete&#34;)
+
+    file = frame.f_code.co_filename
+    line = frame.f_lineno
+    function = frame.f_code.co_name
+
+    stack = &#39;&#39;.join(traceback.format_stack()[:-1])
+    print(stack)
+    banner = f&#34; [ {os.path.basename(file)}:{line} in {function}() ]&#34;
+    banner += &#34;\n Entering interactive mode (Ctrl-D to exit) ...&#34;
+    try:
+        code.interact(banner=banner, local=namespace)
+    finally:
+        readline.write_history_file(history)</code></pre>
 </details>
 </section>
 <section>
@@ -269,8 +332,50 @@ Args:
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
+<dt id="RTFDE.utils.embed"><code class="name flex">
+<span>def <span class="ident">embed</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def embed():
+    import os
+    import readline
+    import rlcompleter
+    import code
+    import inspect
+    import traceback
+
+    history = os.path.join(os.path.expanduser(&#39;~&#39;), &#39;.python_history&#39;)
+    if os.path.isfile(history):
+        readline.read_history_file(history)
+
+    frame = inspect.currentframe().f_back
+    namespace = frame.f_locals.copy()
+    namespace.update(frame.f_globals)
+
+    readline.set_completer(rlcompleter.Completer(namespace).complete)
+    readline.parse_and_bind(&#34;tab: complete&#34;)
+
+    file = frame.f_code.co_filename
+    line = frame.f_lineno
+    function = frame.f_code.co_name
+
+    stack = &#39;&#39;.join(traceback.format_stack()[:-1])
+    print(stack)
+    banner = f&#34; [ {os.path.basename(file)}:{line} in {function}() ]&#34;
+    banner += &#34;\n Entering interactive mode (Ctrl-D to exit) ...&#34;
+    try:
+        code.interact(banner=banner, local=namespace)
+    finally:
+        readline.write_history_file(history)</code></pre>
+</details>
+</dd>
 <dt id="RTFDE.utils.encode_escaped_control_chars"><code class="name flex">
-<span>def <span class="ident">encode_escaped_control_chars</span></span>(<span>raw_text: str) ‑> str</span>
+<span>def <span class="ident">encode_escaped_control_chars</span></span>(<span>raw_text: bytes) ‑> bytes</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Replaces escaped control chars within the text with their RTF encoded versions 'HH.</p>
@@ -285,7 +390,7 @@ Args:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def encode_escaped_control_chars(raw_text: str) -&gt; str:
+<pre><code class="python">def encode_escaped_control_chars(raw_text: bytes) -&gt; bytes:
     &#34;&#34;&#34;Replaces escaped control chars within the text with their RTF encoded versions \\&#39;HH.
 
 Args:
@@ -294,9 +399,9 @@ Args:
 Returns:
     A string with escaped control chars
     &#34;&#34;&#34;
-    cleaned = raw_text.replace(&#39;\\\\&#39;, &#34;\\&#39;5c&#34;)
-    cleaned = cleaned.replace(&#39;\\{&#39;, &#34;\\&#39;7b&#34;)
-    cleaned = cleaned.replace(&#39;\\}&#39;, &#34;\\&#39;7d&#34;)
+    cleaned = raw_text.replace(b&#39;\\\\&#39;, b&#34;\\&#39;5c&#34;)
+    cleaned = cleaned.replace(b&#39;\\{&#39;, b&#34;\\&#39;7b&#34;)
+    cleaned = cleaned.replace(b&#39;\\}&#39;, b&#34;\\&#39;7d&#34;)
     return cleaned</code></pre>
 </details>
 </dd>
@@ -395,7 +500,7 @@ Returns:
 </details>
 </dd>
 <dt id="RTFDE.utils.get_string_diff"><code class="name flex">
-<span>def <span class="ident">get_string_diff</span></span>(<span>original: str, revised: str, sep: Optional[str] = None)</span>
+<span>def <span class="ident">get_string_diff</span></span>(<span>original: bytes, revised: bytes, sep: Optional[bytes] = None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.</p>
@@ -414,7 +519,7 @@ Returns:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+<pre><code class="python">def get_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
     &#34;&#34;&#34;Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
 
 Args:
@@ -426,13 +531,13 @@ Returns:
     A string object representing the diff of the two strings provided.
 &#34;&#34;&#34;
     if sep is None:
-        orig_split = original.splitlines(keepends=True)
-        revised_split = revised.splitlines(keepends=True)
+        orig_split = original.decode().splitlines(keepends=True)
+        revised_split = revised.decode().splitlines(keepends=True)
     else:
-        original = original.replace(&#39;\n&#39;,&#39;&#39;)
-        revised = revised.replace(&#39;\n&#39;,&#39;&#39;)
-        orig_split = [i for i in re.split(sep, original) if i != &#39;&#39;]
-        revised_split = [i for i in re.split(sep, revised) if i != &#39;&#39;]
+        original = original.replace(b&#39;\n&#39;,b&#39;&#39;)
+        revised = revised.replace(b&#39;\n&#39;,b&#39;&#39;)
+        orig_split = [i.decode() for i in re.split(sep, original) if i != b&#39;&#39;]
+        revised_split = [i.decode() for i in re.split(sep, revised) if i != b&#39;&#39;]
     return &#34;\n&#34;.join(list(difflib.context_diff(orig_split,
                                                revised_split)))</code></pre>
 </details>
@@ -485,7 +590,7 @@ Example:
 </details>
 </dd>
 <dt id="RTFDE.utils.is_codeword_with_numeric_arg"><code class="name flex">
-<span>def <span class="ident">is_codeword_with_numeric_arg</span></span>(<span>token: Union[lark.lexer.Token, Any], codeword) ‑> bool</span>
+<span>def <span class="ident">is_codeword_with_numeric_arg</span></span>(<span>token: Union[lark.lexer.Token, Any], codeword: bytes) ‑> bool</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Checks if a Token is a codeword with a numeric argument.</p>
@@ -495,7 +600,7 @@ Example:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword) -&gt; bool:
+<pre><code class="python">def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword: bytes) -&gt; bool:
     &#34;&#34;&#34;Checks if a Token is a codeword with a numeric argument.
 
 Returns:
@@ -503,6 +608,7 @@ Returns:
 &#34;&#34;&#34;
     try:
         val = token.value.strip()
+        # print(val, codeword)
         if (val.startswith(codeword) and
             val[len(codeword):].isdigit()):
             return True
@@ -545,7 +651,7 @@ Raises:
 </details>
 </dd>
 <dt id="RTFDE.utils.log_string_diff"><code class="name flex">
-<span>def <span class="ident">log_string_diff</span></span>(<span>original: str, revised: str, sep: Optional[str] = None)</span>
+<span>def <span class="ident">log_string_diff</span></span>(<span>original: bytes, revised: bytes, sep: Optional[bytes] = None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Log diff of two strings. Defaults to splitting by newlines and keeping the ends.</p>
@@ -563,7 +669,7 @@ Raises:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def log_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+<pre><code class="python">def log_string_diff(original: bytes, revised: bytes, sep: Union[bytes,None] = None):
     &#34;&#34;&#34;Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
 
 Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
@@ -574,6 +680,23 @@ Args:
     sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
 &#34;&#34;&#34;
     log.debug(get_string_diff(original, revised, sep))</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.log_text_extraction"><code class="name flex">
+<span>def <span class="ident">log_text_extraction</span></span>(<span>data)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Log additional text decoding/encoding logging only if RTFDE.text_extraction set to debug.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def log_text_extraction(data):
+    &#34;&#34;&#34;Log additional text decoding/encoding logging only if RTFDE.text_extraction set to debug.
+    &#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.text_extraction&#34;)
+    if logger.level == logging.DEBUG:
+        logger.debug(data)</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.utils.log_transformations"><code class="name flex">
@@ -608,6 +731,38 @@ Args:
     logger = logging.getLogger(&#34;RTFDE.validation_logger&#34;)
     if logger.level == logging.DEBUG:
         logger.debug(data)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.make_token_replacement"><code class="name flex">
+<span>def <span class="ident">make_token_replacement</span></span>(<span>ttype, value, example)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def make_token_replacement(ttype, value, example):
+    if isinstance(example, Token):
+        fake_tok = Token(ttype,
+                        value,
+                        start_pos=example.start_pos,
+                        end_pos=example.end_pos,
+                        line=example.line,
+                        end_line=example.end_line,
+                        column=example.column,
+                        end_column=example.end_column)
+    elif isinstance(example, Tree):
+        fake_tok = Token(ttype,
+                         value,
+                         start_pos=example.meta.start_pos,
+                         end_pos=example.meta.end_pos,
+                         line=example.meta.line,
+                         end_line=example.meta.end_line,
+                         column=example.meta.column,
+                         end_column=example.meta.end_column)
+
+    return fake_tok</code></pre>
 </details>
 </dd>
 <dt id="RTFDE.utils.print_lark_parser_evaluated_grammar"><code class="name flex">
@@ -703,6 +858,7 @@ Args:
 </li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
+<li><code><a title="RTFDE.utils.embed" href="#RTFDE.utils.embed">embed</a></code></li>
 <li><code><a title="RTFDE.utils.encode_escaped_control_chars" href="#RTFDE.utils.encode_escaped_control_chars">encode_escaped_control_chars</a></code></li>
 <li><code><a title="RTFDE.utils.flatten_tree" href="#RTFDE.utils.flatten_tree">flatten_tree</a></code></li>
 <li><code><a title="RTFDE.utils.flatten_tree_to_string_array" href="#RTFDE.utils.flatten_tree_to_string_array">flatten_tree_to_string_array</a></code></li>
@@ -712,8 +868,10 @@ Args:
 <li><code><a title="RTFDE.utils.is_codeword_with_numeric_arg" href="#RTFDE.utils.is_codeword_with_numeric_arg">is_codeword_with_numeric_arg</a></code></li>
 <li><code><a title="RTFDE.utils.log_htmlrtf_stripping" href="#RTFDE.utils.log_htmlrtf_stripping">log_htmlrtf_stripping</a></code></li>
 <li><code><a title="RTFDE.utils.log_string_diff" href="#RTFDE.utils.log_string_diff">log_string_diff</a></code></li>
+<li><code><a title="RTFDE.utils.log_text_extraction" href="#RTFDE.utils.log_text_extraction">log_text_extraction</a></code></li>
 <li><code><a title="RTFDE.utils.log_transformations" href="#RTFDE.utils.log_transformations">log_transformations</a></code></li>
 <li><code><a title="RTFDE.utils.log_validators" href="#RTFDE.utils.log_validators">log_validators</a></code></li>
+<li><code><a title="RTFDE.utils.make_token_replacement" href="#RTFDE.utils.make_token_replacement">make_token_replacement</a></code></li>
 <li><code><a title="RTFDE.utils.print_lark_parser_evaluated_grammar" href="#RTFDE.utils.print_lark_parser_evaluated_grammar">print_lark_parser_evaluated_grammar</a></code></li>
 <li><code><a title="RTFDE.utils.print_to_tmp_file" href="#RTFDE.utils.print_to_tmp_file">print_to_tmp_file</a></code></li>
 </ul>

--- a/docs/RTFDE/utils.html
+++ b/docs/RTFDE/utils.html
@@ -1,0 +1,728 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>RTFDE.utils API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>RTFDE.utils</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of package name, a package description short.
+# Copyright © 2022 seamus tuohy, &lt;code@seamustuohy.com&gt;
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+import difflib
+import sys
+import re
+from typing import Union, AnyStr, Any
+#  from Python 3.9 typing.Generator is deprecated in favour of collections.abc.Generator
+from collections.abc import Generator
+from lark.lexer import Token
+from lark.tree import Tree
+from lark import Lark
+
+
+import logging
+log = logging.getLogger(&#34;RTFDE&#34;)
+
+def get_control_parameter_as_hex_strings(control_parameter: Union[str,int]) -&gt; str:
+    &#34;&#34;&#34;Returns the hex encoded value of a .rtf control parameter.
+
+Args:
+    control_parameter: (int/str) Int or a string which represents an int.
+
+Returns:
+    Zero padded 6 char long hexedecimal string.
+&#34;&#34;&#34;
+    try:
+        return f&#34;{control_parameter:#06x}&#34;
+    except ValueError:
+        # If passed as string convert first
+        control_parameter = int(control_parameter)
+        return f&#34;{control_parameter:#06x}&#34;
+
+def print_to_tmp_file(data: Union[AnyStr,bytes,bytearray], path: str):
+    &#34;&#34;&#34;Prints binary object to a dump file for quick debugging.
+
+Warning: Not for normal use. Only use when debugging.
+
+Args:
+    data (bytes|str): Data to write to path
+    path (str): The file path to write data to
+    &#34;&#34;&#34;
+    # Be able to print binary objects easily
+    if isinstance(data, (bytes, bytearray)) is True:
+        open_as = &#39;wb+&#39;
+    else:
+        open_as = &#39;w+&#39;
+    with open(path, open_as) as fp:
+        original_stdout = sys.stdout
+        sys.stdout = fp
+        print(data)
+        sys.stdout = original_stdout
+
+def encode_escaped_control_chars(raw_text: str) -&gt; str:
+    &#34;&#34;&#34;Replaces escaped control chars within the text with their RTF encoded versions \\&#39;HH.
+
+Args:
+    raw_text (str): string which needs escape characters encoded
+
+Returns:
+    A string with escaped control chars
+    &#34;&#34;&#34;
+    cleaned = raw_text.replace(&#39;\\\\&#39;, &#34;\\&#39;5c&#34;)
+    cleaned = cleaned.replace(&#39;\\{&#39;, &#34;\\&#39;7b&#34;)
+    cleaned = cleaned.replace(&#39;\\}&#39;, &#34;\\&#39;7d&#34;)
+    return cleaned
+
+def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword) -&gt; bool:
+    &#34;&#34;&#34;Checks if a Token is a codeword with a numeric argument.
+
+Returns:
+    True if a Token is a codeword with a numeric argument. False if not.
+&#34;&#34;&#34;
+    try:
+        val = token.value.strip()
+        if (val.startswith(codeword) and
+            val[len(codeword):].isdigit()):
+            return True
+    except AttributeError:
+        return False
+    return False
+
+def print_lark_parser_evaluated_grammar(parser):
+    &#34;&#34;&#34;Prints the final evaluated grammar.
+
+Can be useful for debugging possible errors in grammar evaluation.
+
+Args:
+    parser (Lark obj): Lark object to extract grammar from.
+    &#34;&#34;&#34;
+    if not isinstance(parser, Lark):
+        raise ValueError(&#34;Requires a Lark object.&#34;)
+    eq = &#34;=&#34;*15
+    eq = &#34; &#34; + eq + &#34; &#34;
+    print(eq + &#34;RULES&#34; + eq + &#34;\n&#34;)
+    for i in parser.rules:
+        print(&#34;    &#34; + i)
+    print(eq + &#34;TERMINALS&#34; + eq + &#34;\n&#34;)
+    for i in parser.terminals:
+        print(&#34;    &#34; + i)
+    print(eq + &#34;IGNORED TOKENS&#34; + eq + &#34;\n&#34;)
+    for i in parser.ignore_tokens:
+        print(&#34;    &#34; + i)
+
+def log_validators(data):
+    &#34;&#34;&#34;Log validator logging only if RTFDE.validation_logger set to debug.
+    &#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.validation_logger&#34;)
+    if logger.level == logging.DEBUG:
+        logger.debug(data)
+
+def log_transformations(data):
+    &#34;&#34;&#34;Log transform logging only if RTFDE.transform_logger set to debug.
+    &#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.transform_logger&#34;)
+    if logger.level == logging.DEBUG:
+        logger.debug(data)
+
+def log_htmlrtf_stripping(data: Token):
+    &#34;&#34;&#34;Log HTMLRTF Stripping logging only if RTFDE.HTMLRTF_Stripping_logger set to debug.
+
+Raises:
+    AttributeError: Will occur if you pass this something that is not a token.
+&#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.HTMLRTF_Stripping_logger&#34;)
+    if logger.level == logging.DEBUG:
+        if not isinstance(data, Token):
+            raise AttributeError(&#34;HTMLRTF Stripping logger only logs Tokens&#34;)
+        tok_desc = &#34;HTMLRTF Removed: {value}, {line}, {end_line}, {start_pos}, {end_pos}&#34;
+        log_msg = tok_desc.format(value=data.value,
+                                  line=data.line,
+                                  end_line=data.end_line,
+                                  start_pos=data.start_pos,
+                                  end_pos = data.end_pos)
+        logger.debug(log_msg)
+
+def log_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+    &#34;&#34;&#34;Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
+
+Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
+
+Args:
+    original: The original string
+    revised: The changed version of the string
+    sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+&#34;&#34;&#34;
+    log.debug(get_string_diff(original, revised, sep))
+
+def get_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+    &#34;&#34;&#34;Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
+
+Args:
+    original: The original string
+    revised: The changed version of the string
+    sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+
+Returns:
+    A string object representing the diff of the two strings provided.
+&#34;&#34;&#34;
+    if sep is None:
+        orig_split = original.splitlines(keepends=True)
+        revised_split = revised.splitlines(keepends=True)
+    else:
+        original = original.replace(&#39;\n&#39;,&#39;&#39;)
+        revised = revised.replace(&#39;\n&#39;,&#39;&#39;)
+        orig_split = [i for i in re.split(sep, original) if i != &#39;&#39;]
+        revised_split = [i for i in re.split(sep, revised) if i != &#39;&#39;]
+    return &#34;\n&#34;.join(list(difflib.context_diff(orig_split,
+                                               revised_split)))
+
+def get_tree_diff(original: Tree, revised: Tree):
+    &#34;&#34;&#34;Get the diff of two trees.
+
+Args:
+    original (lark Tree): A lark tree before transformation
+    revised (lark Tree): A lark tree after transformation
+
+Returns:
+    A string object representing the diff of the two Trees provided.
+
+Example:
+    rtf_obj = DeEncapsulator(raw_rtf)
+    rtf_obj.deencapsulate()
+    transformed_tree = SomeTransformer.transform(rtf_obj.full_tree)
+    get_tree_diff(rtf_obj.full_tree, transformed_tree)
+
+    &#34;&#34;&#34;
+    log = logging.getLogger(&#34;RTFDE&#34;)
+    flat_original  = list(flatten_tree(original))
+    flat_revised  = list(flatten_tree(revised))
+    return &#34;\n&#34;.join(list(difflib.context_diff(flat_original,
+                                               flat_revised)))
+def flatten_tree(tree: Tree) -&gt; Generator:
+    &#34;&#34;&#34;Flatten a lark Tree into a list of repr&#39;s of tree objects.
+
+Args:
+    tree (lark Tree): A lark tree
+&#34;&#34;&#34;
+    yield f&#34;Tree(&#39;{tree.data}&#39;)&#34;
+    for child in tree.children:
+        if isinstance(child, Token):
+            yield repr(child)
+        elif isinstance(child, Tree):
+            for i in flatten_tree(child):
+                yield i
+        else:
+            yield repr(child)
+
+def flatten_tree_to_string_array(tree: Tree) -&gt; Generator:
+    &#34;&#34;&#34;Flatten a lark Tree into a list of repr&#39;s of tree objects.
+
+Args:
+    tree (lark Tree): A lark tree
+&#34;&#34;&#34;
+    for child in tree.children:
+        if isinstance(child, Tree):
+            for i in flatten_tree_to_string_array(child):
+                yield i
+        elif isinstance(child, Token):
+            yield child.value
+        else:
+            yield child</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="RTFDE.utils.encode_escaped_control_chars"><code class="name flex">
+<span>def <span class="ident">encode_escaped_control_chars</span></span>(<span>raw_text: str) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Replaces escaped control chars within the text with their RTF encoded versions 'HH.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>raw_text</code></strong> :&ensp;<code>str</code></dt>
+<dd>string which needs escape characters encoded</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A string with escaped control chars</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def encode_escaped_control_chars(raw_text: str) -&gt; str:
+    &#34;&#34;&#34;Replaces escaped control chars within the text with their RTF encoded versions \\&#39;HH.
+
+Args:
+    raw_text (str): string which needs escape characters encoded
+
+Returns:
+    A string with escaped control chars
+    &#34;&#34;&#34;
+    cleaned = raw_text.replace(&#39;\\\\&#39;, &#34;\\&#39;5c&#34;)
+    cleaned = cleaned.replace(&#39;\\{&#39;, &#34;\\&#39;7b&#34;)
+    cleaned = cleaned.replace(&#39;\\}&#39;, &#34;\\&#39;7d&#34;)
+    return cleaned</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.flatten_tree"><code class="name flex">
+<span>def <span class="ident">flatten_tree</span></span>(<span>tree: lark.tree.Tree) ‑> collections.abc.Generator</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Flatten a lark Tree into a list of repr's of tree objects.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>tree</code></strong> :&ensp;<code>lark Tree</code></dt>
+<dd>A lark tree</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def flatten_tree(tree: Tree) -&gt; Generator:
+    &#34;&#34;&#34;Flatten a lark Tree into a list of repr&#39;s of tree objects.
+
+Args:
+    tree (lark Tree): A lark tree
+&#34;&#34;&#34;
+    yield f&#34;Tree(&#39;{tree.data}&#39;)&#34;
+    for child in tree.children:
+        if isinstance(child, Token):
+            yield repr(child)
+        elif isinstance(child, Tree):
+            for i in flatten_tree(child):
+                yield i
+        else:
+            yield repr(child)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.flatten_tree_to_string_array"><code class="name flex">
+<span>def <span class="ident">flatten_tree_to_string_array</span></span>(<span>tree: lark.tree.Tree) ‑> collections.abc.Generator</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Flatten a lark Tree into a list of repr's of tree objects.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>tree</code></strong> :&ensp;<code>lark Tree</code></dt>
+<dd>A lark tree</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def flatten_tree_to_string_array(tree: Tree) -&gt; Generator:
+    &#34;&#34;&#34;Flatten a lark Tree into a list of repr&#39;s of tree objects.
+
+Args:
+    tree (lark Tree): A lark tree
+&#34;&#34;&#34;
+    for child in tree.children:
+        if isinstance(child, Tree):
+            for i in flatten_tree_to_string_array(child):
+                yield i
+        elif isinstance(child, Token):
+            yield child.value
+        else:
+            yield child</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.get_control_parameter_as_hex_strings"><code class="name flex">
+<span>def <span class="ident">get_control_parameter_as_hex_strings</span></span>(<span>control_parameter: Union[str, int]) ‑> str</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the hex encoded value of a .rtf control parameter.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>control_parameter</code></strong></dt>
+<dd>(int/str) Int or a string which represents an int.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>Zero padded 6 char long hexedecimal string.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_control_parameter_as_hex_strings(control_parameter: Union[str,int]) -&gt; str:
+    &#34;&#34;&#34;Returns the hex encoded value of a .rtf control parameter.
+
+Args:
+    control_parameter: (int/str) Int or a string which represents an int.
+
+Returns:
+    Zero padded 6 char long hexedecimal string.
+&#34;&#34;&#34;
+    try:
+        return f&#34;{control_parameter:#06x}&#34;
+    except ValueError:
+        # If passed as string convert first
+        control_parameter = int(control_parameter)
+        return f&#34;{control_parameter:#06x}&#34;</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.get_string_diff"><code class="name flex">
+<span>def <span class="ident">get_string_diff</span></span>(<span>original: str, revised: str, sep: Optional[str] = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>original</code></strong></dt>
+<dd>The original string</dd>
+<dt><strong><code>revised</code></strong></dt>
+<dd>The changed version of the string</dd>
+<dt><strong><code>sep</code></strong> :&ensp;<code>string</code></dt>
+<dd>A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A string object representing the diff of the two strings provided.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+    &#34;&#34;&#34;Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
+
+Args:
+    original: The original string
+    revised: The changed version of the string
+    sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+
+Returns:
+    A string object representing the diff of the two strings provided.
+&#34;&#34;&#34;
+    if sep is None:
+        orig_split = original.splitlines(keepends=True)
+        revised_split = revised.splitlines(keepends=True)
+    else:
+        original = original.replace(&#39;\n&#39;,&#39;&#39;)
+        revised = revised.replace(&#39;\n&#39;,&#39;&#39;)
+        orig_split = [i for i in re.split(sep, original) if i != &#39;&#39;]
+        revised_split = [i for i in re.split(sep, revised) if i != &#39;&#39;]
+    return &#34;\n&#34;.join(list(difflib.context_diff(orig_split,
+                                               revised_split)))</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.get_tree_diff"><code class="name flex">
+<span>def <span class="ident">get_tree_diff</span></span>(<span>original: lark.tree.Tree, revised: lark.tree.Tree)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get the diff of two trees.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>original</code></strong> :&ensp;<code>lark Tree</code></dt>
+<dd>A lark tree before transformation</dd>
+<dt><strong><code>revised</code></strong> :&ensp;<code>lark Tree</code></dt>
+<dd>A lark tree after transformation</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A string object representing the diff of the two Trees provided.</p>
+<h2 id="example">Example</h2>
+<p>rtf_obj = DeEncapsulator(raw_rtf)
+rtf_obj.deencapsulate()
+transformed_tree = SomeTransformer.transform(rtf_obj.full_tree)
+get_tree_diff(rtf_obj.full_tree, transformed_tree)</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_tree_diff(original: Tree, revised: Tree):
+    &#34;&#34;&#34;Get the diff of two trees.
+
+Args:
+    original (lark Tree): A lark tree before transformation
+    revised (lark Tree): A lark tree after transformation
+
+Returns:
+    A string object representing the diff of the two Trees provided.
+
+Example:
+    rtf_obj = DeEncapsulator(raw_rtf)
+    rtf_obj.deencapsulate()
+    transformed_tree = SomeTransformer.transform(rtf_obj.full_tree)
+    get_tree_diff(rtf_obj.full_tree, transformed_tree)
+
+    &#34;&#34;&#34;
+    log = logging.getLogger(&#34;RTFDE&#34;)
+    flat_original  = list(flatten_tree(original))
+    flat_revised  = list(flatten_tree(revised))
+    return &#34;\n&#34;.join(list(difflib.context_diff(flat_original,
+                                               flat_revised)))</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.is_codeword_with_numeric_arg"><code class="name flex">
+<span>def <span class="ident">is_codeword_with_numeric_arg</span></span>(<span>token: Union[lark.lexer.Token, Any], codeword) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks if a Token is a codeword with a numeric argument.</p>
+<h2 id="returns">Returns</h2>
+<p>True if a Token is a codeword with a numeric argument. False if not.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_codeword_with_numeric_arg(token: Union[Token,Any], codeword) -&gt; bool:
+    &#34;&#34;&#34;Checks if a Token is a codeword with a numeric argument.
+
+Returns:
+    True if a Token is a codeword with a numeric argument. False if not.
+&#34;&#34;&#34;
+    try:
+        val = token.value.strip()
+        if (val.startswith(codeword) and
+            val[len(codeword):].isdigit()):
+            return True
+    except AttributeError:
+        return False
+    return False</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.log_htmlrtf_stripping"><code class="name flex">
+<span>def <span class="ident">log_htmlrtf_stripping</span></span>(<span>data: lark.lexer.Token)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Log HTMLRTF Stripping logging only if RTFDE.HTMLRTF_Stripping_logger set to debug.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>AttributeError</code></dt>
+<dd>Will occur if you pass this something that is not a token.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def log_htmlrtf_stripping(data: Token):
+    &#34;&#34;&#34;Log HTMLRTF Stripping logging only if RTFDE.HTMLRTF_Stripping_logger set to debug.
+
+Raises:
+    AttributeError: Will occur if you pass this something that is not a token.
+&#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.HTMLRTF_Stripping_logger&#34;)
+    if logger.level == logging.DEBUG:
+        if not isinstance(data, Token):
+            raise AttributeError(&#34;HTMLRTF Stripping logger only logs Tokens&#34;)
+        tok_desc = &#34;HTMLRTF Removed: {value}, {line}, {end_line}, {start_pos}, {end_pos}&#34;
+        log_msg = tok_desc.format(value=data.value,
+                                  line=data.line,
+                                  end_line=data.end_line,
+                                  start_pos=data.start_pos,
+                                  end_pos = data.end_pos)
+        logger.debug(log_msg)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.log_string_diff"><code class="name flex">
+<span>def <span class="ident">log_string_diff</span></span>(<span>original: str, revised: str, sep: Optional[str] = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Log diff of two strings. Defaults to splitting by newlines and keeping the ends.</p>
+<p>Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>original</code></strong></dt>
+<dd>The original string</dd>
+<dt><strong><code>revised</code></strong></dt>
+<dd>The changed version of the string</dd>
+<dt><strong><code>sep</code></strong> :&ensp;<code>string</code></dt>
+<dd>A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def log_string_diff(original: str, revised: str, sep: Union[str,None] = None):
+    &#34;&#34;&#34;Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
+
+Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
+
+Args:
+    original: The original string
+    revised: The changed version of the string
+    sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+&#34;&#34;&#34;
+    log.debug(get_string_diff(original, revised, sep))</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.log_transformations"><code class="name flex">
+<span>def <span class="ident">log_transformations</span></span>(<span>data)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Log transform logging only if RTFDE.transform_logger set to debug.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def log_transformations(data):
+    &#34;&#34;&#34;Log transform logging only if RTFDE.transform_logger set to debug.
+    &#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.transform_logger&#34;)
+    if logger.level == logging.DEBUG:
+        logger.debug(data)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.log_validators"><code class="name flex">
+<span>def <span class="ident">log_validators</span></span>(<span>data)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Log validator logging only if RTFDE.validation_logger set to debug.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def log_validators(data):
+    &#34;&#34;&#34;Log validator logging only if RTFDE.validation_logger set to debug.
+    &#34;&#34;&#34;
+    logger = logging.getLogger(&#34;RTFDE.validation_logger&#34;)
+    if logger.level == logging.DEBUG:
+        logger.debug(data)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.print_lark_parser_evaluated_grammar"><code class="name flex">
+<span>def <span class="ident">print_lark_parser_evaluated_grammar</span></span>(<span>parser)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Prints the final evaluated grammar.</p>
+<p>Can be useful for debugging possible errors in grammar evaluation.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>parser</code></strong> :&ensp;<code>Lark obj</code></dt>
+<dd>Lark object to extract grammar from.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def print_lark_parser_evaluated_grammar(parser):
+    &#34;&#34;&#34;Prints the final evaluated grammar.
+
+Can be useful for debugging possible errors in grammar evaluation.
+
+Args:
+    parser (Lark obj): Lark object to extract grammar from.
+    &#34;&#34;&#34;
+    if not isinstance(parser, Lark):
+        raise ValueError(&#34;Requires a Lark object.&#34;)
+    eq = &#34;=&#34;*15
+    eq = &#34; &#34; + eq + &#34; &#34;
+    print(eq + &#34;RULES&#34; + eq + &#34;\n&#34;)
+    for i in parser.rules:
+        print(&#34;    &#34; + i)
+    print(eq + &#34;TERMINALS&#34; + eq + &#34;\n&#34;)
+    for i in parser.terminals:
+        print(&#34;    &#34; + i)
+    print(eq + &#34;IGNORED TOKENS&#34; + eq + &#34;\n&#34;)
+    for i in parser.ignore_tokens:
+        print(&#34;    &#34; + i)</code></pre>
+</details>
+</dd>
+<dt id="RTFDE.utils.print_to_tmp_file"><code class="name flex">
+<span>def <span class="ident">print_to_tmp_file</span></span>(<span>data: Union[~AnyStr, bytes, bytearray], path: str)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Prints binary object to a dump file for quick debugging.</p>
+<p>Warning: Not for normal use. Only use when debugging.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt>data (bytes|str): Data to write to path</dt>
+<dt><strong><code>path</code></strong> :&ensp;<code>str</code></dt>
+<dd>The file path to write data to</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def print_to_tmp_file(data: Union[AnyStr,bytes,bytearray], path: str):
+    &#34;&#34;&#34;Prints binary object to a dump file for quick debugging.
+
+Warning: Not for normal use. Only use when debugging.
+
+Args:
+    data (bytes|str): Data to write to path
+    path (str): The file path to write data to
+    &#34;&#34;&#34;
+    # Be able to print binary objects easily
+    if isinstance(data, (bytes, bytearray)) is True:
+        open_as = &#39;wb+&#39;
+    else:
+        open_as = &#39;w+&#39;
+    with open(path, open_as) as fp:
+        original_stdout = sys.stdout
+        sys.stdout = fp
+        print(data)
+        sys.stdout = original_stdout</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="RTFDE" href="index.html">RTFDE</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="RTFDE.utils.encode_escaped_control_chars" href="#RTFDE.utils.encode_escaped_control_chars">encode_escaped_control_chars</a></code></li>
+<li><code><a title="RTFDE.utils.flatten_tree" href="#RTFDE.utils.flatten_tree">flatten_tree</a></code></li>
+<li><code><a title="RTFDE.utils.flatten_tree_to_string_array" href="#RTFDE.utils.flatten_tree_to_string_array">flatten_tree_to_string_array</a></code></li>
+<li><code><a title="RTFDE.utils.get_control_parameter_as_hex_strings" href="#RTFDE.utils.get_control_parameter_as_hex_strings">get_control_parameter_as_hex_strings</a></code></li>
+<li><code><a title="RTFDE.utils.get_string_diff" href="#RTFDE.utils.get_string_diff">get_string_diff</a></code></li>
+<li><code><a title="RTFDE.utils.get_tree_diff" href="#RTFDE.utils.get_tree_diff">get_tree_diff</a></code></li>
+<li><code><a title="RTFDE.utils.is_codeword_with_numeric_arg" href="#RTFDE.utils.is_codeword_with_numeric_arg">is_codeword_with_numeric_arg</a></code></li>
+<li><code><a title="RTFDE.utils.log_htmlrtf_stripping" href="#RTFDE.utils.log_htmlrtf_stripping">log_htmlrtf_stripping</a></code></li>
+<li><code><a title="RTFDE.utils.log_string_diff" href="#RTFDE.utils.log_string_diff">log_string_diff</a></code></li>
+<li><code><a title="RTFDE.utils.log_transformations" href="#RTFDE.utils.log_transformations">log_transformations</a></code></li>
+<li><code><a title="RTFDE.utils.log_validators" href="#RTFDE.utils.log_validators">log_validators</a></code></li>
+<li><code><a title="RTFDE.utils.print_lark_parser_evaluated_grammar" href="#RTFDE.utils.print_lark_parser_evaluated_grammar">print_lark_parser_evaluated_grammar</a></code></li>
+<li><code><a title="RTFDE.utils.print_to_tmp_file" href="#RTFDE.utils.print_to_tmp_file">print_to_tmp_file</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/RTFDE/utils.md
+++ b/docs/RTFDE/utils.md
@@ -1,0 +1,120 @@
+Module RTFDE.utils
+==================
+
+Functions
+---------
+
+    
+`encode_escaped_control_chars(raw_text: str) ‑> str`
+:   Replaces escaped control chars within the text with their RTF encoded versions \'HH.
+    
+    Args:
+        raw_text (str): string which needs escape characters encoded
+    
+    Returns:
+        A string with escaped control chars
+
+    
+`flatten_tree(tree: lark.tree.Tree) ‑> collections.abc.Generator`
+:   Flatten a lark Tree into a list of repr's of tree objects.
+    
+    Args:
+        tree (lark Tree): A lark tree
+
+    
+`flatten_tree_to_string_array(tree: lark.tree.Tree) ‑> collections.abc.Generator`
+:   Flatten a lark Tree into a list of repr's of tree objects.
+    
+    Args:
+        tree (lark Tree): A lark tree
+
+    
+`get_control_parameter_as_hex_strings(control_parameter: Union[str, int]) ‑> str`
+:   Returns the hex encoded value of a .rtf control parameter.
+    
+    Args:
+        control_parameter: (int/str) Int or a string which represents an int.
+    
+    Returns:
+        Zero padded 6 char long hexedecimal string.
+
+    
+`get_string_diff(original: str, revised: str, sep: Optional[str] = None)`
+:   Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
+    
+    Args:
+        original: The original string
+        revised: The changed version of the string
+        sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+    
+    Returns:
+        A string object representing the diff of the two strings provided.
+
+    
+`get_tree_diff(original: lark.tree.Tree, revised: lark.tree.Tree)`
+:   Get the diff of two trees.
+    
+    Args:
+        original (lark Tree): A lark tree before transformation
+        revised (lark Tree): A lark tree after transformation
+    
+    Returns:
+        A string object representing the diff of the two Trees provided.
+    
+    Example:
+        rtf_obj = DeEncapsulator(raw_rtf)
+        rtf_obj.deencapsulate()
+        transformed_tree = SomeTransformer.transform(rtf_obj.full_tree)
+        get_tree_diff(rtf_obj.full_tree, transformed_tree)
+
+    
+`is_codeword_with_numeric_arg(token: Union[lark.lexer.Token, Any], codeword) ‑> bool`
+:   Checks if a Token is a codeword with a numeric argument.
+    
+    Returns:
+        True if a Token is a codeword with a numeric argument. False if not.
+
+    
+`log_htmlrtf_stripping(data: lark.lexer.Token)`
+:   Log HTMLRTF Stripping logging only if RTFDE.HTMLRTF_Stripping_logger set to debug.
+    
+    Raises:
+        AttributeError: Will occur if you pass this something that is not a token.
+
+    
+`log_string_diff(original: str, revised: str, sep: Optional[str] = None)`
+:   Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
+    
+    Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
+    
+    Args:
+        original: The original string
+        revised: The changed version of the string
+        sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
+
+    
+`log_transformations(data)`
+:   Log transform logging only if RTFDE.transform_logger set to debug.
+
+    
+`log_validators(data)`
+:   Log validator logging only if RTFDE.validation_logger set to debug.
+
+    
+`print_lark_parser_evaluated_grammar(parser)`
+:   Prints the final evaluated grammar.
+    
+    Can be useful for debugging possible errors in grammar evaluation.
+    
+    Args:
+        parser (Lark obj): Lark object to extract grammar from.
+
+    
+`print_to_tmp_file(data: Union[~AnyStr, bytes, bytearray], path: str)`
+:   Prints binary object to a dump file for quick debugging.
+    
+    Warning: Not for normal use. Only use when debugging.
+    
+    Args:
+        data (bytes|str): Data to write to path
+        path (str): The file path to write data to

--- a/docs/RTFDE/utils.md
+++ b/docs/RTFDE/utils.md
@@ -5,7 +5,11 @@ Functions
 ---------
 
     
-`encode_escaped_control_chars(raw_text: str) ‑> str`
+`embed()`
+:   
+
+    
+`encode_escaped_control_chars(raw_text: bytes) ‑> bytes`
 :   Replaces escaped control chars within the text with their RTF encoded versions \'HH.
     
     Args:
@@ -39,7 +43,7 @@ Functions
         Zero padded 6 char long hexedecimal string.
 
     
-`get_string_diff(original: str, revised: str, sep: Optional[str] = None)`
+`get_string_diff(original: bytes, revised: bytes, sep: Optional[bytes] = None)`
 :   Get the diff of two strings. Defaults to splitting by newlines and keeping the ends.
     
     Args:
@@ -68,7 +72,7 @@ Functions
         get_tree_diff(rtf_obj.full_tree, transformed_tree)
 
     
-`is_codeword_with_numeric_arg(token: Union[lark.lexer.Token, Any], codeword) ‑> bool`
+`is_codeword_with_numeric_arg(token: Union[lark.lexer.Token, Any], codeword: bytes) ‑> bool`
 :   Checks if a Token is a codeword with a numeric argument.
     
     Returns:
@@ -82,7 +86,7 @@ Functions
         AttributeError: Will occur if you pass this something that is not a token.
 
     
-`log_string_diff(original: str, revised: str, sep: Optional[str] = None)`
+`log_string_diff(original: bytes, revised: bytes, sep: Optional[bytes] = None)`
 :   Log diff of two strings. Defaults to splitting by newlines and keeping the ends.
     
     Logs the result in the main RTFDE logger as a debug log. Warning: Only use when debugging as this is too verbose to be used in regular logging.
@@ -93,12 +97,20 @@ Functions
         sep (string): A pattern to split the string by. Uses re.split under the hood. NOTE: Deletes all empty strings before diffing to make the diff more concise.
 
     
+`log_text_extraction(data)`
+:   Log additional text decoding/encoding logging only if RTFDE.text_extraction set to debug.
+
+    
 `log_transformations(data)`
 :   Log transform logging only if RTFDE.transform_logger set to debug.
 
     
 `log_validators(data)`
 :   Log validator logging only if RTFDE.validation_logger set to debug.
+
+    
+`make_token_replacement(ttype, value, example)`
+:   
 
     
 `print_lark_parser_evaluated_grammar(parser)`

--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# This file is part of RTFDE
+# Copyright © seamus tuohy, <code@seamustuohy.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+# Setup
+
+#Bash should terminate in case a command or chain of command finishes with a non-zero exit status.
+#Terminate the script in case an uninitialized variable is accessed.
+#See: https://github.com/azet/community_bash_style_guide#style-conventions
+set -e
+set -u
+
+# TODO remove DEBUGGING
+set -x
+
+# Read Only variables
+
+# readonly PROG_DIR=$(readlink -m $(dirname $0))
+# readonly PROGNAME="$( cd "$( dirname "BASH_SOURCE[0]" )" && pwd )"
+
+
+
+main() {
+    pdoc --force --output-dir docs RTFDE
+    pdoc --force --html --output-dir docs RTFDE
+}
+
+
+cleanup() {
+    # put cleanup needs here
+    exit 0
+}
+
+trap 'cleanup' EXIT
+
+
+main

--- a/scripts/prep_private_rtf_test_folder.sh
+++ b/scripts/prep_private_rtf_test_folder.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# This file is part of RTFDE.
+# Copyright © Symbol’s function definition is void: end-of-file) seamus tuohy, <code@seamustuohy.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+# =============
+# INSTRUCTIONS
+# =============
+
+# Run this script to extract .rtf msg bodies from .msg files. Can be run in multiple ways.
+#
+# 1) extract the .rtf bodies from a folder of .msg files into another folder.
+#> ./prep_private_rtf_test_folder.sh -i /tmp/msg_files/ -o /tmp/extracted_rtf/
+#
+# 2) exract the .rtf body from a single .msg file into a folder
+#> ./prep_private_rtf_test_folder.sh -i /tmp/msg_files/email.msg -o /tmp/extracted_rtf/
+#
+# 2) exract the .rtf body from a single .msg file to a specific filename
+#> ./prep_private_rtf_test_folder.sh -i /tmp/msg_files/email.msg -o /tmp/extracted_rtf/extracted_msg.rtf
+#
+
+# Setup
+#Bash should terminate in case a command or chain of command finishes with a non-zero exit status.
+#Terminate the script in case an uninitialized variable is accessed.
+#See: https://github.com/azet/community_bash_style_guide#style-conventions
+set -e
+set -u
+
+readonly PROG_DIR=$(readlink -m $(dirname $0))
+
+while getopts "i:o:" option; do
+    case "${option}" in
+        i)  INPATH="${OPTARG}"
+            ;;
+        o)  OUTPATH="${OPTARG}"
+            ;;
+    esac
+done
+
+main() {
+    if [[ -d "${INPATH}" ]] && [[ -d "${OUTPATH}" ]];
+    then
+        convert_folder
+    else
+        convert_file
+    fi
+}
+
+convert_folder() {
+    echo "Extracting RTF from a folder full of .msg files"
+    for i in "${INPATH}"/*.msg; do
+        python3 "${PROG_DIR}/extract_rtf_from_msg.py" -r \
+                -f "${i}" \
+                -o "${OUTPATH}/$(basename ${i/%msg/rtf}).rtf"
+    done
+}
+
+convert_file() {
+    echo "Extracting RTF from a single .msg file"
+    if [[ -d "${OUTPATH}" ]];
+    then
+        extract_location="${OUTPATH}/${INPATH/%msg/rtf}"
+    else
+        extract_location="${OUTPATH/%msg/rtf}"
+    fi
+    python3 "${PROG_DIR}/extract_rtf_from_msg.py" -r \
+            -f "${INPATH}" \
+            -o "${extract_location}"
+}
+
+main

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# This file is part of RTFDE.
+# Copyright © 2022 seamus tuohy, <code@seamustuohy.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+# Setup
+
+#Bash should terminate in case a command or chain of command finishes with a non-zero exit status.
+#Terminate the script in case an uninitialized variable is accessed.
+#See: https://github.com/azet/community_bash_style_guide#style-conventions
+set -e
+set -u
+# set -x
+
+MYPY="false"
+COVERAGE="false"
+DEBUG="false"
+while getopts "mcd" option; do
+    case "${option}" in
+        m)  MYPY="true"
+            ;;
+        c)  COVERAGE="true"
+            ;;
+        d)  DEBUG="true"
+            ;;
+    esac
+done
+
+main() {
+    if [[ "$COVERAGE" == "true" ]]; then
+        coverage run -m unittest discover -v
+        coverage report -m
+    elif [[ "$DEBUG" == "true" ]]; then
+        python3 -m unittest discover -v --locals
+    else
+        python3 -m unittest discover -v
+    fi
+
+    if [[ "$MYPY" == "true" ]]; then
+        mypy --ignore-missing-imports RTFDE/utils.py
+    fi
+}
+
+cleanup() {
+    # put cleanup needs here
+    exit 0
+}
+trap 'cleanup' EXIT
+
+main

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="RTFDE",
-    version="0.0.2",
+    version="0.1.0",
     author="seamus tuohy",
     author_email="code@seamustuohy.com",
     description="A library for extracting HTML content from RTF encapsulated HTML as commonly found in the exchange MSG email format.",
@@ -23,7 +23,11 @@ setuptools.setup(
         "Topic :: Communications :: Email :: Filters"
     ],
     python_requires='>=3.6',
-    install_requires=['lark-parser>=0.11', 'oletools>=0.56'],
+    install_requires=['lark==1.1.5',
+                      'oletools>=0.56'],
     extras_require={'msg_parse': ['extract_msg>=0.27'],
-                    'dev': ['lxml>=4.6']}
+                    'dev': ['lxml>=4.6',
+                            'mypy>=1.1.1',
+                            'pdoc3>=0.10.0',
+                            'coverage>=7.2.2']}
 )

--- a/tests/deencapsulate/test_de_encapsulate.py
+++ b/tests/deencapsulate/test_de_encapsulate.py
@@ -2,49 +2,182 @@
 """
 
 import unittest
+import secrets
 import quopri # Decode MIME quoted-printable data
-from os.path import join
+from os.path import join, abspath, isfile
+from os import walk
+from os import environ
 from lxml.html.diff import InsensitiveSequenceMatcher, tokenize
 from RTFDE.deencapsulate import DeEncapsulator
+from RTFDE.utils import encode_escaped_control_chars
 
+from lark.exceptions import UnexpectedToken
 ## Directory with test data, independent of current working directory
 from tests.test_utils import DATA_BASE_DIR
 
-class TestHtmlCleanDeEncapsulate(unittest.TestCase):
-    """ Test minimal deviation of original and de-encapsulated HTML content.
+from html.parser import HTMLParser
 
-    After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.
+class ExtractHTMLText(HTMLParser):
+    text = ""
+
+    def handle_data(self, data):
+        self.text += data
+        # Remove to ignore newline differences
+        # self.text = self.text.replace("\n"," ")
+        # Remove to ignore whitespace differences
+        # self.text = ' '.join(self.text.split())
+
+class TestPrivateMsgTestCases(unittest.TestCase):
+    """Test against a private folder full of RTF files exported from .msg files.
+
+    This test will run against whatever path is set in the RTFDE_PRIVATE_MSG_FOLDER environment variable. If you do not set this environment variable this test will look for .rtf files in the `tests/test_data/personal_rtf_test_files` folder. If it finds none there it will exit without any error.
+
+    > export RTFDE_PRIVATE_MSG_FOLDER="/path/to/folder/with/messages/"
+    > python3 -m unittest discover -v --locals
+
+    If you want to run tests that check the contents of the original HTML file against the encapsulated version you can use the RTFDE_PRIVATE_MSG_OUTPUT_FOLDER environment variable. If you do not set this environment variable this test will look for .html files in the `tests/test_data/personal_rtf_test_output_files` folder. If it does not find a file with the same name as the .rtf file that it is testing it will not attempt to compare it to anything. (`file.rtf` needs a corresponding `file.html`).
+
+    > export RTFDE_PRIVATE_MSG_OUTPUT_FOLDER="/path/to/folder/with/html/outputs/"
+    > python3 -m unittest discover -v --locals
+
+    It is important to use the --locals variable for unittest since it will expose the filename where an error occurs alongside the unittest failure. Look for the variable named `FAILING_FILENAME`
+
+    The folder `tests/test_data/personal_rtf_test_files` in the source code repository has been included in the .gitignore to allow developers to safely use it for this purpose.
+
+
+    See code in `scripts/prep_private_rtf_test_folder.sh` for guidance on how to populate a private test folder with RTF files extracted from a folder full of .msg files.
 """
+    def test_private_msg_folder(self):
 
-    def test_u_encoded_html(self):
-        "Tests that de-encapsulation on u encoded encoded HTML works."
-        rtf_path = join(DATA_BASE_DIR, "html", "multiple-encodings.rtf")
-        txt_path = join(DATA_BASE_DIR, "html", "multiple-encodings.txt")
-        with open(txt_path, 'r') as fp:
-            raw_text = fp.read()
-            original_text = raw_text
-        with open(rtf_path, 'r') as fp:
-            raw_rtf = fp.read()
-            rtf_obj = DeEncapsulator(raw_rtf)
-            rtf_obj.deencapsulate()
-            output_text = rtf_obj.html
-        self.compare_html(original_text, output_text)
+        try:
+            folder_path = environ["RTFDE_PRIVATE_MSG_FOLDER"]
+        except KeyError:
+            folder_path = join(DATA_BASE_DIR, "personal_rtf_test_files")
+        try:
+            output_path = environ["RTFDE_PRIVATE_MSG_OUTPUT_FOLDER"]
+        except KeyError:
+            output_path = join(DATA_BASE_DIR, "personal_rtf_test_output_files")
+        for (dirpath, dirnames, filenames) in walk(folder_path):
+            for f in filenames:
+                if not f.endswith('.rtf'):
+                    continue
+                else:
+                    raw_rtf = None
+                    abfpath = join(abspath(dirpath), f)
+                    FAILING_FILENAME = f
+                    with open(abfpath, 'rb') as fp:
+                        raw_rtf = fp.read()
+                    rtf_obj = DeEncapsulator(raw_rtf)
+                    try:
+                        rtf_obj.deencapsulate()
+                    except:
+                        self.fail(f"\nFailed to deencapsulate test file: {f}")
+                    # If output result then compare it
+                    html_filename = f.replace('.rtf', '.html')
+                    output_to_compare = join(abspath(output_path),
+                                             html_filename)
+                    if isfile(output_to_compare):
+                        with open(output_to_compare, 'rb') as fp:
+                            html_output = fp.read()
+                        f = ExtractHTMLText()
+                        f.feed(html_output.decode())
+                        html_output_text = f.text
+                        f = ExtractHTMLText()
+                        f.feed(rtf_obj.content.decode())
+                        rtf_output_text = f.text
+                        self.assertEqual(rtf_output_text, html_output_text,
+                                         msg=f"\nFailed comparing personal test file: {html_filename}")
 
-    def compare_html(self, original_text, output_text):
-        """Do a diff of two HTML files.
 
-        Only the text, <img> tags and <a href=***> attributes in the HTML are diffed.
+class TestBinaryData(unittest.TestCase):
+    """Test binary data in RTF files."""
+
+    def test_encoded_bytes_stay_encoded_character(self):
+        """Test that any hexbytes that are not encoded into the RTF stay in the bytes returned without being modified."""
+        raw_rtf = self.get_small_template()
+        bin_data = secrets.token_bytes(1)
+        binary_string = b'This test is one string ' + bin_data + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        self.assertEqual(binary_string,rtf_obj.content)
+
+    def test_bin_data_captured(self):
+        """Tests that binary data is captured.
         """
-        # We start with a diff of the text tokens alone. This allows us to check that the content is the same (weather or not some non-visible structural elements may have been added/removed/modified)
-        old_html_tokens = tokenize(output_text)
-        new_html_tokens = tokenize(original_text)
-        s = InsensitiveSequenceMatcher(a=old_html_tokens, b=new_html_tokens)
-        commands = s.get_opcodes()
-        # If the content is the same it will only have one opcode which states that the objects are equal
-        self.assertEqual(len(commands), 1)
-        self.assertEqual('equal', commands[0][0])
-        # Now we do the real test of equality between the original and the de-encapsulated copy
-        self.assertEqual(original_text, output_text)
+        # Test one bin string
+        raw_rtf = self.get_small_template()
+        bin_data = secrets.token_bytes(20)
+        binary_string = b'This test is one string \\bin20' + bin_data + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+
+        self.assertIsNotNone(rtf_obj.found_binary)
+        self.assertEqual(b'This test is one string that is it.',
+                         rtf_obj.content)
+        # Proove that the stripped data contains the bin_data at the right place.
+        # re_built_string = rtf_obj.content[:]
+        bin_dat = rtf_obj.found_binary[0]
+        self.assertEqual(bin_dat['start_pos'], 216)
+        self.assertEqual(bin_dat['end_pos'], 242)
+        self.assertEqual(bin_dat['bin_start_pos'], 222)
+        self.assertEqual(bin_dat['bytes'], bin_data)
+        self.assertEqual(bin_dat['ctrl_char'][0], b'\\bin')
+        self.assertEqual(bin_dat['ctrl_char'][1], b'20')
+
+        # Make sure spaces after the control char are handled correctly
+        binary_string = b'This test is one string \\bin20 ' + bin_data + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        bin_dat = rtf_obj.found_binary[0]
+        self.assertEqual(bin_dat['bytes'], bin_data)
+        self.assertEqual(bin_dat['ctrl_char'][1], b'20')
+        self.assertEqual(bin_dat['start_pos'], 216)
+        self.assertEqual(bin_dat['end_pos'], 243)
+        self.assertEqual(bin_dat['bin_start_pos'], 223)
+
+        # Test multiple bin string in an rtf file
+        bin_addition = b' and more \\bin20 ' + bin_data
+        bin_addition = bin_addition*5
+        binary_string = b'This test is one string ' + bin_addition + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        self.assertEqual(len(rtf_obj.found_binary), 5)
+
+        # Test bin with negative params are ignored as they are invalid (i.e. \\bin-1234)
+        binary_string = b'This test is one string \\bin-20 ' + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        with self.assertRaises(AttributeError):
+            _test = rtf_obj.found_binary
+
+        # Test bin with no params are ignored as they are invalid
+        binary_string = b'This test is one string \\bin ' + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        with self.assertRaises(AttributeError):
+            _test = rtf_obj.found_binary
+
+        # Test bin with 0 length params only include 0 length bytes (i.e. \\bin0 AND \\bin00000000 )
+        binary_string = b'This test is one string \\bin0 \\bin0000000' + b'that is it.'
+        rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        self.assertEqual(len(rtf_obj.found_binary), 2)
+        for byte_obj in rtf_obj.found_binary:
+            self.assertEqual(byte_obj['bytes'], b'')
+
+
+    def deencapsulate_string(self, raw_rtf):
+        rtf_obj = DeEncapsulator(raw_rtf)
+        rtf_obj.deencapsulate()
+        return rtf_obj
+
+    def get_small_template(self):
+        template_path =  join(DATA_BASE_DIR,
+                              "rtf_parsing",
+                              "small_template.rtf")
+        with open(template_path, 'rb') as fp:
+            raw_rtf = fp.read()
+        return raw_rtf
 
 class TestTextCleanDeEncapsulate(unittest.TestCase):
     """ Test minimal deviation of original and de-encapsulated plain text content.
@@ -54,8 +187,8 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
     def test_japanese_encoded_text(self):
         """ """
         rtf_path = join(DATA_BASE_DIR, "plain_text", "japanese_iso_2022.rtf")
-        original_body = "すみません。\n"
-        with open(rtf_path, 'r') as fp:
+        original_body = "すみません。\n".encode()
+        with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
@@ -68,10 +201,10 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
         This test checks that it is STILL NOT IMPLEMENTED. So, if you fix it this test will expose that and we will need to change the test."""
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         quote_printable_txt_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.txt")
-        with open(quote_printable_txt_path, 'r') as fp:
+        with open(quote_printable_txt_path, 'rb') as fp:
             raw_text = fp.read()
             original_decoded_text = raw_text
-        with open(quote_printable_rtf_path, 'r') as fp:
+        with open(quote_printable_rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
@@ -83,16 +216,241 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         quote_printable_txt_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.txt")
         charset = "cp1251"
-        with open(quote_printable_txt_path, 'r') as fp:
+        with open(quote_printable_txt_path, 'rb') as fp:
             raw_text = fp.read()
             original_decoded_text = quopri.decodestring(raw_text)
             original_decoded_text = original_decoded_text.decode(charset)
-        with open(quote_printable_rtf_path, 'r') as fp:
+        with open(quote_printable_rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
             output_text = rtf_obj.text
-        self.assertEqual(original_decoded_text, output_text)
+        self.assertEqual(original_decoded_text, output_text.decode())
+
+
+
+class TestTextDecoding(unittest.TestCase):
+    """Test text decoding code"""
+
+    def test_theta(self):
+        """ """
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "theta.rtf")
+        original_body = '  ф\n'.encode()
+        with open(rtf_path, 'rb') as fp:
+            raw_rtf = fp.read()
+            rtf_obj = DeEncapsulator(raw_rtf)
+            rtf_obj.deencapsulate()
+            # print(rtf_obj.full_tree)
+            output_text = rtf_obj.text
+        # print(repr(output_text))
+        self.assertEqual(output_text, original_body)
+
+    def test_translated_by(self):
+        """ """
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "translated_by.rtf")
+        original_body = 'ترجمة: سمير المجذوب\n'.encode()
+        with open(rtf_path, 'rb') as fp:
+            raw_rtf = fp.read()
+            rtf_obj = DeEncapsulator(raw_rtf)
+            rtf_obj.deencapsulate()
+            # print(rtf_obj.full_tree)
+            output_text = rtf_obj.text
+        # print(repr(output_text))
+        self.assertEqual(output_text, original_body)
+
+
+    def test_unicode_decoding(self):
+        """ """
+        # print("\n")
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogates.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        self.assertTrue("😊".encode() in rtf_obj.content)
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = 'Ǣ?\nǢ\n😊\n😊??\n😊\n'.encode()
+        # print(correct_repr)
+        # print(rtf_obj.content)
+        self.assertEqual(correct_repr, rtf_obj.content)
+
+        # Test that non unicode chars do not decode
+        from RTFDE.text_extraction import unicode_escape_to_chr
+        surh = b"\\u-10179"
+        surl = b"\\u-8694"
+        bad_encodings = [
+            b"0x000000A9",
+            b"0x00A9",
+            b"0xC2 0xA9",
+            b"&copy;",
+            b"&#xA9;",
+            b"&#169;"
+        ]
+        for bad in bad_encodings:
+            with self.assertRaises(ValueError):
+                unicode_escape_to_chr(bad)
+        surrogate_encodings = [b"\\u-10179", b"\\u-8694"]
+        for sur in surrogate_encodings:
+            self.assertIsInstance(unicode_escape_to_chr(sur), str)
+
+
+    def test_surrogate_in_htmlrtf(self):
+        """Don't show surrogate text within htmlrtf block."""
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_02.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522;'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        print(rtf_obj.content)
+
+    def test_surrogate_without_16bitsigned(self):
+        """Test surrogate which doesn't use a 16 signed integer."""
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_03.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        print(rtf_obj.content)
+        correct_repr =  b'&#128522;'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_04.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522; \xf0\x9f\x93\x9e'
+        self.assertEqual(correct_repr, rtf_obj.content)
+
+    def test_hexencoded(self):
+        original_body = '【 This is a test 】'.encode()
+        raw_rtf = self.get_small_template()
+        # print(raw_rtf)
+        # Add fontdef
+        font_def = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f1\\fswiss\\fcharset128 "PMingLiU";}{\\f2\\fnil\\fcharset1 Arial;}}"""
+        base = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}"""
+        new_rtf = raw_rtf.replace(base, font_def)
+        # print(new_rtf)
+        # Add hec encoded item
+        hex_encoded_text = b"""{\\lang1028 \\f1 \\'81\\'79} This is a test {\\lang1028 \\f1 \\'81\\'7a}"""
+        rep_rtf = new_rtf.replace(b"REPLACE_ME", hex_encoded_text)
+        # print(rep_rtf)
+        rtf_obj = self.deencapsulate_string(rep_rtf)
+        # rtf_obj.deencapsulate()
+        output_text = rtf_obj.content
+        # 'not a valid ANSI representation'
+        self.assertEqual(output_text, original_body)
+        # print(repr(output_text))
+        # print(repr(rtf_obj.content))
+
+    def text_hexencode_as_replacement(self):
+        """test that unicode text with hex encoded replacement works."""
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "unicode_HH_replacement.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522;'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "unicode_HH_replacement_01.rtf")
+        rtf_obj = self.deencapsulate(rtf_path)
+        correct_repr = b'&#128522; \xf0\x9f\x93\x9e'
+        self.assertEqual(correct_repr, rtf_obj.content)
+        print(rtf_obj.content)
+
+#     def test_use_small_template(self):
+#         raw_rtf = self.get_small_template()
+
+#         # rtf_obj = deencapsulate_string(raw_rtf)
+
+#         # REPLACE_ME
+#         small_template = b"""{\\rtf1\\ansi\\ansicpg1252\\deff0\\fromhtml1\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}
+# {\\*\\generator Riched20 10.0.16299}\\viewkind4\\uc1
+# \\pard\\sa200\\sl276\\slmult1\\f0\\fs22\\lang9
+
+# REPLACE_ME
+
+# {}}"""
+
+#         # To Test text_extraction
+#         # is_font_number :
+
+    def test_font_table_variation(self):
+        from RTFDE.text_extraction import get_font_table,parse_font_tree
+        raw_rtf = self.get_small_template()
+        base = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}"""
+
+        # Test \\cpg is consistant with fcharset
+        base_w_cpg = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f2\\cpg1253\\fcharset161 Arial;}}"""
+        new_rtf = raw_rtf.replace(base, base_w_cpg)
+        rtf_obj = self.full_tree_from_string(new_rtf)
+        raw_font_table = get_font_table(rtf_obj.full_tree.children[1])
+        font_table = parse_font_tree(raw_font_table)
+        # print(repr(font_table))
+        # print(type(font_table))
+        self.assertEqual(font_table[b'\\f2'].codepage, 1253)
+
+        # Test \\fcharset takes precedence over \\cpg
+        base_w_cpg = b"""{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}{\\f2\\cpg1253\\fcharset204 Arial;}}"""
+        new_rtf = raw_rtf.replace(base, base_w_cpg)
+        rtf_obj = self.full_tree_from_string(new_rtf)
+        raw_font_table = get_font_table(rtf_obj.full_tree.children[1])
+        font_table = parse_font_tree(raw_font_table)
+        # \\fcharset204 == codepage 1251
+        self.assertEqual(font_table[b'\\f2'].codepage, 1251)
+
+    def test_text_decoder(self):
+        from RTFDE.text_extraction import TextDecoder
+        pass
+
+    def test_default_font(self):
+        from RTFDE.text_extraction import get_default_font
+        raw_rtf = self.get_small_template()
+
+        # set_font_info with missing deff0
+        new_rtf = raw_rtf.replace(b'\\deff0', b'')
+        rtf_obj = self.deencapsulate_string(new_rtf)
+        # deff0 is not required
+        self.assertIsNone(get_default_font(rtf_obj.full_tree))
+
+        # multiple deff0 is fine. Only use the first found
+        new_rtf = raw_rtf.replace(b'\\deff0', b'\\deff0\\deff1\\deff2')
+        rtf_obj = self.deencapsulate_string(new_rtf)
+        self.assertEqual(get_default_font(rtf_obj.full_tree),
+                         b'\\f0')
+
+
+
+
+    def test_codepage_num_from_charset(self):
+        from RTFDE.text_extraction import get_codepage_num_from_fcharset
+        acceptable = [0,128,129,134,136,161,162,177,178,186,204,222,238]
+        for i in acceptable:
+            self.assertIsNotNone(get_codepage_num_from_fcharset(i))
+        acceptable_none = [1,2,255]
+        for i in acceptable_none:
+            self.assertIsNone(get_codepage_num_from_fcharset(i))
+        from random import randrange
+        for i in range(20):
+            test = randrange(600)
+            if test in acceptable:
+                continue
+            else:
+                self.assertIsNone(get_codepage_num_from_fcharset(test))
+
+    def get_small_template(self):
+        template_path =  join(DATA_BASE_DIR,
+                              "rtf_parsing",
+                              "small_template.rtf")
+        with open(template_path, 'rb') as fp:
+            raw_rtf = fp.read()
+        return raw_rtf
+
+    def full_tree_from_string(self, raw_rtf):
+        rtf_obj = DeEncapsulator(raw_rtf)
+        escaped_rtf = encode_escaped_control_chars(rtf_obj.raw_rtf)
+        rtf_obj.parse_rtf(escaped_rtf)
+        return rtf_obj
+
+    def deencapsulate_string(self, raw_rtf):
+        rtf_obj = DeEncapsulator(raw_rtf)
+        rtf_obj.deencapsulate()
+        return rtf_obj
+
+    def deencapsulate(self, rtf_path):
+        with open(rtf_path, 'rb') as fp:
+            raw_rtf = fp.read()
+            rtf_obj = DeEncapsulator(raw_rtf)
+            rtf_obj.deencapsulate()
+        return rtf_obj
+
 
 # just in case somebody calls this file as a script
 if __name__ == '__main__':

--- a/tests/deencapsulate/test_de_encapsulate.py
+++ b/tests/deencapsulate/test_de_encapsulate.py
@@ -350,7 +350,7 @@ class TestTextDecoding(unittest.TestCase):
         self.assertEqual(correct_repr, rtf_obj.content)
 
     def test_windows_950_codec(self):
-        """
+        """Windows 950 codec's currently fail. Ensure that they still fail in tests so we can identify when the underlying libraries fix this.
 
         https://github.com/seamustuohy/RTFDE/issues/19
         """
@@ -360,9 +360,8 @@ class TestTextDecoding(unittest.TestCase):
         with open(rtf_path, 'rb') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
-            rtf_obj.deencapsulate()
-            output_text = rtf_obj.text
-        # self.assertEqual(output_text, original_body) # TODO Add back in once we get past the error.
+            with self.assertRaises(UnicodeDecodeError):
+                rtf_obj.deencapsulate()
 
     def test_font_table_variation(self):
         from RTFDE.text_extraction import get_font_table,parse_font_tree

--- a/tests/deencapsulate/test_de_encapsulate.py
+++ b/tests/deencapsulate/test_de_encapsulate.py
@@ -13,7 +13,8 @@ from tests.test_utils import DATA_BASE_DIR
 class TestHtmlCleanDeEncapsulate(unittest.TestCase):
     """ Test minimal deviation of original and de-encapsulated HTML content.
 
-    After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content."""
+    After de-encapsulation, the HTML and plain text should differ only minimally from the original HTML or plain text content.
+"""
 
     def test_u_encoded_html(self):
         "Tests that de-encapsulation on u encoded encoded HTML works."
@@ -21,12 +22,12 @@ class TestHtmlCleanDeEncapsulate(unittest.TestCase):
         txt_path = join(DATA_BASE_DIR, "html", "multiple-encodings.txt")
         with open(txt_path, 'r') as fp:
             raw_text = fp.read()
-            original_text = self.clean_whitespace(raw_text)
+            original_text = raw_text
         with open(rtf_path, 'r') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
-            output_text = self.clean_whitespace(rtf_obj.html)
+            output_text = rtf_obj.html
         self.compare_html(original_text, output_text)
 
     def compare_html(self, original_text, output_text):
@@ -45,12 +46,6 @@ class TestHtmlCleanDeEncapsulate(unittest.TestCase):
         # Now we do the real test of equality between the original and the de-encapsulated copy
         self.assertEqual(original_text, output_text)
 
-    def clean_whitespace(self, string):
-        """Getting the newlines and spaces correct when decoding is not perfect. So, we compare strings by looking at them without newlines and spaces.
-
-        RTF encapsulation inserts spaces and newlines into the file around html elements which can't easily be identified as insertions. As such, the only way to really evaluate true equality between the source and the destination is to strip all whitespace (spaces and newlines) and compare."""
-        return string.replace('\n',"").replace(' ','')
-
 class TestTextCleanDeEncapsulate(unittest.TestCase):
     """ Test minimal deviation of original and de-encapsulated plain text content.
 
@@ -59,12 +54,12 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
     def test_japanese_encoded_text(self):
         """ """
         rtf_path = join(DATA_BASE_DIR, "plain_text", "japanese_iso_2022.rtf")
-        original_body = "すみません。"
+        original_body = "すみません。\n"
         with open(rtf_path, 'r') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
-            output_text = self.clean_newlines(rtf_obj.text)
+            output_text = rtf_obj.text
         self.assertEqual(output_text, original_body)
 
     def test_quoted_printable(self):
@@ -73,40 +68,31 @@ class TestTextCleanDeEncapsulate(unittest.TestCase):
         This test checks that it is STILL NOT IMPLEMENTED. So, if you fix it this test will expose that and we will need to change the test."""
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         quote_printable_txt_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.txt")
-        # quote_printable_eml_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.eml")
-        # quote_printable_msg_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.msg")
         with open(quote_printable_txt_path, 'r') as fp:
             raw_text = fp.read()
-            original_decoded_text = self.clean_newlines(raw_text)
+            original_decoded_text = raw_text
         with open(quote_printable_rtf_path, 'r') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
-            output_text = self.clean_newlines(rtf_obj.text)
+            output_text = rtf_obj.text
         self.assertNotEqual(original_decoded_text, output_text)
 
     def test_decoded_quoted_printable(self):
         """Test that decoded text in an original quoted printable message is still quoted when de-encapsulated."""
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         quote_printable_txt_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.txt")
-        # quote_printable_eml_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.eml")
-        # quote_printable_msg_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.msg")
         charset = "cp1251"
         with open(quote_printable_txt_path, 'r') as fp:
             raw_text = fp.read()
             original_decoded_text = quopri.decodestring(raw_text)
             original_decoded_text = original_decoded_text.decode(charset)
-            original_decoded_text = self.clean_newlines(original_decoded_text)
         with open(quote_printable_rtf_path, 'r') as fp:
             raw_rtf = fp.read()
             rtf_obj = DeEncapsulator(raw_rtf)
             rtf_obj.deencapsulate()
-            output_text = self.clean_newlines(rtf_obj.text)
+            output_text = rtf_obj.text
         self.assertEqual(original_decoded_text, output_text)
-
-    def clean_newlines(self, string):
-        """Getting the newlines correct when decoding is not perfect. So, we compare strings by looking at them without newlines."""
-        return string.replace('\n',"")
 
 # just in case somebody calls this file as a script
 if __name__ == '__main__':

--- a/tests/deencapsulate/test_de_encapsulate.py
+++ b/tests/deencapsulate/test_de_encapsulate.py
@@ -99,7 +99,12 @@ class TestBinaryData(unittest.TestCase):
         binary_string = b'This test is one string ' + bin_data + b'that is it.'
         rep_rtf = raw_rtf.replace(b"REPLACE_ME", binary_string)
         rtf_obj = self.deencapsulate_string(rep_rtf)
-        self.assertEqual(binary_string,rtf_obj.content)
+        self.assertEqual(binary_string, rtf_obj.content)
+        if not (binary_string == rtf_obj.content):
+            with open('/tmp/bin_data_fail_input.bytes', 'wb') as fp:
+                fp.write(binary_string)
+            with open('/tmp/bin_data_fail_output.bytes', 'wb') as fp:
+                fp.write(rtf_obj.content)
 
     def test_bin_data_captured(self):
         """Tests that binary data is captured.
@@ -298,13 +303,13 @@ class TestTextDecoding(unittest.TestCase):
         rtf_obj = self.deencapsulate(rtf_path)
         correct_repr = b'&#128522;'
         self.assertEqual(correct_repr, rtf_obj.content)
-        print(rtf_obj.content)
+        #print(rtf_obj.content)
 
     def test_surrogate_without_16bitsigned(self):
         """Test surrogate which doesn't use a 16 signed integer."""
         rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_03.rtf")
         rtf_obj = self.deencapsulate(rtf_path)
-        print(rtf_obj.content)
+        #print(rtf_obj.content)
         correct_repr =  b'&#128522;'
         self.assertEqual(correct_repr, rtf_obj.content)
         rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "surrogate_pairs_04.rtf")
@@ -343,24 +348,21 @@ class TestTextDecoding(unittest.TestCase):
         rtf_obj = self.deencapsulate(rtf_path)
         correct_repr = b'&#128522; \xf0\x9f\x93\x9e'
         self.assertEqual(correct_repr, rtf_obj.content)
-        print(rtf_obj.content)
 
-#     def test_use_small_template(self):
-#         raw_rtf = self.get_small_template()
+    def test_windows_950_codec(self):
+        """
 
-#         # rtf_obj = deencapsulate_string(raw_rtf)
-
-#         # REPLACE_ME
-#         small_template = b"""{\\rtf1\\ansi\\ansicpg1252\\deff0\\fromhtml1\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}
-# {\\*\\generator Riched20 10.0.16299}\\viewkind4\\uc1
-# \\pard\\sa200\\sl276\\slmult1\\f0\\fs22\\lang9
-
-# REPLACE_ME
-
-# {}}"""
-
-#         # To Test text_extraction
-#         # is_font_number :
+        https://github.com/seamustuohy/RTFDE/issues/19
+        """
+        rtf_path = join(DATA_BASE_DIR, "rtf_parsing", "windows_950.rtf")
+        # Word successfully parses this, showing "Hello" followed by a space then a single character, though it's either one it doesn't know how to render or is meant to look like a box.
+        original_body = "Hello ??" # TODO: Fix once we know what the char is.
+        with open(rtf_path, 'rb') as fp:
+            raw_rtf = fp.read()
+            rtf_obj = DeEncapsulator(raw_rtf)
+            rtf_obj.deencapsulate()
+            output_text = rtf_obj.text
+        # self.assertEqual(output_text, original_body) # TODO Add back in once we get past the error.
 
     def test_font_table_variation(self):
         from RTFDE.text_extraction import get_font_table,parse_font_tree
@@ -387,6 +389,7 @@ class TestTextDecoding(unittest.TestCase):
         self.assertEqual(font_table[b'\\f2'].codepage, 1251)
 
     def test_text_decoder(self):
+        # TODO
         from RTFDE.text_extraction import TextDecoder
         pass
 

--- a/tests/parse_rtf/test_parse_rtf.py
+++ b/tests/parse_rtf/test_parse_rtf.py
@@ -8,12 +8,16 @@ Ensure that:
 """
 
 import unittest
+import logging
 from os.path import join
 from RTFDE.exceptions import MalformedRtf, MalformedEncapsulatedRtf, NotEncapsulatedRtf
 from RTFDE.deencapsulate import DeEncapsulator
 from RTFDE.utils import encode_escaped_control_chars
+from RTFDE.text_extraction import get_python_codec
+from RTFDE.text_extraction import TextDecoder
 
 from tests.test_utils import DATA_BASE_DIR
+from lark import logger as lark_logger
 
 class TestParseRtf(unittest.TestCase):
     """Test proper parsing of RTF files
@@ -32,29 +36,45 @@ Ensure that:
                                           "rtf_parsing",
                                           "from_header_template.rtf")
         # Has 20 control words
-        ctrl_words = ("\\deff0"*16) + "\\fromhtml1"
-        rtf = self.replace_from_header(template_path, ctrl_words)
+        ctrl_words = (b"\\deff0"*16) + b"\\fromhtml1"
+        rtf = self.replace_text_in_template(template_path, ctrl_words)
         output = self.run_parsing(rtf)
-        ctrl_wds = output._get_header_control_words_before_first_group()
+        ctrl_wds = output.get_header_control_words_before_first_group()
         ctrl_wds =[i.value.strip() for i in ctrl_wds]
-        correct_ctrl = ['\\rtf1', '\\ansi', '\\ansicpg1252', '\\deff0', '\\deff0', '\\deff0',
-                        '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0',
-                        '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0',
-                        '\\deff0', '\\fromhtml1']
+        correct_ctrl = [b'\\rtf1',
+                        b'\\ansi',
+                        b'\\ansicpg1252',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\deff0',
+                        b'\\fromhtml1']
         self.assertEqual(ctrl_wds, correct_ctrl)
 
         # group comes before 20 control words
-        ctrl_words = ("\\deff0"*5) + "\\fromhtml1 \\deff0" + '{\colortbl\red0\green0\blue0;\red5\green99\blue193;}'
-        rtf = self.replace_from_header(template_path, ctrl_words)
+        ctrl_words = (b"\\deff0"*5) + b"\\fromhtml1 \\deff0" + b'{\colortbl\red0\green0\blue0;\red5\green99\blue193;}'
+        rtf = self.replace_text_in_template(template_path, ctrl_words)
         output = self.run_parsing(rtf)
-        ctrl_wds = output._get_header_control_words_before_first_group()
+        ctrl_wds = output.get_header_control_words_before_first_group()
         ctrl_wds = [i.value.strip() for i in ctrl_wds]
-        correct_ctrl = ['\\rtf1', '\\ansi', '\\ansicpg1252', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\deff0', '\\fromhtml1', '\\deff0']
+        correct_ctrl = [b'\\rtf1', b'\\ansi', b'\\ansicpg1252', b'\\deff0', b'\\deff0', b'\\deff0', b'\\deff0', b'\\deff0', b'\\fromhtml1', b'\\deff0']
         self.assertEqual(ctrl_wds, correct_ctrl)
 
         # fromhtml header parsing not affected by this function
-        ctrl_words = '{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}' + "\\fromhtml1 \\deff0"
-        rtf = self.replace_from_header(template_path, ctrl_words)
+        ctrl_words = b'{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}' + b"\\fromhtml1 \\deff0"
+        rtf = self.replace_text_in_template(template_path, ctrl_words)
         # The fromhtml header needs to be in the first 10 tokens. Tokens includes groups in this case. So this should succeed.
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
@@ -66,10 +86,10 @@ Ensure that:
                               "from_header_template.rtf")
 
         # bad
-        bad_charsets = ["\\ansicpg1234", "\\pccpg1252", "\\ansicpg"]
+        bad_charsets = [b"\\ansicpg1234", b"\\ansicpg"]
         for badchar in bad_charsets:
-            rtf = self.replace_from_header(template_path, "\\fromhtml1")
-            rtf = self.replace_from_header(None, badchar, rep_str="\\ansicpg1252", string=rtf)
+            rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+            rtf = self.replace_text_in_template(None, badchar, rep_str=b"\\ansicpg1252", string=rtf)
             self.check_deencapsulate_validity(rtf,
                                               expect_error=MalformedRtf,
                                               name="bad codepage keyword: {0}".format(badchar))
@@ -82,21 +102,16 @@ Ensure that:
         # NOTE: oletools supports some codepages which MS doesn't include so those are not included here: (32768, 32769)
         supported_codepage_nums = [37, 708, 709, 710, 870, 1047, 1141, 1201, 10000, 10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10021, 10029, 10079, 10081, 12000, 12001, 20127, 28591, 28592, 28593, 28594, 28595, 28596, 28597, 28598, 28599, 28603, 28605, 38598, 65000]
         for goodpg in supported_codepage_nums:
-            rtf = self.replace_from_header(template_path, "\\fromhtml1")
-            good_codepage = "\\ansicpg{0}".format(goodpg)
-            rtf = self.replace_from_header(None, good_codepage, rep_str="\\ansicpg1252", string=rtf)
-            output = self.run_parsing(rtf)
-            output._validate_encapsulation()
-            codec = output._get_python_codec()
+            codec = get_python_codec(goodpg)
             self.assertIsInstance(codec, str)
             self.assertNotEqual(codec, 'utf8')
 
-        # missing
-        rtf = self.replace_from_header(template_path, "\\fromhtml1")
-        rtf = self.replace_from_header(None, "", rep_str="\\ansicpg1252", string=rtf)
+        # Codepage is optional. Therefore a missing codepage number is fine.
+        rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+        rtf = self.replace_text_in_template(None, b"", rep_str=b"\\ansicpg1252", string=rtf)
         self.check_deencapsulate_validity(rtf,
-                                          expect_error=MalformedRtf,
-                                          name="Missing codepage num")
+                                          expect_error=None,
+                                          name="Ansi codepage num is optional")
 
     def test_charset_header(self):
         template_path =  join(DATA_BASE_DIR,
@@ -104,77 +119,78 @@ Ensure that:
                               "from_header_template.rtf")
 
         # Bad charset
-        bad_charsets = ["\\ANSI", "ansi", "\\PC", "\\osx"]
+        bad_charsets = [b"\\ANSI", b"ansi", b"\\PC", b"\\osx"]
         for badchar in bad_charsets:
-            rtf = self.replace_from_header(template_path, "\\fromhtml1")
-            rtf = self.replace_from_header(None, badchar, rep_str="\\ansi", string=rtf)
+            rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+            rtf = self.replace_text_in_template(None, badchar, rep_str=b"\\ansi", string=rtf)
             self.check_deencapsulate_validity(rtf,
                                               expect_error=MalformedRtf,
                                               name="bad charset keyword: {0}".format(badchar))
 
         # Good charset
         # included \\ after the charset keyword to ensure we don't capture the \\ansicpg
-        good_charsets = ["\\ansi\\", "\\mac\\", "\\pc\\", "\\pac\\"]
+        good_charsets = [b"\\ansi\\", b"\\mac\\", b"\\pc\\", b"\\pca\\"]
         for goodchar in good_charsets:
-            rtf = self.replace_from_header(template_path, "\\fromhtml1")
-            rtf = self.replace_from_header(None, goodchar, rep_str="\\ansi\\", string=rtf)
+            rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+            rtf = self.replace_text_in_template(None, goodchar, rep_str=b"\\ansi\\", string=rtf)
             self.check_deencapsulate_validity(rtf,
                                               expect_error=None,
                                               name="Good charset keyword: {0}".format(goodchar))
 
         # group before charset
-        new_front = '{\\rtf1{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}'
-        rtf = self.replace_from_header(template_path, "\\fromhtml1")
+        new_front = b'{\\rtf1{\\colortbl\\red0\\green0\\blue0;\\red5\\green99\\blue193;}'
+        rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
         rtf = new_front + rtf[6:] # Replaces `{\\rtf1`
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedRtf,
                                           name="no groups before charset")
 
         # Missing
-        rtf = self.replace_from_header(template_path, "\\fromhtml1")
-        rtf = self.replace_from_header(None, "\\", rep_str="\\ansi\\", string=rtf)
+        rtf = self.replace_text_in_template(template_path, b"\\fromhtml1")
+        rtf = self.replace_text_in_template(None, b"\\", rep_str=b"\\ansi\\", string=rtf)
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedRtf,
                                           name="missing charset")
         # Test missing using default fallback to ansi
         output = self.run_parsing(rtf)
-        output._validate_encapsulation()
-        charset = output._get_charset(fallback_to_default=True)
-        self.assertEqual("\\ansi", charset)
+        charset = output.validate_charset(fallback_to_default=True)
+        self.assertEqual(b"\\ansi", charset)
 
     def test_get_python_codec(self):
         """Test getting correct python codec."""
         template_path =  join(DATA_BASE_DIR,
                               "rtf_parsing",
                               "from_header_template.rtf")
-        base = self.replace_from_header(template_path, "\\fromhtml1")
+        base = self.replace_text_in_template(template_path, b"\\fromhtml1")
         # Big-5
         big5string = b'\xb3o\xacO\xa4@\xad\xd3\xa4\xe5\xa5\xbb\xa6r\xb2\xc5\xa6\xea\xa1C'
-        rtf = self.replace_from_header(None,
-                                       replacement="\\ansicpg10002",
-                                       rep_str="\\ansicpg1252",
+        rtf = self.replace_text_in_template(None,
+                                       replacement=b"\\ansicpg10002",
+                                       rep_str=b"\\ansicpg1252",
                                        string=base)
 
         output = self.run_parsing(rtf)
-        output._validate_encapsulation()
-        output.charset = output._get_charset()
-        output.text_codec = output._get_python_codec()
-        big5string.decode(output.text_codec)
-        self.assertEqual(output.text_codec, "big5")
-        self.assertEqual(big5string.decode(output.text_codec),
+        # output.validate_encapsulation()
+        # charset = output._validate_charset()
+        ansicpg_header = output.get_ansicpg_header()
+        possible_cpg_num = int(ansicpg_header.value.strip()[8:])
+        text_codec = get_python_codec(possible_cpg_num)
+        big5string.decode(text_codec)
+        self.assertEqual(text_codec, "big5")
+        self.assertEqual(big5string.decode(text_codec),
                          '這是一個文本字符串。')
         # Hebrew
         hebrew = b'\xe6\xe4\xe5 \xee\xe7\xf8\xe5\xe6\xfa \xe8\xf7\xf1\xe8.'
-        rtf = self.replace_from_header(None,
-                                       replacement="\\ansicpg10005",
-                                       rep_str="\\ansicpg1252",
+        rtf = self.replace_text_in_template(None,
+                                       replacement=b"\\ansicpg10005",
+                                       rep_str=b"\\ansicpg1252",
                                        string=base)
         output = self.run_parsing(rtf)
-        output._validate_encapsulation()
-        output.charset = output._get_charset()
-        output.text_codec = output._get_python_codec()
-        self.assertEqual(output.text_codec, "hebrew")
-        self.assertEqual(hebrew.decode(output.text_codec), "זהו מחרוזת טקסט.")
+        ansicpg_header = output.get_ansicpg_header()
+        possible_cpg_num = int(ansicpg_header.value.strip()[8:])
+        text_codec = get_python_codec(possible_cpg_num)
+        self.assertEqual(text_codec, "hebrew")
+        self.assertEqual(hebrew.decode(text_codec), "זהו מחרוזת טקסט.")
 
 
     def test_from_header_html(self):
@@ -182,7 +198,7 @@ Ensure that:
         from_html =  join(DATA_BASE_DIR,
                           "rtf_parsing",
                           "from_header_template.rtf")
-        rtf = self.replace_from_header(from_html, "\\fromhtml1")
+        rtf = self.replace_text_in_template(from_html, b"\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
                                           name="working fromheaderhtml")
@@ -192,7 +208,7 @@ Ensure that:
         from_text =  join(DATA_BASE_DIR,
                           "rtf_parsing",
                           "from_header_template.rtf")
-        rtf = self.replace_from_header(from_text, "\\fromtext")
+        rtf = self.replace_text_in_template(from_text, b"\\fromtext")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
                                           name="working fromheader text")
@@ -202,7 +218,7 @@ Ensure that:
         missing_from =  join(DATA_BASE_DIR,
                              "rtf_parsing",
                              "from_header_template.rtf")
-        rtf = self.replace_from_header(missing_from, "")
+        rtf = self.replace_text_in_template(missing_from, b"")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=NotEncapsulatedRtf,
                                           name="missing fromheader text")
@@ -210,9 +226,9 @@ Ensure that:
         missing_but_one_in_body =  join(DATA_BASE_DIR,
                                      "rtf_parsing",
                                      "from_header_template.rtf")
-        rtf = self.replace_from_header(missing_but_one_in_body, "")
-        rtf = self.replace_from_header(None, "\\fromtext",
-                                       rep_str="INSERT_BODY_TEXT_HERE",
+        rtf = self.replace_text_in_template(missing_but_one_in_body, b"")
+        rtf = self.replace_text_in_template(None, b"\\fromtext",
+                                       rep_str=b"INSERT_BODY_TEXT_HERE",
                                        string=rtf)
         self.check_deencapsulate_validity(rtf,
                                           expect_error=NotEncapsulatedRtf,
@@ -223,7 +239,7 @@ Ensure that:
         multiple_from_html =  join(DATA_BASE_DIR,
                                    "rtf_parsing",
                                    "from_header_template.rtf")
-        rtf = self.replace_from_header(multiple_from_html, "\\fromhtml1\\fromhtml1")
+        rtf = self.replace_text_in_template(multiple_from_html, b"\\fromhtml1\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -231,7 +247,7 @@ Ensure that:
         multiple_from_html_first =  join(DATA_BASE_DIR,
                                          "rtf_parsing",
                                          "from_header_template.rtf")
-        rtf = self.replace_from_header(multiple_from_html_first, "\\fromhtml1\\fromtext")
+        rtf = self.replace_text_in_template(multiple_from_html_first, b"\\fromhtml1\\fromtext")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -239,7 +255,7 @@ Ensure that:
         multiple_from_txt_first =  join(DATA_BASE_DIR,
                                         "rtf_parsing",
                                         "from_header_template.rtf")
-        rtf = self.replace_from_header(multiple_from_txt_first, "\\fromtext\\fromhtml1")
+        rtf = self.replace_text_in_template(multiple_from_txt_first, b"\\fromtext\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -249,9 +265,10 @@ Ensure that:
         missing_from =  join(DATA_BASE_DIR,
                              "rtf_parsing",
                              "from_header_template.rtf")
-        rtf = self.replace_from_header(missing_from, "")
+        rtf = self.replace_text_in_template(missing_from, b"")
         # Append a new curly and the control word to the start of the rtf file
-        rtf = "{\\fromhtml1" + rtf[1:]
+        # TODO: Fix this array use on a bytes object
+        rtf = b"{\\fromhtml1" + rtf[1:]
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedRtf,
                                           name="from header before magic")
@@ -261,22 +278,25 @@ Ensure that:
         missing_from =  join(DATA_BASE_DIR,
                              "rtf_parsing",
                              "from_header_template.rtf")
-        rtf = self.replace_from_header(missing_from, "\\fromhtml1")
+        rtf = self.replace_text_in_template(missing_from, b"\\fromhtml1")
         # Append a new curly and broken rtf to the start of the rtf file
-        rtf_no_one = "{\\rtf" + rtf[6:] # Removes `{\\rtf1`
+        # TODO: Fix this array use on a bytes object
+        rtf_no_one = b"{\\rtf" + rtf[6:] # Removes `{\\rtf1`
         self.check_deencapsulate_validity(rtf_no_one,
                                           expect_error=MalformedRtf,
                                           name="malformed file magic")
-
-        rtf_two = "{\\rtf2" + rtf[6:]
+        # TODO: Fix this array use on a bytes object
+        rtf_two = b"{\\rtf2" + rtf[6:]
         self.check_deencapsulate_validity(rtf_two,
                                           expect_error=MalformedRtf,
                                           name="malformed file magic")
-        RTF = "{\\RTF1" + rtf[6:]
+        # TODO: Fix this array use on a bytes object
+        RTF = b"{\\RTF1" + rtf[6:]
         self.check_deencapsulate_validity(RTF,
                                           expect_error=MalformedRtf,
                                           name="malformed file magic")
-        PiRTF = "{\\ARRRRRR-TEEE-FFF" + rtf[6:] # Because Pirates
+        # TODO: Fix this array use on a bytes object
+        PiRTF = b"{\\ARRRRRR-TEEE-FFF" + rtf[6:] # Because Pirates
         self.check_deencapsulate_validity(PiRTF,
                                           expect_error=MalformedRtf,
                                           name="Ahoy, matey! this here file magic be broken")
@@ -292,11 +312,32 @@ Ensure that:
                               "rtf_parsing",
                               "from_header_template.rtf")
 
-        early_font_table = '{\\fonttbl\n{\\f0\\fswiss Arial;}\n{\\f1\\fmodern Courier New;}\n{\\f2\\fnil\\fcharset2 Symbol;}\n{\\f3\\fmodern\\fcharset0 Courier New;}}' + "\\fromhtml1 \\deff0"
-        rtf = self.replace_from_header(template_path, early_font_table)
+        early_font_table = b'{\\fonttbl\n{\\f0\\fswiss Arial;}\n{\\f1\\fmodern Courier New;}\n{\\f2\\fnil\\fcharset2 Symbol;}\n{\\f3\\fmodern\\fcharset0 Courier New;}}' + b"\\fromhtml1 \\deff0"
+        rtf = self.replace_text_in_template(template_path, early_font_table)
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="fonttable before fromhtml in header")
+
+    def test_missing_fonttable(self):
+        """fail when fonttable is missing"""
+        template_path =  join(DATA_BASE_DIR,
+                              "rtf_parsing",
+                              "font_table_template.rtf")
+
+        no_font_table = b""
+        rtf = self.replace_text_in_template(template_path,
+                                            no_font_table,
+                                            rep_str=b"REPLACE_FONT_TABLE_HERE")
+        NA = b"REPLACE_FONT_TABLE_HERE"
+        default = b"""{\\fonttbl
+{\\f0\\fswiss Arial;}
+{\\f1\\fmodern Courier New;}
+{\\f2\\fnil\\fcharset2 Symbol;}
+{\\f3\\fmodern\\fcharset0 Courier New;}}"""
+        self.check_deencapsulate_validity(rtf,
+                                          expect_error=ValueError,
+                                          name="fonttable Missing")
+                                          # print_error=True)
 
     def test_extracted_correct_from_header(self):
         """
@@ -306,23 +347,23 @@ Ensure that:
         template_data =  join(DATA_BASE_DIR,
                           "rtf_parsing",
                           "from_header_template.rtf")
-        rtf = self.replace_from_header(template_data, "\\fromhtml1")
+        rtf = self.replace_text_in_template(template_data, b"\\fromhtml1")
         output = DeEncapsulator(rtf)
         output.deencapsulate()
         self.assertEqual('html', output.get_content_type())
 
-        rtf = self.replace_from_header(template_data, "\\fromtext")
+        rtf = self.replace_text_in_template(template_data, b"\\fromtext")
         output = DeEncapsulator(rtf)
         output.deencapsulate()
         self.assertEqual('text', output.get_content_type())
 
          # Try with them back to back. First should win.
-        rtf = self.replace_from_header(template_data, "\\fromtext\\fromhtml1")
+        rtf = self.replace_text_in_template(template_data, b"\\fromtext\\fromhtml1")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
 
-        rtf = self.replace_from_header(template_data, "\\fromhtml1\\fromtext")
+        rtf = self.replace_text_in_template(template_data, b"\\fromhtml1\\fromtext")
         self.check_deencapsulate_validity(rtf,
                                           expect_error=MalformedEncapsulatedRtf,
                                           name="multiple FROM headers means malformed")
@@ -334,17 +375,90 @@ Ensure that:
                      "rtf_parsing",
                      "control_chars.rtf")
         if path is not None:
-            with open(path, 'r') as fp:
+            with open(path, 'rb') as fp:
                 rtf = fp.read()
         self.check_deencapsulate_validity(rtf,
                                           expect_error=None,
                                           name="Parse the tilde the \~ command char.")
 
-    def replace_from_header(self, path, replacement,
-                            rep_str="REPLACE_FROM_HEADER_HERE",
+    def test_parse_spaces_in_own_groups(self):
+        """Correctly parse spaces when in their own groups
+        """
+        path =  join(DATA_BASE_DIR,
+                     "rtf_parsing",
+                     "five_spaces.rtf")
+        if path is not None:
+            with open(path, 'rb') as fp:
+                rtf = fp.read()
+        self.check_deencapsulate_validity(rtf,
+                                          expect_error=None,
+                                          name="Parse spaces in their own groups.")
+        output = DeEncapsulator(rtf)
+        output.deencapsulate()
+        # self.maxDiff = None
+        self.assertEqual(b'INSERT_BODY_TEXT_HERE     ', output.text)
+
+    def test_parse_multiple_features(self):
+        """Correctly parse spaces when in their own groups
+        """
+        path =  join(DATA_BASE_DIR,
+                     "rtf_parsing",
+                     "encapsulated_example.rtf")
+        htmlpath =  join(DATA_BASE_DIR,
+                        "rtf_parsing",
+                        "encapsulated_example.html")
+
+        if path is not None:
+            with open(path, 'rb') as fp:
+                rtf = fp.read()
+        if htmlpath is not None:
+            with open(htmlpath, 'rb') as fp:
+                html = fp.read()
+
+        self.check_deencapsulate_validity(rtf,
+                                          expect_error=None,
+                                          print_error=True,
+                                          name="Test parse multiple features.")
+        self.maxDiff = None
+        output = DeEncapsulator(rtf)
+        output.deencapsulate()
+        # print("RUNNING DIFF")
+        # print(repr(html))
+        # The CR+LF newlines should not match.
+        self.assertNotEqual(html, output.html)
+        # The LF newlines should be replaced.
+        html = html.replace(b'\r\n', b'\n')
+        self.assertEqual(html, output.html)
+
+
+    def debug_error(self, err):
+        print("FOUND ERROR")
+        # print(dir(err))
+        # print(err)
+        # print(err.start)
+        # print(err.considered_rules)
+        # print(err.state)
+        # print(dir(err.state))
+        print("Current stack of tokens")
+        # print(err.state.state_stack)
+        # print(err.state.value_stack)
+        for i in err.state.value_stack:
+            print(i)
+            # print(dir(i))
+            # print(len(i))
+            # print(type(i))
+        # 'lexer', 'parse_conf', 'position', 'state_stack', 'value_stack'
+        print(err.token_history)
+        # print(err.interactive_parser.lexer_thread )
+
+        print("FOUND ERROR DONE")
+        return True
+
+    def replace_text_in_template(self, path, replacement,
+                            rep_str=b"REPLACE_FROM_HEADER_HERE",
                             string=None):
         if path is not None:
-            with open(path, 'r') as fp:
+            with open(path, 'rb') as fp:
                 raw_rtf = fp.read()
         else:
             raw_rtf = string
@@ -353,13 +467,15 @@ Ensure that:
 
     def run_parsing(self, rtf):
         output = DeEncapsulator(rtf)
-        output.stripped_rtf = output._strip_htmlrtf_sections()
-        _simp = encode_escaped_control_chars(output.stripped_rtf)
-        output.simplified_rtf = _simp
-        output.doc_tree = output._parse_rtf()
+        escaped_rtf = encode_escaped_control_chars(output.raw_rtf)
+        output.parse_rtf(escaped_rtf)
+        output.get_doc_tree()
         return output
 
-    def check_deencapsulate_validity(self, data, expect_error=None, name="test"):
+    def check_deencapsulate_validity(self, data,
+                                     expect_error=None,
+                                     name="test",
+                                     print_error=False):
         """Helper to check if a test input raises or doesn't raise an error."""
         found_error = None
         try:
@@ -367,7 +483,12 @@ Ensure that:
             output.deencapsulate()
         except Exception as _e:
             found_error = _e
-
+            if print_error is True:
+                import traceback
+                traceback.print_exception(type(found_error),
+                                          found_error,
+                                          found_error.__traceback__)
+        # output.deencapsulate()
         if expect_error is not None:
             if found_error is None:
                 self.fail("Expected {} but DeEncapsulator finished without error on {}.".format(expect_error, name))

--- a/tests/parse_rtf/test_validate_file.py
+++ b/tests/parse_rtf/test_validate_file.py
@@ -8,9 +8,10 @@ Ensure that:
 
 import unittest
 from os.path import join
-from RTFDE.exceptions import MalformedRtf
+from RTFDE.exceptions import MalformedRtf, MalformedEncapsulatedRtf
 from RTFDE.deencapsulate import DeEncapsulator
 from tests.test_utils import DATA_BASE_DIR
+
 
 class TestInputValidity(unittest.TestCase):
     """ Tests basic valid and invalid inputs."""
@@ -61,6 +62,16 @@ class TestInputValidity(unittest.TestCase):
             self.check_deencapsulate_validity(fp,
                                               expect_error=TypeError,
                                               name="rtf file pointer")
+
+    def test_far_too_minimal_rtf_file(self):
+        raw_rtf = b"{\\rtf1}}"
+        self.check_deencapsulate_validity(raw_rtf,
+                                          expect_error=MalformedEncapsulatedRtf,
+                                          name="rtf with an extra brace")
+        raw_rtf = b"{\\rtf1}1"
+        self.check_deencapsulate_validity(raw_rtf,
+                                          expect_error=MalformedEncapsulatedRtf,
+                                          name="rtf with an extra 1")
 
     def check_deencapsulate_validity(self, data, expect_error=None, name="test"):
         """Helper to check if a test input raises or doesn't raise an error."""

--- a/tests/parse_rtf/test_validate_file.py
+++ b/tests/parse_rtf/test_validate_file.py
@@ -16,12 +16,12 @@ class TestInputValidity(unittest.TestCase):
     """ Tests basic valid and invalid inputs."""
 
     def test_valid_rtf_string(self):
-        """ Check that a valid encapsulated rtf string returns 0 exit status."""
+        """ Check that opening an rtf file as a string returns a TypeError."""
         quote_printable_rtf_path = join(DATA_BASE_DIR, "plain_text", "quoted_printable_01.rtf")
         with open(quote_printable_rtf_path, 'r') as fp:
             raw_rtf = fp.read()
             self.check_deencapsulate_validity(raw_rtf,
-                                              expect_error=None,
+                                              expect_error=TypeError,
                                               name="quoted_printable_01.rtf")
 
     def test_valid_rtf_bytes(self):
@@ -35,7 +35,7 @@ class TestInputValidity(unittest.TestCase):
 
     def test_invalid_none(self):
         """ Check that passing nothing returns a non-zero exit status."""
-        self.check_deencapsulate_validity("",
+        self.check_deencapsulate_validity(b"",
                                           expect_error=MalformedRtf,
                                           name="empty string")
         self.check_deencapsulate_validity(b"",

--- a/tests/test_data/html/multiple-encodings.rtf
+++ b/tests/test_data/html/multiple-encodings.rtf
@@ -2,15 +2,15 @@
 {\f0\fswiss Arial;}}
 {\colortbl\red0\green0\blue0;}
 \uc1\pard\plain\deftab360 \f0\fs24
-{\*\htmltag96 <div dir="ltr">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0\u36889 ?\u26159 ?\u19968 ?\u20491 ?\u25991 ?\u26412 ?\u23383 ?\u31526 ?\u20018 ?
+{\*\htmltag96 <div dir="ltr">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0\u36889 ?\u26159 ?\u19968 ?\u20491 ?\u25991 ?\u26412 ?\u65533 ?=AD\u65533 ?\u31526 ?\u20018 ?
 {\*\htmltag116 <br>}\htmlrtf \line
-\htmlrtf0 \u1494 ?\u1492 ?\u1493 ? \u32 ? \u1502 ?\u1495 ?\u1512 ?\u1493 ?\u1494 ?\u1514 ?\u32 ? \u1496 ?\u1511 ?\u1505 ?\u1496 ?.
+\htmlrtf0 \u1494 ?\u1492 ?\u1493 ? \u1502 ?\u1495 ?\u1512 ?\u1493 ?\u65533 ?=96\u1514 ? \u1496 ?\u1511 ?\u1505 ?\u1496 ?.
 {\*\htmltag240 <br clear="all">}
 {\*\htmltag96 <div>}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0
 {\*\htmltag116 <br>}\htmlrtf \line
 \htmlrtf0 {\*\htmltag72}\htmlrtf\par}\htmlrtf0
 
-{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
 {\*\htmltag96 <div dir="ltr" class="gmail_signature" data-smartmail="gmail_signature">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0
 {\*\htmltag96 <div dir="ltr">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0
 {\*\htmltag96 <div>}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0
@@ -34,6 +34,6 @@
 
 {\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 {\*\htmltag72}\htmlrtf\par}\htmlrtf0
 
-{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
 {\*\htmltag104 </div>}
 {\*\htmltag0 \par }}

--- a/tests/test_data/personal_rtf_test_files/README.md
+++ b/tests/test_data/personal_rtf_test_files/README.md
@@ -1,0 +1,63 @@
+# Private Data Test Folder
+
+Use this folder to include files to test against a private folder full of RTF files exported from .msg files. The `TestPrivateMsgTestCases` unittest in `test_de_encapsulate.py` will run against this, or any other, folder full of raw encapsulated .rtf files.
+
+This test will first try to run against whatever path is set in the RTFDE_PRIVATE_MSG_FOLDER environment variable.
+
+If you do not set this environment variable this test will look for .rtf files in the `tests/test_data/personal_rtf_test_files` folder. If it finds none there it will exit without any error.
+
+```
+> export RTFDE_PRIVATE_MSG_FOLDER="/path/to/folder/with/messages/"
+> python3 -m unittest discover -v
+```
+
+If you want to run tests that check the contents of the original HTML file against the encapsulated version you can use the RTFDE_PRIVATE_MSG_OUTPUT_FOLDER environment variable. If you do not set this environment variable this test will look for .html files in the `tests/test_data/personal_rtf_test_output_files` folder. If it does not find a file with the same name as the .rtf file that it is testing it will not attempt to compare it to anything. (`file.rtf` needs a corresponding `file.html`).
+
+```
+    > export RTFDE_PRIVATE_MSG_OUTPUT_FOLDER="/path/to/folder/with/html/outputs/"
+    > python3 -m unittest discover -v --locals
+```
+
+It is important to use the --locals variable for unittest since it will expose the filename where an error occurs alongside the unittest failure. Look for the variable named `FAILING_FILENAME`
+
+This folder `tests/test_data/personal_rtf_test_files` has been included in the .gitignore to allow developers to safely use it for this purpose.
+
+
+# Populating the private test folder
+See code in `scripts/prep_private_rtf_test_folder.sh` for guidance on how to populate a private test folder with RTF files extracted from a folder full of .msg files.
+
+Run this script to extract .rtf msg bodies from .msg files. Can be run in multiple ways.
+
+1) extract the .rtf bodies from a folder of .msg files into another folder.
+```
+./prep_private_rtf_test_folder.sh \
+    -i /tmp/msg_files/ \
+    -o /tmp/extracted_rtf/
+```
+
+2) exract the .rtf body from a single .msg file into a folder
+```
+./prep_private_rtf_test_folder.sh \
+    -i /tmp/msg_files/email.msg \
+    -o /tmp/extracted_rtf/
+```
+
+2) exract the .rtf body from a single .msg file to a specific filename
+```
+./prep_private_rtf_test_folder.sh \
+    -i /tmp/msg_files/email.msg \
+    -o /tmp/extracted_rtf/extracted_msg.rtf
+```
+
+
+# Example test files to include
+
+```
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/input/chinese-exotic-test.rtf'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/input/complex-test.rtf'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/input/hebrew-test.rtf'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/input/mixed-charsets-test.rtf'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/input/newlines-test.rtf'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/input/russian-test.rtf'
+wget 'https://github.com/bbottema/rtf-to-html/raw/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/input/simple-test.rtf'
+```

--- a/tests/test_data/personal_rtf_test_output_files/README.md
+++ b/tests/test_data/personal_rtf_test_output_files/README.md
@@ -1,0 +1,29 @@
+# Private Data Test HTML output Folder
+
+Use this folder to include HTML files which correspond to the to RTF files in the private test folder. It is used in the `TestPrivateMsgTestCases` unittest in `test_de_encapsulate.py`.
+
+See the README.md in the `tests/test_data/personal_rtf_test_files` directory for more info on the primary .rtf files.
+
+If you want to run tests that check the contents of the original HTML file against the encapsulated version you can use the RTFDE_PRIVATE_MSG_OUTPUT_FOLDER environment variable. If you do not set this environment variable this test will look for .html files in the `tests/test_data/personal_rtf_test_output_files` folder. If it does not find a file with the same name as the .rtf file that it is testing it will not attempt to compare it to anything. (`file.rtf` needs a corresponding `file.html`).
+
+```
+    > export RTFDE_PRIVATE_MSG_OUTPUT_FOLDER="/path/to/folder/with/html/outputs/"
+    > python3 -m unittest discover -v --locals
+```
+
+It is important to use the --locals variable for unittest since it will expose the filename where an error occurs alongside the unittest failure. Look for the variable named `FAILING_FILENAME`
+
+This folder `tests/test_data/personal_rtf_test_outputfiles` has been included in the .gitignore to allow developers to safely use it for this purpose.
+
+
+# Example test files to include
+
+```
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/output/rfcompliant/chinese-exotic-test.html'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/output/rfcompliant/complex-test.html'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/output/rfcompliant/hebrew-test.html'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/output/rfcompliant/mixed-charsets-test.html'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/output/rfcompliant/newlines-test.html'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/output/rfcompliant/russian-test.html'
+wget 'https://raw.githubusercontent.com/bbottema/rtf-to-html/9e4c42dbd7a8505d862aaf905739c5b6fc5e3be9/src/test/resources/test-messages/output/rfcompliant/simple-test.html'
+```

--- a/tests/test_data/plain_text/test_data.rtf
+++ b/tests/test_data/plain_text/test_data.rtf
@@ -1,0 +1,8 @@
+{\rtf1\ansi\ansicpg1252\fromtext \fbidis \deff0{\fonttbl
+{\f0\fswiss Arial;}
+{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}}
+{\colortbl\red0\green0\blue0;\red0\green0\blue255;}
+\uc1\pard\plain\deftab360 \f0\fs20 body\par
+}

--- a/tests/test_data/rtf_parsing/control_chars.rtf
+++ b/tests/test_data/rtf_parsing/control_chars.rtf
@@ -1,0 +1,185 @@
+{\rtf1\ansi\fbidis\ansicpg1252\deff0\fromhtml1{\fonttbl{\f0\fswiss\fcharset0 Times New Roman;}{\f1\fswiss\fcharset2 Symbol;}{\f2
+\fswiss\fcharset0 Calibri;}{\f3\fswiss\fcharset0 Verdana;}}
+{\colortbl;\red192\green192\blue192;\red255\green255\blue255;\red0\green0\blue1;\red43\green59\blue70;\red0\green0\blue255
+;\red5\green99\blue193;\red167\green207\blue56;\red42\green59\blue69;\red60\green60\blue59;}
+{\*\generator Microsoft Exchange Server;}
+{\*\formatConverter converted from html;}
+\viewkind5\viewscale100
+\htmlrtf{\*\bkmkstart BM_BEGIN}\htmlrtf0{\*\htmltag64}{\*\htmltag0 <html><head><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"><meta name="Generator" content="Microsoft Word 15 (filtered medium)"><!--[if !mso]><style>v\\:* \{behavior:url(#default#VML);\}\par
+o\\:* \{behavior:url(#default#VML);\}\par
+w\\:* \{behavior:url(#default#VML);\}\par
+.shape \{behavior:url(#default#VML);\}\par
+</style><![endif]--><style><!--\par
+/* Font Definitions */\par
+@font-face\par
+\'09\{font-family:"Cambria Math";\par
+\'09panose-1:2 4 5 3 5 4 6 3 2 4;\}\par
+@font-face\par
+\'09\{font-family:Calibri;\par
+\'09panose-1:2 15 5 2 2 2 4 3 2 4;\}\par
+@font-face\par
+\'09\{font-family:Verdana;\par
+\'09panose-1:2 11 6 4 3 5 4 4 2 4;\}\par
+/* Style Definitions */\par
+p.MsoNormal, li.MsoNormal, div.MsoNormal\par
+\'09\{margin:0cm;\par
+\'09font-size:11.0pt;\par
+\'09font-family:"Calibri",sans-serif;\par
+\'09mso-fareast-language:EN-US;\}\par
+span.EmailStyle17\par
+\'09\{mso-style-type:personal-compose;\par
+\'09font-family:"Calibri",sans-serif;\par
+\'09color:windowtext;\}\par
+.MsoChpDefault\par
+\'09\{mso-style-type:export-only;\par
+\'09font-family:"Calibri",sans-serif;\par
+\'09mso-fareast-language:EN-US;\}\par
+@page WordSection1\par
+\'09\{size:612.0pt 792.0pt;\par
+\'09margin:72.0pt 72.0pt 72.0pt 72.0pt;\}\par
+div.WordSection1\par
+\'09\{page:WordSection1;\}\par
+--></Style><!--[if gte mso 9]><xml>\par
+<o:shapedefaults v:ext="edit" spidmax="1026" />\par
+</xml><![endif]--><!--[if gte mso 9]><xml>\par
+<o:shapelayout v:ext="edit">\par
+<o:idmap v:ext="edit" data="1" />\par
+</o:shapelayout></xml><![endif]--></Head><body lang="EN-GB" link="#0563C1" vlink="#954F72" style="word-wrap:break-word"><div class="WordSection1">}{\*\htmltag0 <p class="MsoNormal">}\pard
+\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 Hi {\*\htmltag0 <o:p></o:p></P>}\htmlrtf}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal">}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 Lorem ipsum dolor sit amet, consectetur adipiscing elit. (\'A30k) Vestibulum malesuada cursus est, eget sollicitudin lorem.{\*\htmltag0 <o:p></o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal">}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 Duis convallis dui a scelerisque aliquet. Quisque accumsan auctor convallis. Morbi faucibus nibh tellus, non tincidunt lorem elementum sed. Vestibulum ipsum magna, aliquet a enim sagittis, finibus elementum dolor.{\*\htmltag0 <br>}\htmlrtf
+}{\f2\lang2057\fs22\line
+\htmlrtf0{\*\htmltag0\par}{\*\htmltag0 <br>}\htmlrtf}{\f2\lang2057\fs22\line
+\htmlrtf0{\*\htmltag0\par}Etiam maximus blandit nibh nec porttitor.{\*\htmltag0 <o:p></o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal">}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 A brier quality data.{\*\htmltag0 <o:p></o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal">}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 Sed a porttitor leo 1{\*\htmltag0 <sup>}\htmlrtf
+}{\f2\lang2057\super\htmlrtf0 st{\*\htmltag0 </Sup>}\htmlrtf}{\f2\lang2057\fs22\htmlrtf0  Curabitur laoreet massa ut tincidunt.{\*\htmltag0 <o:p></o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal">}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 Vivamus tempor turpis ante?{\*\htmltag0 <o:p></o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal">}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 Thanks{\*\htmltag0 <o:p></o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal">}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0 {\*\htmltag0 <o:p></o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><span style="mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard\plain\htmlrtf{\f2\lang2057
+\fs22\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" align="left" width="600" style="width:450.0pt;background:white;border-collapse:collapse"><tbody>}{\*\htmltag0 <tr><td valign="top" style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0">}\htmlrtf
+\trowd\irow0\irowband0\trcbpat2\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\htmlrtf0
+{\*\htmltag0 <tbody>}{\*\htmltag0 <tr style="height:15.6pt"><td style="padding:0cm 0cm 0cm 0cm;height:15.6pt">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:9.0pt;color:#000001;mso-fareast-language:EN-GB">}{\*\htmltag0 <img width="1" height="26" style="width:.0138in;height:.2708in" id="Picture_x0020_7" src="cid:image001.gif@01D82331.3F8C7950"></Span>}\pard
+\intbl\itap2\cbpat2\plain{\*\htmltag0 }\htmlrtf\objattph  \htmlrtf0{\*\htmltag0 <span style="font-size:9.0pt;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}\htmlrtf
+\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:9.0pt;color:#000001;mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f2\lang2057\cf3\fs18\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf
+\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#000001;mso-fareast-language:EN-GB">}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf3\fs18\htmlrtf0 Kind Regards{\*\htmltag0 </Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 <span style="font-size:10.0pt;font-family:"Verdana",sans-serif;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}\htmlrtf
+\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f2\lang2057\cf3\fs20\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow0\irowband0\trcbpat2
+\trrh312\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr><td style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <b>}{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#2B3B46;letter-spacing:-.15pt;mso-fareast-language:EN-GB">}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf4\fs18\b\htmlrtf0 C{\*\htmltag0 </Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </B><span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow1\irowband1\trcbpat2
+\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr><td style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#2B3B46;letter-spacing:-.15pt;mso-fareast-language:EN-GB">}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf4\fs18\htmlrtf0 Viles &amp; Support {\*\htmltag0 </Span>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow2\irowband2\trcbpat2
+\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr style="height:6.0pt"><td style="padding:0cm 0cm 0cm 0cm;height:6.0pt">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#000001;mso-fareast-language:EN-GB">}{\*\htmltag0 <img width="1" height="10" style="width:.0138in;height:.1041in" id="Picture_x0020_8" src="cid:image001.gif@01D82331.3F8C7950"><o:p></o:p></Span>}\pard
+\intbl\itap2\cbpat2\plain{\*\htmltag0 }\htmlrtf\objattph  \htmlrtf0{\*\htmltag0 </P>}{\*\htmltag0 </TD>}\htmlrtf\nestcell{\nonesttables\tab}\htmlrtf0
+{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow3\irowband3\trcbpat2\trrh120\clpadl0\clpadfl3\clpadr0
+\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr><td style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#000001;mso-fareast-language:EN-GB">}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf3\fs18\htmlrtf0 +44 (0)7788 365 955{\*\htmltag0 <o:p></o:p></Span>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 </P>}{\*\htmltag0 </TD>}\htmlrtf\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl
+\itap2{\*\nesttableprops\trowd\irow4\irowband4\trcbpat2\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3
+\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr><td style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;mso-fareast-language:EN-GB">}{\*\htmltag0 <a href="mailto:cemery@senceive.com"><span style="color:#0563C1">}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\field{\*\fldinst HYPERLINK "mailto:ceme@e.com" }{\fldrslt{\f3\lang2057\cf6\fs18
+\ul\htmlrtf0 cemery@senceive.com{\*\htmltag0 </Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </A>}\htmlrtf}}\htmlrtf0{\*\htmltag0 <o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow5\irowband5\trcbpat2
+\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr><td style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#2B3B46;letter-spacing:-.15pt;mso-fareast-language:EN-GB">}{\*\htmltag0 <a href="https://www.linkedin.com/" target="_blank"><b>}\pard
+\intbl\itap2\cbpat2\plain{\*\htmltag0 <span style="color:#A7CF38">}\htmlrtf{\field{\*\fldinst HYPERLINK "https://www.linkedin.com/in//" }{\fldrslt
+{\f3\lang2057\cf7\fs18\b\ul\htmlrtf0 Connect\~{\*\htmltag0 </Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </B></A>}\htmlrtf}}{\f3\lang2057
+\cf4\fs18\htmlrtf0 with me on LinkedIn{\*\htmltag0 </Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 <span style="font-size:9.0pt;font-family:"Verdana",sans-serif;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow6\irowband6\trcbpat2
+\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr style="height:8.4pt"><td style="padding:0cm 0cm 0cm 0cm;height:8.4pt">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB">}{\*\htmltag0 <img border="0" width="1" height="14" style="width:.0138in;height:.1458in" id="Picture_x0020_3" src="cid:image001.gif@01D82331.3F8C7950"></Span>}\pard
+\intbl\itap2\cbpat2\plain{\*\htmltag0 }\htmlrtf\objattph  \htmlrtf0{\*\htmltag0 <span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow7\irowband7\trcbpat2
+\trrh168\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 </Tbody></Table>}{\*\htmltag0 </TD>}\htmlrtf\pard\intbl\cbpat2\cell\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard
+\intbl\row
+\htmlrtf0{\*\htmltag0 <tr><td valign="top" style="background:#2A3B45;padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="600" style="width:450.0pt;background:#2A3B45">}\htmlrtf
+\trowd\irow1\irowband1\trcbpat2\clcbpat8\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\cellx8856\htmlrtf0
+{\*\htmltag0 <tbody>}{\*\htmltag0 <tr><td style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="color:white">}{\*\htmltag0 <a href="https://www.sss.com/" target="_blank"><span style="font-size:10.0pt;color:silver;mso-fareast-language:EN-GB;text-decoration:none">}\pard
+\intbl\itap2\cbpat8\plain{\*\htmltag0 <img border="0" width="600" height="84" style="width:6.25in;height:.875in" id="Picture_x0020_4" src="cid:image002.jpg@01D82331.3F8C7950"></Span>}\htmlrtf
+{\field{\*\fldinst HYPERLINK "https://www.sss.com/" }{\fldrslt\htmlrtf0{\*\htmltag0 }\htmlrtf\objattph  \htmlrtf0{\*\htmltag0 </A>}\htmlrtf
+}}\htmlrtf0{\*\htmltag0 </Span><span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow0\irowband0\trcbpat8
+\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat8\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 </Tbody></Table>}{\*\htmltag0 </TD>}\htmlrtf\pard\intbl\cbpat8\cell\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard
+\intbl\row
+\htmlrtf0{\*\htmltag0 <tr><td valign="top" style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0">}\htmlrtf
+\trowd\irow2\irowband2\trcbpat2\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\htmlrtf0
+{\*\htmltag0 <tbody>}{\*\htmltag0 <tr style="height:12.0pt"><td style="padding:0cm 0cm 0cm 0cm;height:12.0pt">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB">}{\*\htmltag0 <img border="0" width="1" height="20" style="width:.0138in;height:.2083in" id="Picture_x0020_5" src="cid:image001.gif@01D82331.3F8C7950"></Span>}\pard
+\intbl\itap2\cbpat2\plain{\*\htmltag0 }\htmlrtf\objattph  \htmlrtf0{\*\htmltag0 <span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow0\irowband0\trcbpat2
+\trrh240\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr><td style="padding:0cm 0cm 0cm 0cm">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:7.5pt;font-family:"Verdana",sans-serif;color:#3C3C3B;mso-fareast-language:EN-GB">}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf9\fs15\htmlrtf0 7b/7c Imperial Studios, Imperial Road, Fulham, London SW6 2AG{\*\htmltag0 <br>}\htmlrtf
+}{\f3\lang2057\cf9\fs15\line
+\htmlrtf0{\*\htmltag0\par}United Kingdom Company no. 05608752 (England) VAT no. GB 894344685{\*\htmltag0 <o:p></o:p></Span>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:7.5pt;font-family:"Verdana",sans-serif;color:#3C3C3B;mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf9\fs15\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf
+\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:7.5pt;font-family:"Verdana",sans-serif;color:#3C3C3B;mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf9\fs15\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf
+\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:7.5pt;font-family:"Verdana",sans-serif;color:#3C3C3B;mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf9\fs15\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf
+\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:7.5pt;font-family:"Verdana",sans-serif;color:#3C3C3B;mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf9\fs15\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf
+\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly"><span style="font-size:7.5pt;font-family:"Verdana",sans-serif;color:#3C3C3B;mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\intbl\itap2\cbpat2\plain\htmlrtf{\f3\lang2057\cf9\fs15\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow1\irowband1\trcbpat2
+\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 <tr style="height:12.0pt"><td style="padding:0cm 0cm 0cm 0cm;height:12.0pt">}{\*\htmltag0 <p class="MsoNormal" style="mso-element:frame;mso-element-frame-hspace:2.25pt;mso-element-wrap:around;mso-element-anchor-vertical:paragraph;mso-element-anchor-horizontal:column;mso-height-rule:exactly">}{\*\htmltag0 <span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB">}{\*\htmltag0 <img border="0" width="1" height="20" style="width:.0138in;height:.2083in" id="Picture_x0020_6" src="cid:image001.gif@01D82331.3F8C7950"></Span>}\pard
+\intbl\itap2\cbpat2\plain{\*\htmltag0 }\htmlrtf\objattph  \htmlrtf0{\*\htmltag0 <span style="font-size:10.0pt;color:#000001;mso-fareast-language:EN-GB"><o:p></o:p></Span></P>}{\*\htmltag0 </TD>}\htmlrtf
+\nestcell{\nonesttables\tab}\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard\intbl\itap2{\*\nesttableprops\trowd\irow2\irowband2\trcbpat2
+\trrh240\clpadl0\clpadfl3\clpadr0\clpadfr3\clpadb0\clpadfb3\clpadt0\clpadft3\clcbpat2\cellx8856\nestrow}{\nonesttables\par}
+\htmlrtf0{\*\htmltag0 </Tbody></Table>}{\*\htmltag0 </TD>}\htmlrtf\pard\intbl\cbpat2\cell\htmlrtf0{\*\htmltag0 </TR>}\htmlrtf\pard
+\intbl\row
+\htmlrtf0{\*\htmltag0 </Tbody></Table>}{\*\htmltag0 <p class="MsoNormal"><span style="mso-fareast-language:EN-GB">}{\*\htmltag0 <o:p>}\pard
+\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></Span>}\htmlrtf}\htmlrtf0{\*\htmltag0 </P>}\htmlrtf\par
+\htmlrtf0{\*\htmltag0 <p class="MsoNormal"><o:p>}\pard\plain\htmlrtf{\f2\lang2057\fs22\htmlrtf0\~{\*\htmltag0 </o:p></P>}\htmlrtf
+}\htmlrtf0{\*\htmltag0 }{\*\htmltag0 </Div>}{\*\htmltag0 </Body>}{\*\htmltag0 </Html>}}

--- a/tests/test_data/rtf_parsing/encapsulated_example.html
+++ b/tests/test_data/rtf_parsing/encapsulated_example.html
@@ -1,0 +1,23 @@
+<HTML><head>
+<style>
+<!--
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal {font-family:Arial;}
+-->
+</style>
+	<!-- This is a HTML comment.
+There is a horizontal tab (%x09) character before the comment, 
+and some new lines inside the comment. -->
+</head>
+<body>
+<p
+class="MsoNormal">Note the line break inside a P tag. <b>This is bold text</b> </p>
+<p class="MsoNormal">
+This is a normal text with a character references:&nbsp; &lt; &uml;<br>
+characters that have special meaning in RTF: {}\<br>
+</p>
+<ol>
+<li class="MsoNormal">This is a list item
+</ol>
+</body>
+</HTML>

--- a/tests/test_data/rtf_parsing/encapsulated_example.rtf
+++ b/tests/test_data/rtf_parsing/encapsulated_example.rtf
@@ -1,0 +1,38 @@
+{\rtf1\ansi\ansicpg1251\fromhtml1 \deff0
+{\fonttbl {\f0\fmodern Courier New;}{\f1\fswiss Arial;}{\f2\fswiss\fcharset0 Arial;}}
+{\colortbl\red0\green0\blue0;\red0\green0\blue255;}
+{\*\htmltag64}
+\uc1\pard\plain\deftab360 \f0\fs24
+{\*\htmltag <HTML><head>\par
+<style>\par
+<!--\par
+/* Style Definitions */\par
+p.MsoNormal, li.MsoNormal \{font-family:Arial;\}\par
+-->\par
+</style>\par
+\tab <!-- This is a HTML comment.\par
+There is a horizontal tab (%x09) character before the comment, \par
+and some new lines inside the comment. -->\par
+</head>\par
+<body>\par
+<p\par
+class="MsoNormal">}
+{\htmlrtf \f1 \htmlrtf0 Note the line break inside a P tag. {\*\htmltag <b>}{\htmlrtf \b
+\htmlrtf0 This is bold text{\*\htmltag </b>}} \htmlrtf\par\htmlrtf0}
+\htmlrtf \par \htmlrtf0
+{\*\htmltag </p>\par
+<p class="MsoNormal">\par}
+{\htmlrtf \f1 \htmlrtf0 This is a normal text with a character references:
+{\*\htmltag &nbsp;}\htmlrtf \'a0\htmlrtf0  {\*\htmltag &lt;}\htmlrtf <\htmlrtf0  {\*\htmltag
+&uml;}\htmlrtf {\f2\'a8}\htmlrtf0{\*\htmltag <br>\par}\htmlrtf\line\htmlrtf0
+characters that have special meaning in RTF: \{\}\\{\*\htmltag
+<br>\par}\htmlrtf\line\htmlrtf0\htmlrtf\par\htmlrtf0}
+{\*\htmltag </p>\par
+<ol>\par
+<li class="MsoNormal">}{\htmlrtf
+{{\*\pn\pnlvlbody\pndec\pnstart1\pnindent360{\pntxta.}}\li360\fi-360{\pntext 1.\tab} \f1
+\htmlrtf0 This is a list item}\htmlrtf\par\htmlrtf0}
+{\*\htmltag \par
+</ol>\par
+</body>\par
+</HTML>\par }}

--- a/tests/test_data/rtf_parsing/five_spaces.rtf
+++ b/tests/test_data/rtf_parsing/five_spaces.rtf
@@ -1,0 +1,11 @@
+{\rtf1\ansi\ansicpg1252\fromtext \fbidis \deff0{\fonttbl
+{\f0\fswiss Arial;}
+{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain\deftab360 \f0\fs24\lang1033
+{
+INSERT_BODY_TEXT_HERE { {\*\customDest You really shouldn't be seeting this in the rendered file}  {\*\customDest Hi there} }
+}
+}

--- a/tests/test_data/rtf_parsing/font_table_template.rtf
+++ b/tests/test_data/rtf_parsing/font_table_template.rtf
@@ -1,0 +1,27 @@
+{\rtf1\ansi\ansicpg1252\\fromhtml1 \\deff0 \fbidis \deff0REPLACE_FONT_TABLE_HERE
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain\deftab360 \f0\fs24
+{\*\htmltag19 <html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">}
+{\*\htmltag34 <head>}
+{\*\htmltag161 <meta name=Generator content="Microsoft Word 15 (filtered medium)">}
+{\*\htmltag241 <!--[if !mso]><style>v\\:* \{behavior:url(#default#VML);\}\par o\\:* \{behavior:url(#default#VML);\}\par w\\:* \{behavior:url(#default#VML);\}\par .shape \{behavior:url(#default#VML);\}\par </style><![endif]-->}
+{\*\htmltag241 <style>}
+{\*\htmltag241 <!--\par /* Font Definitions */\par @font-face\par \tab \{font-family:"Cambria Math";\par \tab panose-1:2 4 5 3 5 4 6 3 2 4;\}\par @font-face\par \tab \{font-family:Calibri;\par \tab panose-1:2 15 5 2 2 2 4 3 2 4;\}\par /* Style Definitions */\par p.MsoNormal, li.MsoNormal, div.MsoNormal\par \tab \{margin:0in;\par \tab font-size:11.0pt;\par \tab font-family:"Calibri",sans-serif;\}\par span.EmailStyle17\par \tab \{mso-style-type:personal-compose;\par \tab font-family:"Calibri",sans-serif;\par \tab color:windowtext;\}\par .MsoChpDefault\par \tab \{mso-style-type:export-only;\par \tab font-family:"Calibri",sans-serif;\}\par @page WordSection1\par \tab \{size:8.5in 11.0in;\par \tab margin:1.0in 1.0in 1.0in 1.0in;\}\par div.WordSection1\par \tab \{page:WordSection1;\}\par -->}
+{\*\htmltag249 </style>}
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapedefaults v:ext="edit" spidmax="1026" />\par </xml><![endif]-->}
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapelayout v:ext="edit">\par <o:idmap v:ext="edit" data="1" />\par </o:shapelayout></xml><![endif]-->}
+{\*\htmltag41 </head>}
+{\*\htmltag50 <body lang=EN-US link="#0563C1" vlink="#954F72" style='word-wrap:break-word'>}\htmlrtf \lang1033 \htmlrtf0
+{\*\htmltag96 <div class=WordSection1>}\htmlrtf {\htmlrtf0
+{\*\htmltag64 <p class=MsoNormal>}INSERT_BODY_TEXT_HERE
+{\*\htmltag72 </p>}
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0
+{\*\htmltag84 <img width=539 height=500 style='width:5.618in;height:5.2083in' id="Picture_x0020_1" src="cid:image001.jpg@01D6C8CB.B649BB50" alt="A picture containing text, primate, mammal, sitting&#10;&#10;Description automatically generated">}
+{\*\htmltag244 <o:p>}
+{\*\htmltag252 </o:p>}\htmlrtf\par}\htmlrtf0
+\htmlrtf \par
+\htmlrtf0
+{\*\htmltag72 </p>}
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0
+{\*\htmltag58 </body>}
+{\*\htmltag27 </html>}}

--- a/tests/test_data/rtf_parsing/small_template.rtf
+++ b/tests/test_data/rtf_parsing/small_template.rtf
@@ -1,0 +1,7 @@
+{\rtf1\ansi\ansicpg1252\deff0\fromhtml1\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.16299}\viewkind4\uc1
+\pard\sa200\sl276\slmult1\f0\fs22\lang9
+
+REPLACE_ME
+
+{}}

--- a/tests/test_data/rtf_parsing/surrogate_pairs.rtf
+++ b/tests/test_data/rtf_parsing/surrogate_pairs.rtf
@@ -1,0 +1,11 @@
+{\rtf1\ansi\ansicpg1252\deff0\fromhtml1\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.16299}\viewkind4\uc1
+\pard\sa200\sl276\slmult1\f0\fs22\lang9
+
+{\uc1\u482??}\line
+{\uc2\u482??}\line
+{\uc1\u-10179 ?\u-8694 ?}\line
+{\uc1\u-10179 ??\u-8694 ??}\line
+{\uc2\u-10179 ??\u-8694 ??}\line
+
+{}}

--- a/tests/test_data/rtf_parsing/surrogate_pairs_02.rtf
+++ b/tests/test_data/rtf_parsing/surrogate_pairs_02.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;}\htmlrtf \u-10179 ?\u-8694 ?\htmlrtf0
+}

--- a/tests/test_data/rtf_parsing/surrogate_pairs_03.rtf
+++ b/tests/test_data/rtf_parsing/surrogate_pairs_03.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;}\htmlrtf \u55357 ?\u56542 ?\htmlrtf0
+}

--- a/tests/test_data/rtf_parsing/surrogate_pairs_04.rtf
+++ b/tests/test_data/rtf_parsing/surrogate_pairs_04.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;} \u55357 ?\u56542 ?
+}

--- a/tests/test_data/rtf_parsing/surrogates.rtf
+++ b/tests/test_data/rtf_parsing/surrogates.rtf
@@ -1,0 +1,31 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss Arial;}
+{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}}
+{\colortbl\red0\green0\blue0;\red0\green0\blue255;}
+\uc1\pard\plain\deftab360 \f0\fs24 
+{\*\htmltag2 \par }
+{\*\htmltag18 <html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">}
+{\*\htmltag34 <head>}
+{\*\htmltag161 <meta name=Generator content="Microsoft Word 15 (filtered medium)">}
+{\*\htmltag241 <style>}
+{\*\htmltag241 <!--\par /* Font Definitions */\par @font-face\par \tab \{font-family:"MS Mincho";\par \tab panose-1:2 2 6 9 4 2 5 8 3 4;\}\par @font-face\par \tab \{font-family:"Cambria Math";\par \tab panose-1:2 4 5 3 5 4 6 3 2 4;\}\par @font-face\par \tab \{font-family:Calibri;\par \tab panose-1:2 15 5 2 2 2 4 3 2 4;\}\par @font-face\par \tab \{font-family:"Segoe UI Emoji";\par \tab panose-1:2 11 5 2 4 2 4 2 2 3;\}\par @font-face\par \tab \{font-family:"\\@MS Mincho";\par \tab panose-1:2 2 6 9 4 2 5 8 3 4;\}\par /* Style Definitions */\par p.MsoNormal, li.MsoNormal, div.MsoNormal\par \tab \{margin:0in;\par \tab font-size:11.0pt;\par \tab font-family:"Calibri",sans-serif;\}\par span.EmailStyle17\par \tab \{mso-style-type:personal-compose;\par \tab font-family:"Calibri",sans-serif;\par \tab color:windowtext;\}\par .MsoChpDefault\par \tab \{mso-style-type:export-only;\}\par @page WordSection1\par \tab \{size:8.5in 11.0in;\par \tab margin:1.0in 1.0in 1.0in 1.0in;\}\par div.WordSection1\par \tab \{page:WordSection1;\}\par -->}
+{\*\htmltag249 </style>}
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapedefaults v:ext="edit" spidmax="1026" />\par </xml><![endif]-->}
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapelayout v:ext="edit">\par <o:idmap v:ext="edit" data="1" />\par </o:shapelayout></xml><![endif]-->}
+{\*\htmltag41 </head>}
+{\*\htmltag50 <body lang=EN-US link=blue vlink=purple style='word-wrap:break-word'>}\htmlrtf \lang1033 \htmlrtf0 
+{\*\htmltag96 <div class=WordSection1>}\htmlrtf {\htmlrtf0 
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+{\*\htmltag148 <span style='font-size:12.0pt;font-family:"Segoe UI Emoji",sans-serif'>}\htmlrtf {\f4 \htmlrtf0 \u-10179 ?\u-8694 ?
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 
+{\*\htmltag244 <o:p>}
+{\*\htmltag252 </o:p>}\htmlrtf\par}\htmlrtf0
+\htmlrtf \par
+\htmlrtf0 
+{\*\htmltag72 </p>}
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag58 </body>}
+{\*\htmltag27 </html>}}

--- a/tests/test_data/rtf_parsing/theta.rtf
+++ b/tests/test_data/rtf_parsing/theta.rtf
@@ -1,0 +1,1 @@
+{\rtf1\ansi\ansicpg1252\fromtext \fbidis \deff0{\fonttbl {\f0\fswiss\fcharset0 Arial;} {\f1\fmodern Courier New;} {\f2\fnil\fcharset2 Symbol;} {\f3\fmodern\fcharset0 Courier New;} {\f4\fswiss\fcharset204 Arial;}} {\colortbl\red0\green0\blue0;\red0\green0\blue255;} \uc1\pard\plain\deftab360 \f0\fs20 \htmlrtf{\f4\fs20\htmlrtf0 \'f4\htmlrtf\f0}\htmlrtf0 \par }

--- a/tests/test_data/rtf_parsing/translated_by.rtf
+++ b/tests/test_data/rtf_parsing/translated_by.rtf
@@ -1,0 +1,5 @@
+{\rtf1\fromtext\fbidis\ansi\deff0{\fonttbl{\f0\fnil\fcharset178 MS Sans Serif;}{\f1\fnil\fcharset0 MS Sans Serif;}}
+
+\viewkind4\uc1\pard\ltrpar\lang12289\f0\rtlch\fs16\'ca\'d1\'cc\'e3\'c9: \'d3\'e3\'ed\'d1 \'c7\'e1\'e3\'cc\'d0\'e6\'c8\f1\ltrch\par
+
+}

--- a/tests/test_data/rtf_parsing/unicode_HH_replacement.rtf
+++ b/tests/test_data/rtf_parsing/unicode_HH_replacement.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;}\htmlrtf \u55357\'20\u56542 ?\htmlrtf0
+}

--- a/tests/test_data/rtf_parsing/unicode_HH_replacement_01.rtf
+++ b/tests/test_data/rtf_parsing/unicode_HH_replacement_01.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+{\f5\fswiss\fcharset0 "Century Gothic";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain
+{\*\htmltag84 &#128522;} \u55357\'20\u56542 ?
+}

--- a/tests/test_data/rtf_parsing/windows_950.rtf
+++ b/tests/test_data/rtf_parsing/windows_950.rtf
@@ -1,0 +1,14 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+{\f0\fswiss\fcharset0 Arial;}
+{\f1\fmodern Courier New;}
+{\f2\fnil\fcharset2 Symbol;}
+{\f3\fmodern\fcharset0 Courier New;}
+{\f4\fnil\fcharset2 Symbol;}
+{\f5\fswiss\fcharset136 New MingLiu;}
+{\f6\fswiss\fcharset0 "Century Gothic";}
+{\f7\fswiss\fcharset0 "Arial";}
+{\f8\fswiss "Calibri Light";}
+{\f9\fswiss\fcharset0 "Courier New";}}
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+\uc1\pard\plain\deftab360 \f5\fs24
+Hello \'84\'68}

--- a/tests/test_utils/test_main_utils.py
+++ b/tests/test_utils/test_main_utils.py
@@ -1,0 +1,172 @@
+"""Test Utilities
+"""
+
+import unittest
+import logging
+from contextlib import contextmanager
+from io import StringIO
+
+from RTFDE.deencapsulate import DeEncapsulator
+from RTFDE.utils import log_validators, log_transformations
+from RTFDE.utils import encode_escaped_control_chars
+from tests.test_utils import DATA_BASE_DIR
+from RTFDE.utils import get_tree_diff, log_string_diff
+from os.path import join
+
+@contextmanager
+def capture_log(logger):
+    for i in logger.handlers:
+        logger.removeHandler(i)
+    stream = StringIO()
+    strm_handler = logging.StreamHandler(stream)
+    f = '%(name)s - %(levelname)s - %(message)s'
+    formatter = logging.Formatter(f)
+    strm_handler.setFormatter(formatter)
+    logger.addHandler(strm_handler)
+    logger.propagate = False
+    yield stream
+
+def get_logger_defaults(logger):
+    defaults = {}
+    defaults.setdefault('level', logger.level)
+    defaults.setdefault('handlers', logger.handlers)
+    defaults.setdefault('propagate', logger.propagate)
+    return defaults
+
+def set_logger_defaults(logger, defaults):
+    defaults = {}
+    logger.level = defaults.get('level', logging.NOTSET)
+    logger.handlers = defaults.get('handlers', [])
+    logger.propagate = defaults.get('propagate', True)
+
+
+class TestLogging(unittest.TestCase):
+    """Test that custom logging is working
+    """
+
+    def test_validators(self):
+        logger = logging.getLogger("RTFDE.validation_logger")
+        defaults = get_logger_defaults(logger)
+        data = "we will check validators"
+
+        with capture_log(logger) as log:
+            log_validators(data)
+        log = log.getvalue()
+        self.assertNotIn("RTFDE.transform_logger", log)
+        self.assertNotIn("check transformations", log)
+        self.assertNotIn("DEBUG", log)
+
+        logger.setLevel(logging.DEBUG)
+        with capture_log(logger) as log:
+            log_validators(data)
+        log = log.getvalue()
+        self.assertIn("RTFDE.validation_logger", log)
+        self.assertIn("check validators", log)
+        self.assertIn("DEBUG", log)
+        # Cleaning back up for future tests
+        set_logger_defaults(logger, defaults)
+
+    def test_transformations(self):
+        logger = logging.getLogger("RTFDE.transform_logger")
+        defaults = get_logger_defaults(logger)
+        data = "we will check transformations"
+
+        with capture_log(logger) as log:
+            log_transformations(data)
+        self.assertNotIn("RTFDE.transform_logger", log)
+        self.assertNotIn("check transformations", log)
+        self.assertNotIn("DEBUG", log)
+
+        logger.setLevel(logging.DEBUG)
+        with capture_log(logger) as log:
+            log_transformations(data)
+
+        log = log.getvalue()
+        self.assertIn("RTFDE.transform_logger", log)
+        self.assertIn("check transformations", log)
+        self.assertIn("DEBUG", log)
+        # Cleaning back up for future tests
+        set_logger_defaults(logger, defaults)
+
+    def test_string_diff(self):
+        logger = logging.getLogger("RTFDE")
+        logger.setLevel(logging.DEBUG)
+        rtf_path = join(DATA_BASE_DIR, "plain_text", "test_data.rtf")
+        with open(rtf_path, 'rb') as fp:
+            raw_rtf = fp.read()
+        mod_rtf = raw_rtf
+        mod_rtf = mod_rtf.replace(b'\\fswiss ', b'\\things ')
+        mod_rtf = mod_rtf.replace(b'\\blue255', b'\\notblueothernumber')
+        # log_string_diff(raw_rtf, mod_rtf)
+        print("===========================sep========================")
+        with capture_log(logger) as log:
+            log_string_diff(raw_rtf, mod_rtf, sep=b'\\{|\\}')
+        log = log.getvalue()
+        self.assertIn(r"! \f0\fswiss Arial;", log)
+        self.assertIn(r"! \f0\things Arial;", log)
+        self.assertIn(r"! \colortbl\red0\green0\blue0;\red0\green0\blue255;", log)
+        self.assertIn(r"! \colortbl\red0\green0\blue0;\red0\green0\notblueothernumber;", log)
+
+
+    def test_tree_diff(self):
+        rtf_path = join(DATA_BASE_DIR, "plain_text", "test_data.rtf")
+        with open(rtf_path, 'rb') as fp:
+            raw_rtf = fp.read()
+        mod_rtf = raw_rtf
+        mod_rtf = mod_rtf.replace(b'\\fswiss ', b'\\things ')
+        mod_rtf = mod_rtf.replace(b'\\blue255', b'\\notblueothernumber')
+        # Create Trees
+        rtf_obj = DeEncapsulator(raw_rtf)
+        rtf_obj.deencapsulate()
+        mod_rtf_obj = DeEncapsulator(mod_rtf)
+        mod_rtf_obj.deencapsulate()
+        log = get_tree_diff(rtf_obj.full_tree,
+                          mod_rtf_obj.full_tree)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\fswiss ')", log)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\things ')", log)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\blue255')", log)
+        self.assertIn(r"! Token('CONTROLWORD', b'\\notblueothernumber')", log)
+
+class TestUtilities(unittest.TestCase):
+    """Test that important utilities are working
+    """
+
+    def test_encode_escape_chars(self):
+        raw_text = r"test\\thing\{stuff\}test".encode()
+        converted = encode_escaped_control_chars(raw_text)
+        self.assertIn(b"\\'5c", converted)
+        self.assertIn(b"\\'7b", converted)
+        self.assertIn(b"\\'7d", converted)
+
+
+def embed():
+    import os
+    import readline
+    import rlcompleter
+    import code
+    import inspect
+    import traceback
+
+    history = os.path.join(os.path.expanduser('~'), '.python_history')
+    if os.path.isfile(history):
+        readline.read_history_file(history)
+
+    frame = inspect.currentframe().f_back
+    namespace = frame.f_locals.copy()
+    namespace.update(frame.f_globals)
+
+    readline.set_completer(rlcompleter.Completer(namespace).complete)
+    readline.parse_and_bind("tab: complete")
+
+    file = frame.f_code.co_filename
+    line = frame.f_lineno
+    function = frame.f_code.co_name
+
+    stack = ''.join(traceback.format_stack()[:-1])
+    print(stack)
+    banner = f" [ {os.path.basename(file)}:{line} in {function}() ]"
+    banner += "\n Entering interactive mode (Ctrl-D to exit) ..."
+    try:
+        code.interact(banner=banner, local=namespace)
+    finally:
+        readline.write_history_file(history)


### PR DESCRIPTION
Merging Dev branch for Release 0.1.0

The major change here is that I updated RTFDE to only work with bytes and leave all encoding up to the downstream library. Please update your code as necessary! 

* Updated to only work with bytes.
* Added far greater unicode support.
* Fixed various whitespace issues.
* Added proper htmlrtf support.
* Added support for extracting (but not parsing binary data). 
* Update grammar to be far more explicit when extracting objects.
* Fixes to ensure deencapsulation handles whitespace properly.
* Adds grammar composer to make grammar modifications more clearly defined.
* Adding support for surrogates which use raw unicode instead of 16bit signed encoding.
* Added better handling of parsing unicode HH replacement chars.