### PR TITLE
Update to try to use windows-950 when extract-msg is imported

### DIFF
--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -13,6 +13,7 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
 
+import codecs
 import re
 from collections import namedtuple
 from typing import Union, Any, List, Tuple, Dict
@@ -197,6 +198,14 @@ Args:
 Returns:
     The name of the codec in the Python codec registry. Used as the name for enacoding/decoding.
 """
+    if codepage_num == 950:
+        # See if an implementation has been added for windows-950. If it has, use that.
+        try:
+            codecs.lookup('windows-950') # Raises LookupError if not found.
+            log.debug('Found python codec corresponding to code page {0}: windows-950'.format(codepage_num))
+            return 'windows-950'
+        except LookupError:
+            pass
     text_codec = codepages.codepage2codec(codepage_num)
     log.debug('Found python codec corresponding to code page {0}: {1}'.format(codepage_num, text_codec))
     return text_codec


### PR DESCRIPTION
Changed `RTFDE.text_extraction.get_python_codec` to lookup the `windows-950` encoding to see if it is available. This is only done when the codepage number is 950, and if `windows-950` is not found, the function behaves like normal. If the encoding is found, it will return `'windows-950'` for the codec to use. 

The upcoming version of `extract-msg`, version 0.42.0, adds the implementation that Microsoft uses for cp950 to ensure that documents using it will be parsed correctly.

This is a fix for #19 and passes with the test file specified in that issue.