### PR TITLE
Exclude `tests` from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/seamustuohy/RTFDE",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(
+        exclude=['tests*'],
+    ),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",


### PR DESCRIPTION
This is necessary to exclude `tests` from being installed as top level module when building the wheel from source.
    
I know `find_packages()` should exclude that directory automatically. But somehow that appears not to work. I guess the `__init__.py` inside `tests/` is preventing the magic.