### PR TITLE
Update python_requires to > 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setuptools.setup(
         "Topic :: Text Processing :: Filters",
         "Topic :: Communications :: Email :: Filters"
     ],
-
-    python_requires='~=3.8',
+    python_requires='>=3.8',
     install_requires=['lark~=1.1.8',
                       'oletools>=0.56'],
     extras_require={'msg_parse': ['extract_msg~=0.27'],


### PR DESCRIPTION
Change requires python version to be greater than 3.8 to allow for easy use with later versions. Tested up to python 3.11 with no issues. Will add limits if later 3.X versions cause issues. Per: #38 