### PR TITLE
Remove unnecessary shebang

### DIFF
--- a/RTFDE/__init__.py
+++ b/RTFDE/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Date Format: YYYY-MM-DD
 #

--- a/RTFDE/deencapsulate.py
+++ b/RTFDE/deencapsulate.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # This file is part of RTFDE, a RTF De-Encapsulator.

--- a/RTFDE/exceptions.py
+++ b/RTFDE/exceptions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # This file is part of RTFDE, a RTF De-Encapsulator.

--- a/RTFDE/grammar.py
+++ b/RTFDE/grammar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # This file is part of RTFDE, a RTF De-Encapsulator.

--- a/RTFDE/text_extraction.py
+++ b/RTFDE/text_extraction.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # This file is part of RTFDE, a RTF De-Encapsulator.

--- a/RTFDE/transformers.py
+++ b/RTFDE/transformers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # This file is part of RTFDE, a RTF De-Encapsulator.

--- a/RTFDE/utils.py
+++ b/RTFDE/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # This file is part of package name, a package description short.


### PR DESCRIPTION
The files do not have executable permissions and are not meant to be run standalone. Thus, the shebang is obsolete.