### PR TITLE
Drop oletools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ setuptools.setup(
         "Topic :: Communications :: Email :: Filters"
     ],
     python_requires='>=3.8',
-    install_requires=['lark~=1.1.8',
-                      'oletools>=0.56'],
+    install_requires=['lark~=1.1.8'],
     extras_require={'msg_parse': ['extract_msg~=0.27'],
                     'dev': ['lxml~=4.6',
                             'mypy~=1.1',


### PR DESCRIPTION
oletools is nasty because it depends on easygui which does not seem to be available for some platforms, at least it's not available for osx-arm64 on conda-forge.